### PR TITLE
Release ActiveRecord connections on yield

### DIFF
--- a/lib/rage/fiber.rb
+++ b/lib/rage/fiber.rb
@@ -50,6 +50,13 @@ class Fiber
     Fiber.yield
   end
 
+  # @private
+  # under normal circumstances, the method is a copy of `yield`, but it can be overriden to perform
+  # additional steps on yielding, e.g. releasing AR connections; see "lib/rage/rails.rb"
+  class << self
+    alias_method :defer, :yield
+  end
+
   # Wait on several fibers at the same time. Calling this method will automatically pause the current fiber, allowing the
   #   server to process other requests. Once all fibers have completed, the current fiber will be automatically resumed.
   #

--- a/lib/rage/fiber_scheduler.rb
+++ b/lib/rage/fiber_scheduler.rb
@@ -13,7 +13,7 @@ class Rage::FiberScheduler
     f = Fiber.current
     ::Iodine::Scheduler.attach(io.fileno, events, timeout&.ceil || 0) { |err| f.resume(err) }
 
-    err = Fiber.yield
+    err = Fiber.defer
     if err == Errno::ETIMEDOUT::Errno
       0
     else

--- a/lib/rage/rails.rb
+++ b/lib/rage/rails.rb
@@ -30,6 +30,21 @@ if defined?(ActiveRecord)
   end
 end
 
+# release ActiveRecord connections on yield
+if defined?(ActiveRecord)
+  class Fiber
+    def self.defer
+      res = Fiber.yield
+
+      if ActiveRecord::Base.connection_pool.active_connection?
+        ActiveRecord::Base.connection_handler.clear_active_connections!
+      end
+
+      res
+    end
+  end
+end
+
 # plug into Rails' Zeitwerk instance to reload the code
 Rails.autoloaders.main.on_setup do
   if Iodine.running?


### PR DESCRIPTION
this improves performance in the case when an application sends a query to the DB (for instance, to check the validity of an API token) and then sends an HTTP request. Without this change the AR connection would hang unavailable for other fibers until the HTTP request is finished.