### PR TITLE
Change the way controller names are logged

### DIFF
--- a/lib/rage/all.rb
+++ b/lib/rage/all.rb
@@ -18,6 +18,7 @@ require_relative "router/constrainer"
 require_relative "router/dsl"
 require_relative "router/handler_storage"
 require_relative "router/node"
+require_relative "router/util"
 
 require_relative "controller/api"
 

--- a/lib/rage/logger/json_formatter.rb
+++ b/lib/rage/logger/json_formatter.rb
@@ -17,8 +17,8 @@ class Rage::JSONFormatter
 
     if final = logger[:final]
       params, env = final[:params], final[:env]
-      if params
-        return "{\"tags\":[\"#{tags[0]}\"],\"timestamp\":\"#{timestamp}\",\"pid\":\"#{@pid}\",\"level\":\"info\",\"method\":\"#{env["REQUEST_METHOD"]}\",\"path\":\"#{env["PATH_INFO"]}\",\"controller\":\"#{params[:controller]}\",\"action\":\"#{params[:action]}\",#{context_msg}\"status\":#{final[:response][0]},\"duration\":#{final[:duration]}}\n"
+      if params && params[:controller]
+        return "{\"tags\":[\"#{tags[0]}\"],\"timestamp\":\"#{timestamp}\",\"pid\":\"#{@pid}\",\"level\":\"info\",\"method\":\"#{env["REQUEST_METHOD"]}\",\"path\":\"#{env["PATH_INFO"]}\",\"controller\":\"#{Rage::Router::Util.path_to_name(params[:controller])}\",\"action\":\"#{params[:action]}\",#{context_msg}\"status\":#{final[:response][0]},\"duration\":#{final[:duration]}}\n"
       else
         # no controller/action keys are written if there are no params
         return "{\"tags\":[\"#{tags[0]}\"],\"timestamp\":\"#{timestamp}\",\"pid\":\"#{@pid}\",\"level\":\"info\",\"method\":\"#{env["REQUEST_METHOD"]}\",\"path\":\"#{env["PATH_INFO"]}\",#{context_msg}\"status\":#{final[:response][0]},\"duration\":#{final[:duration]}}\n"

--- a/lib/rage/logger/text_formatter.rb
+++ b/lib/rage/logger/text_formatter.rb
@@ -17,8 +17,8 @@ class Rage::TextFormatter
 
     if final = logger[:final]
       params, env = final[:params], final[:env]
-      if params
-        return "[#{tags[0]}] timestamp=#{timestamp} pid=#{@pid} level=info method=#{env["REQUEST_METHOD"]} path=#{env["PATH_INFO"]} controller=#{params[:controller]} action=#{params[:action]} #{context_msg}status=#{final[:response][0]} duration=#{final[:duration]}\n"
+      if params && params[:controller]
+        return "[#{tags[0]}] timestamp=#{timestamp} pid=#{@pid} level=info method=#{env["REQUEST_METHOD"]} path=#{env["PATH_INFO"]} controller=#{Rage::Router::Util.path_to_name(params[:controller])} action=#{params[:action]} #{context_msg}status=#{final[:response][0]} duration=#{final[:duration]}\n"
       else
         # no controller/action keys are written if there are no params
         return "[#{tags[0]}] timestamp=#{timestamp} pid=#{@pid} level=info method=#{env["REQUEST_METHOD"]} path=#{env["PATH_INFO"]} #{context_msg}status=#{final[:response][0]} duration=#{final[:duration]}\n"

--- a/lib/rage/router/backend.rb
+++ b/lib/rage/router/backend.rb
@@ -67,7 +67,7 @@ class Rage::Router::Backend
     if handler.is_a?(String)
       raise "Invalid route handler format, expected to match the 'controller#action' pattern" unless handler =~ STRING_HANDLER_REGEXP
 
-      controller, action = to_controller_class($1), $2
+      controller, action = Rage::Router::Util.path_to_class($1), $2
       run_action_method_name = controller.__register_action(action.to_sym)
 
       meta[:controller] = $1
@@ -271,24 +271,6 @@ class Rage::Router::Backend
         url_params << param
         path_index = param_end_index
       end
-    end
-  end
-
-  def to_controller_class(str)
-    str.capitalize!
-    str.gsub!(/([\/_])([a-zA-Z0-9]+)/) do
-      if $1 == "/"
-        "::#{$2.capitalize}"
-      else
-        $2.capitalize
-      end
-    end
-
-    klass = "#{str}Controller"
-    if Object.const_defined?(klass)
-      Object.const_get(klass)
-    else
-      raise Rage::Errors::RouterError, "Routing error: could not find the #{klass} class"
     end
   end
 end

--- a/lib/rage/router/handler_storage.rb
+++ b/lib/rage/router/handler_storage.rb
@@ -48,10 +48,11 @@ class Rage::Router::HandlerStorage
   private
 
   def compile_create_params_object(param_keys, defaults, meta)
-    lines = [
-      ":controller => '#{meta[:controller]}'.freeze",
-      ":action => '#{meta[:action]}'.freeze"
-    ]
+    lines = if meta[:controller]
+      [":controller => '#{meta[:controller]}'.freeze", ":action => '#{meta[:action]}'.freeze"]
+    else
+      []
+    end
 
     param_keys.each_with_index do |key, i|
       lines << ":#{key} => param_values[#{i}]"

--- a/lib/rage/router/util.rb
+++ b/lib/rage/router/util.rb
@@ -1,0 +1,33 @@
+class Rage::Router::Util
+  class << self
+    # converts controller name in a path form into a class
+    # `api/v1/users` => `Api::V1::UsersController`
+    def path_to_class(str)
+      str = str.capitalize
+      str.gsub!(/([\/_])([a-zA-Z0-9]+)/) do
+        if $1 == "/"
+          "::#{$2.capitalize}"
+        else
+          $2.capitalize
+        end
+      end
+
+      klass = "#{str}Controller"
+      if Object.const_defined?(klass)
+        Object.const_get(klass)
+      else
+        raise Rage::Errors::RouterError, "Routing error: could not find the #{klass} class"
+      end
+    end
+
+    @@names_map = {}
+
+    # converts controller name in a path form into a string representation of a class
+    # `api/v1/users` => `"Api::V1::UsersController"`
+    def path_to_name(str)
+      @@names_map[str] || begin
+        @@names_map[str] = path_to_class(str).name
+      end
+    end
+  end
+end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe "End-to-end" do
 
     it "correctly adds 2xx entries" do
       HTTP.get("http://localhost:3000/empty")
-      expect(logs.last).to match(/^\[\w{16}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info method=GET path=\/empty controller=application action=empty status=204 duration=\d+\.\d+$/)
+      expect(logs.last).to match(/^\[\w{16}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info method=GET path=\/empty controller=ApplicationController action=empty status=204 duration=\d+\.\d+$/)
     end
 
     it "correctly adds 404 entries" do
@@ -199,12 +199,12 @@ RSpec.describe "End-to-end" do
 
       expect(request_logs.size).to eq(2)
       expect(request_logs[0]).to match(/^\[#{request_tag}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=error message=RuntimeError \(1155 test error\):$/)
-      expect(request_logs[1]).to match(/^\[#{request_tag}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info method=GET path=\/raise_error controller=application action=raise_error status=500 duration=\d+\.\d+$/)
+      expect(request_logs[1]).to match(/^\[#{request_tag}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info method=GET path=\/raise_error controller=ApplicationController action=raise_error status=500 duration=\d+\.\d+$/)
     end
 
     it "correctly adds non-get entries" do
       HTTP.patch("http://localhost:3000/patch")
-      expect(logs.last).to match(/^\[\w{16}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info method=PATCH path=\/patch controller=application action=patch status=200 duration=\d+\.\d+$/)
+      expect(logs.last).to match(/^\[\w{16}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info method=PATCH path=\/patch controller=ApplicationController action=patch status=200 duration=\d+\.\d+$/)
     end
 
     it "correctly adds custom entries" do
@@ -216,7 +216,7 @@ RSpec.describe "End-to-end" do
       expect(request_logs[0]).to match(/^\[#{request_tag}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info message=log_1$/)
       expect(request_logs[1]).to match(/^\[#{request_tag}\]\[tag_2\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=warn message=log_2$/)
       expect(request_logs[2]).to match(/^\[#{request_tag}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=error test=true message=log_3$/)
-      expect(request_logs[3]).to match(/^\[#{request_tag}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info method=GET path=\/logs\/custom controller=logs action=custom status=204 duration=\d+\.\d+$/)
+      expect(request_logs[3]).to match(/^\[#{request_tag}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info method=GET path=\/logs\/custom controller=LogsController action=custom status=204 duration=\d+\.\d+$/)
     end
 
     it "correctly adds entries from inner fibers" do
@@ -228,22 +228,27 @@ RSpec.describe "End-to-end" do
       expect(request_logs[0]).to match(/^\[#{request_tag}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info message=outside_1$/)
       expect(request_logs[1]).to match(/^\[#{request_tag}\]\[in_fiber\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info message=inside$/)
       expect(request_logs[2]).to match(/^\[#{request_tag}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info message=outside_2$/)
-      expect(request_logs[3]).to match(/^\[#{request_tag}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info method=GET path=\/logs\/fiber controller=logs action=fiber status=204 duration=\d+\.\d+$/)
+      expect(request_logs[3]).to match(/^\[#{request_tag}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info method=GET path=\/logs\/fiber controller=LogsController action=fiber status=204 duration=\d+\.\d+$/)
+    end
+
+    it "correctly adds entries from lambda handlers" do
+      HTTP.get("http://localhost:3000")
+      expect(logs.last).to match(/^\[\w{16}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info method=GET path=\/ status=200 duration=\d+\.\d+$/)
     end
 
     it "correctly adds root entries from mounted apps" do
       HTTP.get("http://localhost:3000/admin")
-      expect(logs.last).to match(/^\[\w{16}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info method=GET path=\/admin controller= action= status=200 duration=\d+\.\d+$/)
+      expect(logs.last).to match(/^\[\w{16}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info method=GET path=\/admin status=200 duration=\d+\.\d+$/)
     end
 
     it "correctly adds non-root entries from mounted apps" do
       HTTP.delete("http://localhost:3000/admin/undo")
-      expect(logs.last).to match(/^\[\w{16}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info method=DELETE path=\/admin\/undo controller= action= status=200 duration=\d+\.\d+$/)
+      expect(logs.last).to match(/^\[\w{16}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info method=DELETE path=\/admin\/undo status=200 duration=\d+\.\d+$/)
     end
 
     it "correctly appends info" do
       HTTP.get("http://localhost:3000/logs/custom", params: { append_info_to_payload: true })
-      expect(logs.last).to match(/^\[\w{16}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info method=GET path=\/logs\/custom controller=logs action=custom hello=world status=204 duration=\d+\.\d+$/)
+      expect(logs.last).to match(/^\[\w{16}\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} pid=\d+ level=info method=GET path=\/logs\/custom controller=LogsController action=custom hello=world status=204 duration=\d+\.\d+$/)
     end
   end
 end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -188,14 +188,16 @@ RSpec.describe Rage::Logger do
         response: [300, {}, []],
         duration: 1.45
       }
+
+      stub_const("RspecController", double(name: "RspecController"))
     end
 
     it "correctly add an entry" do
       subject.info ""
-      expect(io.tap(&:rewind).read).to eq("[my_test_tag] timestamp=very_accurate_timestamp pid=777 level=info method=GET path=/test_path controller=rspec action=index status=300 duration=1.45\n")
+      expect(io.tap(&:rewind).read).to eq("[my_test_tag] timestamp=very_accurate_timestamp pid=777 level=info method=GET path=/test_path controller=RspecController action=index status=300 duration=1.45\n")
     end
 
-    context "without params" do
+    context "with no params" do
       before do
         Thread.current[:rage_logger][:final].delete(:params)
       end
@@ -203,6 +205,29 @@ RSpec.describe Rage::Logger do
       it "correctly add an entry" do
         subject.info ""
         expect(io.tap(&:rewind).read).to eq("[my_test_tag] timestamp=very_accurate_timestamp pid=777 level=info method=GET path=/test_path status=300 duration=1.45\n")
+      end
+    end
+
+    context "with empty params" do
+      before do
+        Thread.current[:rage_logger][:final][:params] = {}
+      end
+
+      it "correctly add an entry" do
+        subject.info ""
+        expect(io.tap(&:rewind).read).to eq("[my_test_tag] timestamp=very_accurate_timestamp pid=777 level=info method=GET path=/test_path status=300 duration=1.45\n")
+      end
+    end
+
+    context "with namespaced controllers" do
+      before do
+        Thread.current[:rage_logger][:final][:params][:controller] = "api/v2/users"
+        stub_const("Api::V2::UsersController", double(name: "Api::V2::UsersController"))
+      end
+
+      it "correctly add an entry" do
+        subject.info ""
+        expect(io.tap(&:rewind).read).to eq("[my_test_tag] timestamp=very_accurate_timestamp pid=777 level=info method=GET path=/test_path controller=Api::V2::UsersController action=index status=300 duration=1.45\n")
       end
     end
   end

--- a/spec/router/util_spec.rb
+++ b/spec/router/util_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+RSpec.describe Rage::Router::Util do
+  describe "#path_to_class" do
+    let(:klass) { Class.new }
+
+    context "with one section" do
+      before do
+        stub_const("UsersController", klass)
+      end
+
+      it "correctly converts string to class" do
+        expect(described_class.path_to_class("users")).to eq(klass)
+      end
+    end
+
+    context "with multiple sections" do
+      before do
+        stub_const("AdminUsersController", klass)
+      end
+
+      it "correctly converts string to class" do
+        expect(described_class.path_to_class("admin_users")).to eq(klass)
+      end
+    end
+
+    context "with a namespace" do
+      before do
+        stub_const("Api::UsersController", klass)
+      end
+
+      it "correctly converts string to class" do
+        expect(described_class.path_to_class("api/users")).to eq(klass)
+      end
+    end
+
+    context "with multiple namespaces" do
+      before do
+        stub_const("Admin::Api::V1::UsersController", klass)
+      end
+
+      it "correctly converts string to class" do
+        expect(described_class.path_to_class("admin/api/v1/users")).to eq(klass)
+      end
+    end
+
+    context "with multiple namespaces and sections" do
+      before do
+        stub_const("Api::V1::FavoritePhotosController", klass)
+      end
+
+      it "correctly converts string to class" do
+        expect(described_class.path_to_class("api/v1/favorite_photos")).to eq(klass)
+      end
+    end
+
+    context "with incorrect name" do
+      before do
+        stub_const("UsersController", klass)
+      end
+
+      it "raises an error" do
+        expect { described_class.path_to_class("api/v1/users") }.to raise_error(Rage::Errors::RouterError)
+      end
+    end
+  end
+
+  describe "#path_to_name" do
+    it "correctly converts string to class name" do
+      expect(described_class).to receive(:path_to_class).once.and_return(double(name: "test-name"))
+
+      expect(described_class.path_to_name("test")).to eq("test-name")
+      expect(described_class.path_to_name("test")).to eq("test-name")
+    end
+  end
+end


### PR DESCRIPTION
* controller keys in logs now show the name of the class, e.g. "Api::V1::UsersController";
* lambda handlers now don't log controller/action values;