### PR TITLE
Disable `Fiber.defer` for ActiveRecord 7.1+

### DIFF
--- a/lib/rage/ext/setup.rb
+++ b/lib/rage/ext/setup.rb
@@ -4,7 +4,7 @@ if defined?(ActiveSupport::IsolatedExecutionState)
 end
 
 # release ActiveRecord connections on yield
-if defined?(ActiveRecord)
+if defined?(ActiveRecord) && ActiveRecord.version < Gem::Version.create("7.1.0")
   class Fiber
     def self.defer
       res = Fiber.yield

--- a/lib/rage/fiber.rb
+++ b/lib/rage/fiber.rb
@@ -91,7 +91,7 @@ class Fiber
 
   # @private
   # under normal circumstances, the method is a copy of `yield`, but it can be overriden to perform
-  # additional steps on yielding, e.g. releasing AR connections; see "lib/rage/rails.rb"
+  # additional steps on yielding, e.g. releasing AR connections; see "lib/rage/ext/setup.rb"
   class << self
     alias_method :defer, :yield
   end


### PR DESCRIPTION
something has changed in AR 7.1, and releasing the connections on yield doesn't work reliably anymore. At the moment, I've got neither time nor motivation to look into what's happened there, and as much as I'm not happy about it, currently, the solution is to disable this behaviour for AR 7.1+.

ref: #66