### PR TITLE
Preload fiber ID

### DIFF
--- a/lib/rage/fiber.rb
+++ b/lib/rage/fiber.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Fiber
+  # @private
   AWAIT_ERROR_MESSAGE = "err"
 
   # @private
@@ -23,14 +24,14 @@ class Fiber
     @__err
   end
 
-   # @private
-  def __get_id
-    @__rage_id ||= object_id.to_s
+  # @private
+  def __set_id
+    @__rage_id = object_id.to_s
   end
 
-  # @private
-  def __yielded?
-    !@__rage_id.nil?
+   # @private
+  def __get_id
+    @__rage_id
   end
 
   # @private

--- a/lib/rage/fiber_scheduler.rb
+++ b/lib/rage/fiber_scheduler.rb
@@ -109,6 +109,7 @@ class Rage::FiberScheduler
     fiber = if parent == @root_fiber
       # the fiber to wrap a request in
       Fiber.new(blocking: false) do
+        Fiber.current.__set_id
         Fiber.current.__set_result(block.call)
       end
     else

--- a/lib/rage/middleware/fiber_wrapper.rb
+++ b/lib/rage/middleware/fiber_wrapper.rb
@@ -17,7 +17,7 @@ class Rage::FiberWrapper
       @app.call(env)
     ensure
       # notify Iodine the request can now be resumed
-      Iodine.publish(Fiber.current.__get_id, "", Iodine::PubSub::PROCESS) if Fiber.current.__yielded?
+      Iodine.publish(Fiber.current.__get_id, "", Iodine::PubSub::PROCESS)
     end
 
     # the fiber encountered blocking IO and yielded; instruct Iodine to pause the request

--- a/lib/rage/rspec.rb
+++ b/lib/rage/rspec.rb
@@ -18,6 +18,7 @@ abort("The test suite is running in #{Rage.env} mode instead of 'test'!") unless
 class Fiber
   def self.schedule(&block)
     fiber = Fiber.new(blocking: true) do
+      Fiber.current.__set_id
       Fiber.current.__set_result(block.call)
     end
     fiber.resume


### PR DESCRIPTION
It's hard to say what's happening here, but calling `__get_id` to set the variable from the C level and then reading this variable on the Ruby level somehow, sometimes corrupts memory