### PR TITLE
connection_pool | Allow unblock calls to interrupt sleeping

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,4 @@ gem "yard"
 
 gem "pg"
 gem "mysql2"
+gem "connection_pool", "~> 2.0"

--- a/spec/fiber_scheduler_spec.rb
+++ b/spec/fiber_scheduler_spec.rb
@@ -200,6 +200,21 @@ RSpec.describe Rage::FiberScheduler do
         -> { expect(result).to be < pool_timeout }
       end
     end
+
+    context "with timeout" do
+      let(:pool_timeout) { 1 }
+      let(:pool_size) { 1 }
+
+      it "correctly times out" do
+        within_reactor do
+          Fiber.schedule { pool.with { |conn| conn.get(URI("#{TEST_HTTP_URL}/timeout")) } }
+          pool.with { |conn| conn.get(URI("#{TEST_HTTP_URL}/instant-http-get")) }
+          raise "failed"
+        rescue => e
+          -> { expect(e).to be_a(ConnectionPool::TimeoutError) }
+        end
+      end
+    end
   end
 
   it "correctly blocks and unblocks fibers" do


### PR DESCRIPTION
the connection_pool gem uses `Thread::ConditionVariable#wait` to wait on an unavailable connection to become available. Turns out, this method is backed by `FiberScheduler#kernel_sleep` instead of `FiberScheduler#block`. Once a connection becomes available, connection_pool uses `Thread::ConditionVariable#broadcast` which, in its turn, is backed by `FiberScheduler#unblock`. This change makes `kernel_sleep` share logic with `block`, so that `unblock` calls could interrupt both `block` and `kernel_sleep`. As a bonus, `block` now supports timeouts.