### PR TITLE
Add conditional GET using `stale?`

### DIFF
--- a/spec/controller/api/conditional_get_spec.rb
+++ b/spec/controller/api/conditional_get_spec.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+module ControllerApiConditionalGetSpec
+  TestModel = Struct.new(:updated_at)
+
+  class TestController < RageController::API
+    def stale_last_modified_test
+      return unless stale?(last_modified: Time.utc(2023, 12, 1))
+
+      render plain: "test_last_modified"
+    end
+
+    def stale_etag_test
+      return unless stale?(etag: "123")
+
+      render plain: "test_etag"
+    end
+
+    def stale_last_modified_and_etag_test
+      return unless stale?(last_modified: Time.utc(2023, 12, 1), etag: "123")
+
+      render plain: "test_last_modified_and_etag"
+    end
+
+    def no_freshness_info_in_response_test
+      render plain: "test_no_freshness_info_in_response"
+    end
+  end
+end
+
+RSpec.describe RageController::API do
+  let(:klass) { ControllerApiConditionalGetSpec::TestController }
+
+  context "when IF-MODIFIED-SINCE is given" do
+    context "but last_modified is not set in the action" do
+      let(:env) { { "HTTP_IF_MODIFIED_SINCE" => Time.utc(2023, 12, 15) } }
+
+      it "executes the action normally" do
+        expect(run_action(klass, :no_freshness_info_in_response_test, env:)).to match(
+          [200, an_instance_of(Hash), ["test_no_freshness_info_in_response"]]
+        )
+      end
+    end
+
+    context "and it's more recent than the requested content" do
+      let(:env) { { "HTTP_IF_MODIFIED_SINCE" => Time.utc(2023, 12, 15) } }
+
+      it "returns NOT MODIFIED" do
+        expect(run_action(klass, :stale_last_modified_test, env:)).to match(
+          [304, an_instance_of(Hash), []]
+        )
+      end
+    end
+
+    context "and it's less recent that the requested content" do
+      let(:env) { { "HTTP_IF_MODIFIED_SINCE" => Time.utc(2023, 11, 15) } }
+
+      it "renders the requested resource" do
+        expect(run_action(klass, :stale_last_modified_test, env:)).to match(
+          [200, an_instance_of(Hash), ["test_last_modified"]]
+        )
+      end
+    end
+  end
+
+  context "when IF-MODIFIED-SINCE is not given" do
+    let(:env) { {} }
+
+    context "and last_modified is not set in the action" do
+      it "executes the action normally" do
+        expect(run_action(klass, :no_freshness_info_in_response_test, env:)).to match(
+          [200, an_instance_of(Hash), ["test_no_freshness_info_in_response"]]
+        )
+      end
+    end
+
+    context "and last_modified is set in the action" do
+      it "renders the requested resource" do
+        expect(run_action(klass, :stale_last_modified_test, env:)).to match(
+          [200, an_instance_of(Hash), ["test_last_modified"]]
+        )
+      end
+    end
+  end
+
+  context "when IF-NONE-MATCH is given" do
+    context "but etag is not set in the action" do
+      let(:env) { { "HTTP_IF_NONE_MATCH" => "123" } }
+
+      it "executes the action normally" do
+        expect(run_action(klass, :no_freshness_info_in_response_test, env:)).to match(
+          [200, an_instance_of(Hash), ["test_no_freshness_info_in_response"]]
+        )
+      end
+    end
+
+    context "and a matching etag is set in the action" do
+      let(:env) { { "HTTP_IF_NONE_MATCH" => "123" } }
+
+      it "returns NOT MODIFIED" do
+        expect(run_action(klass, :stale_etag_test, env:)).to match(
+          [304, an_instance_of(Hash), []]
+        )
+      end
+    end
+
+    context "and a non-matching etag is set in the action" do
+      let(:env) { { "HTTP_IF_NONE_MATCH" => "456" } }
+
+      it "renders the requested resource" do
+        expect(run_action(klass, :stale_etag_test, env:)).to match(
+          [200, an_instance_of(Hash), ["test_etag"]]
+        )
+      end
+    end
+  end
+
+  context "when IF-NONE-MATCH contains a wildcard" do
+    let(:env) { { "HTTP_IF_NONE_MATCH" => "*" } }
+
+    it "returns NOT MODIFIED" do
+      expect(run_action(klass, :stale_etag_test, env:)).to match(
+        [304, an_instance_of(Hash), []]
+      )
+    end
+  end
+
+  context "when IF-NONE-MATCH is not given" do
+    let(:env) { {} }
+
+    context "and etag is not set in the action" do
+      it "executes the action normally" do
+        expect(run_action(klass, :no_freshness_info_in_response_test, env:)).to match(
+          [200, an_instance_of(Hash), ["test_no_freshness_info_in_response"]]
+        )
+      end
+    end
+
+    context "and etag is set in the action" do
+      it "renders the requested resource" do
+        expect(run_action(klass, :stale_etag_test, env:)).to match(
+          [200, an_instance_of(Hash), ["test_etag"]]
+        )
+      end
+    end
+  end
+
+  context "when both IF-MODIFIED-SINCE and IF-NONE-MATCH are given" do
+    context "and request is fresh" do
+      let(:env) do
+        {
+          "HTTP_IF_MODIFIED_SINCE" => Time.utc(2023, 12, 15),
+          "HTTP_IF_NONE_MATCH" => "123"
+        }
+      end
+
+      it "returns NOT MODIFIED" do
+        expect(run_action(klass, :stale_last_modified_and_etag_test, env:)).to match(
+          [304, an_instance_of(Hash), []]
+        )
+      end
+    end
+
+    context "and request is stale" do
+      let(:env) do
+        {
+          "HTTP_IF_MODIFIED_SINCE" => Time.utc(2023, 11, 15),
+          "HTTP_IF_NONE_MATCH" => "123"
+        }
+      end
+
+      it "renders the requested resource" do
+        expect(run_action(klass, :stale_last_modified_and_etag_test, env:)).to match(
+          [200, an_instance_of(Hash), ["test_last_modified_and_etag"]]
+        )
+      end
+    end
+
+    context "and request is fresh but etag does not match" do
+      let(:env) do
+        {
+          "HTTP_IF_MODIFIED_SINCE" => Time.utc(2023, 12, 15),
+          "HTTP_IF_NONE_MATCH" => "456"
+        }
+      end
+
+      it "renders the requested resource" do
+        expect(run_action(klass, :stale_last_modified_and_etag_test, env:)).to match(
+          [200, an_instance_of(Hash), ["test_last_modified_and_etag"]]
+        )
+      end
+    end
+
+    context "and etag is not set in the action" do
+      let(:env) do
+        {
+          "HTTP_IF_MODIFIED_SINCE" => Time.utc(2023, 12, 15),
+          "HTTP_IF_NONE_MATCH" => "123"
+        }
+      end
+
+      it "renders the requested resource" do
+        expect(run_action(klass, :stale_last_modified_test, env:)).to match(
+          [200, an_instance_of(Hash), ["test_last_modified"]]
+        )
+      end
+    end
+
+    context "and last_modified is not set in the action" do
+      let(:env) do
+        {
+          "HTTP_IF_MODIFIED_SINCE" => Time.utc(2023, 12, 15),
+          "HTTP_IF_NONE_MATCH" => "123"
+        }
+      end
+
+      it "renders the requested resource" do
+        expect(run_action(klass, :stale_etag_test, env:)).to match(
+          [200, an_instance_of(Hash), ["test_etag"]]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds conditional GET, that is [planned for version 0.8](https://github.com/rage-rb/rage#upcoming-releases).

## Some background info
While the goal of rage is to stay compliant to the Rails API, we decided to slightly diverge from it here.
Rails also has `fresh_when`, which in our case does no really make sense:
1. It's first argument (`object`) needs to respond to `updated_at`, which would create tight coupling to an ActiveRecord(ish) library, which might not be what we want
2. `fresh_when` is only practical when an implicit render happens afterwards. Rails API controllers do not support implicit rendering and neither does rage. Explicitly calling render leads to a double render error.

This is why we decided to stick to `stale?` exclusively:
- It does not take an `object` as an argument
- It can be used to guard against double renders:
  ```ruby
    def index
      return unless stale?(etag: "foo")

      render @items
    end
  ```

Furthermore, we decided that ETag generation will not be part of rage for now. As we gather some data of people actually using rage in production, we will be able to see if and how this feature is used. For now, all we have is assumptions and copying Rails' behaviour seems unreasonable here, since it again relies on ActiveRecord (`cache_key`, in this case).

### To be discussed

* Since the user has to generate ETags for themselves, I was wondering if having multiple parameters (`etag`, `strong_etag` and `weak_etag`) was still justifiable. Not to mention that, in order to __really__ support strong ETags, we would have to implement a byte-by-byte comparison (i.e. rendering the action, creating a digest and compare that). [Even Rails doesn't do it](https://www.bigbinary.com/blog/rails-5-switches-from-strong-etags-to-weak-tags).
* Do we want the `public` parameter to control the publicness of `Cache-Control` headers? I wasn't sure if that might be out of scope, so I left it out for now.


### Additional notes

* I also removed the `template` parameter, because we're not using templates.

