### PR TITLE
Use formatters in console

### DIFF
--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -166,7 +166,7 @@ class Rage::Configuration
 
   # @private
   class Internal
-    attr_accessor :rails_mode, :rails_console
+    attr_accessor :rails_mode
 
     def inspect
       "#<#{self.class.name}>"

--- a/lib/rage/logger/logger.rb
+++ b/lib/rage/logger/logger.rb
@@ -129,13 +129,6 @@ class Rage::Logger
             false
           end
         RUBY
-      elsif (Rage.config.internal.rails_mode ? Rage.config.internal.rails_console : defined?(IRB))
-        # the call was made from the console - don't use the formatter
-        <<-RUBY
-          def #{level_name}(msg = nil)
-            @logdev.write((msg || yield) + "\n")
-          end
-        RUBY
       elsif @formatter.class.name.start_with?("Rage::")
         # the call was made from within the application and a built-in formatter is used;
         # in such case we use the `gen_timestamp` method which is much faster than `Time.now.strftime`;

--- a/lib/rage/rails.rb
+++ b/lib/rage/rails.rb
@@ -11,12 +11,6 @@ Iodine.patch_rack
 # configure the framework
 Rage.config.internal.rails_mode = true
 
-# make sure log formatter is not used in console
-Rails.application.console do
-  Rage.config.internal.rails_console = true
-  Rage.logger.level = Rage.logger.level if Rage.logger # trigger redefining log methods
-end
-
 # patch ActiveRecord's connection pool
 if defined?(ActiveRecord)
   Rails.configuration.after_initialize do

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -155,33 +155,28 @@ RSpec.describe Rage::Logger do
     end
   end
 
-  context "from outside the application" do
+  context "outside the request/response cycle" do
     before do
-      stub_const("IRB", Class.new)
+      Thread.current[:rage_logger] = nil
     end
 
     it "correctly adds an entry" do
       subject.info "this is a test message"
-      expect(io.tap(&:rewind).read).to eq("this is a test message\n")
+      expect(io.tap(&:rewind).read).to eq("timestamp=very_accurate_timestamp pid=777 level=info message=this is a test message\n")
     end
 
-    it "correctly adds a block entry" do
-      subject.info { "this is a test message" }
-      expect(io.tap(&:rewind).read).to eq("this is a test message\n")
-    end
-
-    it "ignores tags" do
+    it "correctly adds tagged entry" do
       subject.tagged("rspec") do
         subject.info "this is a test message"
       end
-      expect(io.tap(&:rewind).read).to eq("this is a test message\n")
+      expect(io.tap(&:rewind).read).to eq("[rspec] timestamp=very_accurate_timestamp pid=777 level=info message=this is a test message\n")
     end
 
-    it "ignores context" do
-      subject.with_context(a: "1") do
+    it "correctly adds an entry with context" do
+      subject.with_context(key: "test") do
         subject.info "this is a test message"
       end
-      expect(io.tap(&:rewind).read).to eq("this is a test message\n")
+      expect(io.tap(&:rewind).read).to eq("timestamp=very_accurate_timestamp pid=777 level=info key=test message=this is a test message\n")
     end
   end
 


### PR DESCRIPTION
we now have fail-safe implementations (#64) of the formatters, `Logger.with_context`, and `Logger.tagged`, so this limitation doesn't make sense anymore