### PR TITLE
Clear logger context after a request is processed

### DIFF
--- a/lib/rage/application.rb
+++ b/lib/rage/application.rb
@@ -61,5 +61,6 @@ class Rage::Application
 
     logger[:final] = { env:, params:, response:, duration: }
     Rage.logger.info("")
+    logger[:final] = nil
   end
 end


### PR DESCRIPTION
allows for correct logging of "detached" fibers