### PR TITLE
Controller parameters wrapping feature

### DIFF
--- a/lib/rage/controller/api.rb
+++ b/lib/rage/controller/api.rb
@@ -77,6 +77,22 @@ class RageController::API
 
       activerecord_loaded = defined?(::ActiveRecord)
 
+      wrap_parameters_chunk = if __wrap_parameters_key
+        <<~RUBY
+          options = self.class.__wrap_parameters_options
+          
+          wrapped_params = if options[:include]
+            @__params.slice(*[options[:include]].flatten)
+          elsif options[:exclude]
+            @__params.except(*[options[:exclude]].flatten)
+          else
+            @__params
+          end
+          
+          @__params = {self.class.__wrap_parameters_key => wrapped_params}
+        RUBY
+      end
+
       class_eval <<~RUBY,  __FILE__, __LINE__ + 1
         def __run_#{action}
           #{if activerecord_loaded
@@ -85,6 +101,7 @@ class RageController::API
             RUBY
           end}
 
+          #{wrap_parameters_chunk}
           #{before_actions_chunk}
           #{action}
 
@@ -122,6 +139,7 @@ class RageController::API
 
     # @private
     attr_writer :__before_actions, :__after_actions, :__rescue_handlers
+    attr_accessor :__wrap_parameters_key, :__wrap_parameters_options
 
     # @private
     # pass the variable down to the child; the child will continue to use it until changes need to be made;
@@ -130,6 +148,8 @@ class RageController::API
       klass.__before_actions = @__before_actions.freeze
       klass.__after_actions = @__after_actions.freeze
       klass.__rescue_handlers = @__rescue_handlers.freeze
+      klass.__wrap_parameters_key = __wrap_parameters_key
+      klass.__wrap_parameters_options = __wrap_parameters_options
     end
 
     # @private
@@ -275,6 +295,20 @@ class RageController::API
       end
 
       @__before_actions[i] = action
+    end
+
+    # Initialize controller params wrapping into a nested hash.
+    # If initialized, params wrapping logic will be added to the controller.
+    #
+    # @param key [Symbol] key that the params hash will nested under
+    # @param options [Hash] wrapping options
+    # @example
+    #   wrap_parameters :user, include: [:name, :age]
+    # @example
+    #   wrap_parameters :user, exclude: :address
+    def wrap_parameters(key, options = {})
+      @__wrap_parameters_key = key
+      @__wrap_parameters_options = options
     end
 
     private

--- a/lib/rage/controller/api.rb
+++ b/lib/rage/controller/api.rb
@@ -79,17 +79,20 @@ class RageController::API
 
       wrap_parameters_chunk = if __wrap_parameters_key
         <<~RUBY
-          options = self.class.__wrap_parameters_options
-
-          wrapped_params = if options[:include]
-            @__params.slice(*[options[:include]].flatten)
-          elsif options[:exclude]
-            @__params.except(*[options[:exclude]].flatten)
-          else
-            @__params
+          wrap_key = self.class.__wrap_parameters_key
+          if !@__params.key?(wrap_key) && @__env['CONTENT_TYPE']
+            wrap_options = self.class.__wrap_parameters_options
+  
+            wrapped_params = if wrap_options[:include]
+              @__params.slice(*[wrap_options[:include]].flatten)
+            elsif wrap_options[:exclude]
+              @__params.except(*[wrap_options[:exclude]].flatten)
+            else
+              @__params
+            end
+  
+            @__params = @__params.merge({wrap_key => wrapped_params})
           end
-
-          @__params = @__params.merge({self.class.__wrap_parameters_key => wrapped_params})
         RUBY
       end
 

--- a/lib/rage/controller/api.rb
+++ b/lib/rage/controller/api.rb
@@ -80,7 +80,7 @@ class RageController::API
       wrap_parameters_chunk = if __wrap_parameters_key
         <<~RUBY
           options = self.class.__wrap_parameters_options
-          
+
           wrapped_params = if options[:include]
             @__params.slice(*[options[:include]].flatten)
           elsif options[:exclude]
@@ -88,8 +88,8 @@ class RageController::API
           else
             @__params
           end
-          
-          @__params = {self.class.__wrap_parameters_key => wrapped_params}
+
+          @__params = @__params.merge({self.class.__wrap_parameters_key => wrapped_params})
         RUBY
       end
 

--- a/lib/rage/controller/api.rb
+++ b/lib/rage/controller/api.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class RageController::API
+  RESERVED_PARAMS = %i[action controller].freeze
+
   class << self
     # @private
     # used by the router to register a new action;
@@ -86,9 +88,9 @@ class RageController::API
             wrapped_params = if wrap_options[:include]
               @__params.slice(*[wrap_options[:include]].flatten)
             elsif wrap_options[:exclude]
-              @__params.except(*[wrap_options[:exclude]].flatten)
+              @__params.except(*([wrap_options[:exclude]].flatten + RESERVED_PARAMS))
             else
-              @__params
+              @__params.except(*RESERVED_PARAMS)
             end
   
             @__params = @__params.merge({wrap_key => wrapped_params})

--- a/spec/controller/api/wrap_parameters_spec.rb
+++ b/spec/controller/api/wrap_parameters_spec.rb
@@ -1,0 +1,279 @@
+RSpec.describe RageController::API do
+  describe 'parameters wrapping logic' do
+    context 'when parameters wrapper is not declared' do
+      let(:controller) do
+        Class.new(RageController::API) do
+          def index
+            render json: params
+          end
+        end
+      end
+
+      it "doesn't wrap the parameters" do
+        initial_params = {param: :value}
+        expected_result = {param: :value}
+
+        expect(run_action(controller, :index, params: initial_params)).to match(
+          [200, instance_of(Hash), [expected_result.to_json]]
+        )
+      end
+    end
+
+    context 'when parameters wrapper is declared without options' do
+      let(:controller) do
+        Class.new(RageController::API) do
+          wrap_parameters :root
+
+          def index
+            render json: params
+          end
+        end
+      end
+
+      context "and wrapping root doesn't conflict with parameter key" do
+        it 'wraps the parameters into a nested hash' do
+          initial_params = {param: :value}
+          expected_result = {param: :value, root: {param: :value}}
+
+          expect(run_action(controller, :index, params: initial_params)).to match(
+            [200, instance_of(Hash), [expected_result.to_json]]
+          )
+        end
+      end
+
+      context 'and wrapping root conflicts with parameter key' do
+        it 'wraps the parameters into a nested hash and overrides the conflicting key' do
+          initial_params = {root: :value, param: :value}
+          expected_result = {root: {root: :value, param: :value}, param: :value}
+
+          expect(run_action(controller, :index, params: initial_params)).to match(
+            [200, instance_of(Hash), [expected_result.to_json]]
+          )
+        end
+      end
+    end
+
+    context 'when parameters wrapper is declared with :include option' do
+      context 'and :include option is set as Symbol' do
+        let(:controller) do
+          Class.new(RageController::API) do
+            wrap_parameters :root, include: :param_a
+
+            def index
+              render json: params
+            end
+          end
+        end
+
+        it 'wraps the param that is set to be included' do
+          initial_params = {param_a: :value, param_b: :value}
+          expected_result = {param_a: :value, param_b: :value, root: {param_a: :value}}
+
+          expect(run_action(controller, :index, params: initial_params)).to match(
+            [200, instance_of(Hash), [expected_result.to_json]]
+          )
+        end
+      end
+
+      context 'and :include option is set as Array' do
+        let(:controller) do
+          Class.new(RageController::API) do
+            wrap_parameters :root, include: [:param_a, :param_b]
+
+            def index
+              render json: params
+            end
+          end
+        end
+
+        it 'wraps the params that are set to be included' do
+          initial_params = {param_a: :value, param_b: :value, param_c: :value}
+          expected_result = {
+            param_a: :value,
+            param_b: :value,
+            param_c: :value,
+            root: {param_a: :value, param_b: :value}
+          }
+
+          expect(run_action(controller, :index, params: initial_params)).to match(
+            [200, instance_of(Hash), [expected_result.to_json]]
+          )
+        end
+      end
+    end
+
+    context 'when parameters wrapper is declared with :exclude option' do
+      context 'and :exclude option is set as Symbol' do
+        let(:controller) do
+          Class.new(RageController::API) do
+            wrap_parameters :root, exclude: :param_a
+
+            def index
+              render json: params
+            end
+          end
+        end
+
+        it 'wraps the params except the param that is set to be excluded' do
+          initial_params = {param_a: :value, param_b: :value}
+          expected_result = {param_a: :value, param_b: :value, root: {param_b: :value}}
+
+          expect(run_action(controller, :index, params: initial_params)).to match(
+            [200, instance_of(Hash), [expected_result.to_json]]
+          )
+        end
+      end
+
+      context 'and :exclude option is set as Array' do
+        let(:controller) do
+          Class.new(RageController::API) do
+            wrap_parameters :root, exclude: [:param_a, :param_b]
+
+            def index
+              render json: params
+            end
+          end
+        end
+
+        it 'wraps the params except the params that are set to be excluded' do
+          initial_params = {param_a: :value, param_b: :value, param_c: :value}
+          expected_result = {param_a: :value, param_b: :value, param_c: :value, root: {param_c: :value}}
+
+          expect(run_action(controller, :index, params: initial_params)).to match(
+            [200, instance_of(Hash), [expected_result.to_json]]
+          )
+        end
+      end
+    end
+
+    context 'when parameters wrapper is declared with both :exclude and :include options' do
+      let(:controller) do
+        Class.new(RageController::API) do
+          wrap_parameters :root, exclude: :param_a, include: :param_a
+
+          def index
+            render json: params
+          end
+        end
+      end
+
+      it 'wraps the params using the :include option' do
+        initial_params = {param_a: :value, param_b: :value}
+        expected_result = {param_a: :value, param_b: :value, root: {param_a: :value}}
+
+        expect(run_action(controller, :index, params: initial_params)).to match(
+          [200, instance_of(Hash), [expected_result.to_json]]
+        )
+      end
+    end
+  end
+
+  describe 'controller inheritance' do
+    let(:grandchild_controller) do
+      Class.new(child_controller) do
+        def index
+          render json: params
+        end
+      end
+    end
+
+    context 'when parameters wrapper is declared in parent controller' do
+      let(:parent_controller) do
+        Class.new(RageController::API) do
+          wrap_parameters :parent_root, include: [:parent_param]
+
+          def index
+            render json: params
+          end
+        end
+      end
+
+      context 'and parameters wrapper is declared in child controller' do
+        context 'and child wrapper is declared without options' do
+          let(:child_controller) do
+            Class.new(parent_controller) do
+              wrap_parameters :child_root
+
+              def index
+                render json: params
+              end
+            end
+          end
+
+          let(:initial_params) { {parent_param: :value, child_param: :value} }
+          let(:expected_result) do
+            {
+              parent_param: :value,
+              child_param: :value,
+              child_root: {parent_param: :value, child_param: :value}
+            }
+          end
+
+          it 'wraps params of child controller using wrapping key of child controller without options' do
+            expect(run_action(child_controller, :index, params: initial_params)).to match(
+              [200, instance_of(Hash), [expected_result.to_json]]
+            )
+          end
+
+          it 'wraps params of grandchild controller using wrapping key of child controller without options' do
+            expect(run_action(grandchild_controller, :index, params: initial_params)).to match(
+              [200, instance_of(Hash), [expected_result.to_json]]
+            )
+          end
+        end
+
+        context 'and child wrapper is defined with options' do
+          let(:child_controller) do
+            Class.new(parent_controller) do
+              wrap_parameters :child_root, include: [:child_param]
+
+              def index
+                render json: params
+              end
+            end
+          end
+
+          let(:initial_params) { {parent_param: :value, child_param: :value} }
+          let(:expected_result) { {parent_param: :value, child_param: :value, child_root: {child_param: :value}} }
+
+          it 'wraps params of child controller using wrapping key and options of child controller' do
+            expect(run_action(child_controller, :index, params: initial_params)).to match(
+              [200, instance_of(Hash), [expected_result.to_json]]
+            )
+          end
+
+          it 'wraps params of grandchild controller using wrapping key and options of child controller' do
+            expect(run_action(grandchild_controller, :index, params: initial_params)).to match(
+              [200, instance_of(Hash), [expected_result.to_json]]
+            )
+          end
+        end
+      end
+
+      context 'and parameters wrapper is not declared in child controller' do
+        let(:child_controller) do
+          Class.new(parent_controller) do
+            def index
+              render json: params
+            end
+          end
+        end
+
+        let(:initial_params) { {parent_param: :value, child_param: :value} }
+        let(:expected_result) { {parent_param: :value, child_param: :value, parent_root: {parent_param: :value}} }
+
+        it 'wraps params of child controller using wrapping key and options of parent controller' do
+          expect(run_action(child_controller, :index, params: initial_params)).to match(
+           [200, instance_of(Hash), [expected_result.to_json]]
+         )
+        end
+
+        it 'wraps params of grandchild controller using wrapping key and options of parent controller' do
+          expect(run_action(child_controller, :index, params: initial_params)).to match(
+            [200, instance_of(Hash), [expected_result.to_json]]
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/controller/api/wrap_parameters_spec.rb
+++ b/spec/controller/api/wrap_parameters_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe RageController::API do
         end
 
         context 'and CONTENT_TYPE header is present' do
-          it 'wraps the parameters into a nested hash' do
-            initial_params = {param: :value}
-            expected_result = {param: :value, root: {param: :value}}
+          it 'wraps the parameters into a nested hash without the reserved params' do
+            initial_params = {param: :value, action: :action, controller: :controller}
+            expected_result = {param: :value, action: :action, controller: :controller, root: {param: :value}}
 
             response = run_action(
               controller,
@@ -59,8 +59,8 @@ RSpec.describe RageController::API do
 
       context 'and wrapping root conflicts with parameter key' do
         it "doesn't wrap the parameters into a nested hash" do
-          initial_params = {root: :value, param: :value}
-          expected_result = {root: :value, param: :value}
+          initial_params = {root: :value, param: :value, action: :action, controller: :controller}
+          expected_result = {root: :value, param: :value, action: :action, controller: :controller}
 
           response = run_action(controller, :index, params: initial_params, env: {'CONTENT_TYPE' => "application/json"})
           expect(response).to match([200, instance_of(Hash), [expected_result.to_json]])
@@ -81,8 +81,14 @@ RSpec.describe RageController::API do
         end
 
         it 'wraps the param that is set to be included' do
-          initial_params = {param_a: :value, param_b: :value}
-          expected_result = {param_a: :value, param_b: :value, root: {param_a: :value}}
+          initial_params = {param_a: :value, param_b: :value, action: :action, controller: :controller}
+          expected_result = {
+            param_a: :value,
+            param_b: :value,
+            action: :action,
+            controller: :controller,
+            root: {param_a: :value}
+          }
 
           response = run_action(controller, :index, params: initial_params, env: {'CONTENT_TYPE' => "application/json"})
           expect(response).to match([200, instance_of(Hash), [expected_result.to_json]])
@@ -101,11 +107,13 @@ RSpec.describe RageController::API do
         end
 
         it 'wraps the params that are set to be included' do
-          initial_params = {param_a: :value, param_b: :value, param_c: :value}
+          initial_params = {param_a: :value, param_b: :value, param_c: :value, action: :action, controller: :controller}
           expected_result = {
             param_a: :value,
             param_b: :value,
             param_c: :value,
+            action: :action,
+            controller: :controller,
             root: {param_a: :value, param_b: :value}
           }
 
@@ -128,8 +136,13 @@ RSpec.describe RageController::API do
         end
 
         it 'wraps the params except the param that is set to be excluded' do
-          initial_params = {param_a: :value, param_b: :value}
-          expected_result = {param_a: :value, param_b: :value, root: {param_b: :value}}
+          initial_params = {param_a: :value, param_b: :value, action: :action, controller: :controller}
+          expected_result = {
+            param_a: :value,
+            param_b: :value, action: :action,
+            controller: :controller,
+            root: {param_b: :value}
+          }
 
           response = run_action(controller, :index, params: initial_params, env: {'CONTENT_TYPE' => "application/json"})
           expect(response).to match([200, instance_of(Hash), [expected_result.to_json]])

--- a/spec/controller/api/wrap_parameters_spec.rb
+++ b/spec/controller/api/wrap_parameters_spec.rb
@@ -13,9 +13,8 @@ RSpec.describe RageController::API do
         initial_params = {param: :value}
         expected_result = {param: :value}
 
-        expect(run_action(controller, :index, params: initial_params)).to match(
-          [200, instance_of(Hash), [expected_result.to_json]]
-        )
+        response = run_action(controller, :index, params: initial_params, env: {'CONTENT_TYPE' => "application/json"})
+        expect(response).to match([200, instance_of(Hash), [expected_result.to_json]])
       end
     end
 
@@ -31,24 +30,40 @@ RSpec.describe RageController::API do
       end
 
       context "and wrapping root doesn't conflict with parameter key" do
-        it 'wraps the parameters into a nested hash' do
-          initial_params = {param: :value}
-          expected_result = {param: :value, root: {param: :value}}
+        context 'and CONTENT_TYPE header is blank' do
+          it "doesn't wrap the parameters into a nested hash" do
+            initial_params = {param: :value}
+            expected_result = {param: :value}
 
-          expect(run_action(controller, :index, params: initial_params)).to match(
-            [200, instance_of(Hash), [expected_result.to_json]]
-          )
+            response = run_action(controller, :index, params: initial_params)
+            expect(response).to match([200, instance_of(Hash), [expected_result.to_json]])
+          end
+        end
+
+        context 'and CONTENT_TYPE header is present' do
+          it 'wraps the parameters into a nested hash' do
+            initial_params = {param: :value}
+            expected_result = {param: :value, root: {param: :value}}
+
+            response = run_action(
+              controller,
+              :index,
+              params: initial_params,
+              env: {'CONTENT_TYPE' => "application/json"}
+            )
+
+            expect(response).to match([200, instance_of(Hash), [expected_result.to_json]])
+          end
         end
       end
 
       context 'and wrapping root conflicts with parameter key' do
-        it 'wraps the parameters into a nested hash and overrides the conflicting key' do
+        it "doesn't wrap the parameters into a nested hash" do
           initial_params = {root: :value, param: :value}
-          expected_result = {root: {root: :value, param: :value}, param: :value}
+          expected_result = {root: :value, param: :value}
 
-          expect(run_action(controller, :index, params: initial_params)).to match(
-            [200, instance_of(Hash), [expected_result.to_json]]
-          )
+          response = run_action(controller, :index, params: initial_params, env: {'CONTENT_TYPE' => "application/json"})
+          expect(response).to match([200, instance_of(Hash), [expected_result.to_json]])
         end
       end
     end
@@ -69,9 +84,8 @@ RSpec.describe RageController::API do
           initial_params = {param_a: :value, param_b: :value}
           expected_result = {param_a: :value, param_b: :value, root: {param_a: :value}}
 
-          expect(run_action(controller, :index, params: initial_params)).to match(
-            [200, instance_of(Hash), [expected_result.to_json]]
-          )
+          response = run_action(controller, :index, params: initial_params, env: {'CONTENT_TYPE' => "application/json"})
+          expect(response).to match([200, instance_of(Hash), [expected_result.to_json]])
         end
       end
 
@@ -95,9 +109,8 @@ RSpec.describe RageController::API do
             root: {param_a: :value, param_b: :value}
           }
 
-          expect(run_action(controller, :index, params: initial_params)).to match(
-            [200, instance_of(Hash), [expected_result.to_json]]
-          )
+          response = run_action(controller, :index, params: initial_params, env: {'CONTENT_TYPE' => "application/json"})
+          expect(response).to match([200, instance_of(Hash), [expected_result.to_json]])
         end
       end
     end
@@ -118,9 +131,8 @@ RSpec.describe RageController::API do
           initial_params = {param_a: :value, param_b: :value}
           expected_result = {param_a: :value, param_b: :value, root: {param_b: :value}}
 
-          expect(run_action(controller, :index, params: initial_params)).to match(
-            [200, instance_of(Hash), [expected_result.to_json]]
-          )
+          response = run_action(controller, :index, params: initial_params, env: {'CONTENT_TYPE' => "application/json"})
+          expect(response).to match([200, instance_of(Hash), [expected_result.to_json]])
         end
       end
 
@@ -139,9 +151,8 @@ RSpec.describe RageController::API do
           initial_params = {param_a: :value, param_b: :value, param_c: :value}
           expected_result = {param_a: :value, param_b: :value, param_c: :value, root: {param_c: :value}}
 
-          expect(run_action(controller, :index, params: initial_params)).to match(
-            [200, instance_of(Hash), [expected_result.to_json]]
-          )
+          response = run_action(controller, :index, params: initial_params, env: {'CONTENT_TYPE' => "application/json"})
+          expect(response).to match([200, instance_of(Hash), [expected_result.to_json]])
         end
       end
     end
@@ -161,9 +172,8 @@ RSpec.describe RageController::API do
         initial_params = {param_a: :value, param_b: :value}
         expected_result = {param_a: :value, param_b: :value, root: {param_a: :value}}
 
-        expect(run_action(controller, :index, params: initial_params)).to match(
-          [200, instance_of(Hash), [expected_result.to_json]]
-        )
+        response = run_action(controller, :index, params: initial_params, env: {'CONTENT_TYPE' => "application/json"})
+        expect(response).to match([200, instance_of(Hash), [expected_result.to_json]])
       end
     end
   end
@@ -210,15 +220,25 @@ RSpec.describe RageController::API do
           end
 
           it 'wraps params of child controller using wrapping key of child controller without options' do
-            expect(run_action(child_controller, :index, params: initial_params)).to match(
-              [200, instance_of(Hash), [expected_result.to_json]]
+            response = run_action(
+              child_controller,
+              :index,
+              params: initial_params,
+              env: {'CONTENT_TYPE' => "application/json"}
             )
+
+            expect(response).to match([200, instance_of(Hash), [expected_result.to_json]])
           end
 
           it 'wraps params of grandchild controller using wrapping key of child controller without options' do
-            expect(run_action(grandchild_controller, :index, params: initial_params)).to match(
-              [200, instance_of(Hash), [expected_result.to_json]]
+            response = run_action(
+              grandchild_controller,
+              :index,
+              params: initial_params,
+              env: {'CONTENT_TYPE' => "application/json"}
             )
+
+            expect(response).to match([200, instance_of(Hash), [expected_result.to_json]])
           end
         end
 
@@ -237,15 +257,25 @@ RSpec.describe RageController::API do
           let(:expected_result) { {parent_param: :value, child_param: :value, child_root: {child_param: :value}} }
 
           it 'wraps params of child controller using wrapping key and options of child controller' do
-            expect(run_action(child_controller, :index, params: initial_params)).to match(
-              [200, instance_of(Hash), [expected_result.to_json]]
+            response = run_action(
+              child_controller,
+              :index,
+              params: initial_params,
+              env: { 'CONTENT_TYPE' => "application/json" }
             )
+
+            expect(response).to match([200, instance_of(Hash), [expected_result.to_json]])
           end
 
           it 'wraps params of grandchild controller using wrapping key and options of child controller' do
-            expect(run_action(grandchild_controller, :index, params: initial_params)).to match(
-              [200, instance_of(Hash), [expected_result.to_json]]
+            response = run_action(
+              grandchild_controller,
+              :index,
+              params: initial_params,
+              env: {'CONTENT_TYPE' => "application/json"}
             )
+
+            expect(response).to match([200, instance_of(Hash), [expected_result.to_json]])
           end
         end
       end
@@ -263,15 +293,25 @@ RSpec.describe RageController::API do
         let(:expected_result) { {parent_param: :value, child_param: :value, parent_root: {parent_param: :value}} }
 
         it 'wraps params of child controller using wrapping key and options of parent controller' do
-          expect(run_action(child_controller, :index, params: initial_params)).to match(
-           [200, instance_of(Hash), [expected_result.to_json]]
-         )
+          response = run_action(
+            child_controller,
+            :index,
+            params: initial_params,
+            env: {'CONTENT_TYPE' => "application/json"}
+          )
+
+          expect(response).to match([200, instance_of(Hash), [expected_result.to_json]])
         end
 
         it 'wraps params of grandchild controller using wrapping key and options of parent controller' do
-          expect(run_action(child_controller, :index, params: initial_params)).to match(
-            [200, instance_of(Hash), [expected_result.to_json]]
+          response = run_action(
+            child_controller,
+            :index,
+            params: initial_params,
+            env: {'CONTENT_TYPE' => "application/json"}
           )
+
+          expect(response).to match([200, instance_of(Hash), [expected_result.to_json]])
         end
       end
     end


### PR DESCRIPTION
Implementation of wrappers for controller parameters. 

Controllers got new class method `wrap_parameters` that accepts 2 parameters: `key`(mandatory) and `options`(optional). If called, all parameters are wrapped into a nested hash like this:
`{query_param: 'queryparam', body_param: 'bodyparam', action: 'action', controller: 'controller', wrapping_key: {query_param: 'queryparam', body_param: 'bodyparam', action: 'action', controller: 'controller'}}` where `wrapping_key` is the key set with the `wrap_parameters` method.

Parameters get wrapped only if there is no param that is named like the key passed during wrap_parameters call. Also, the 'Content_Type' header has to be present for the parameters to be wrapped.

Currently 2 options are available: include and exclude. When called with _include_ option, the logic will only wrap parameters that are passed along with this option. If called with _exclude_ option, all parameters except those that were passed with the option will be wrapped.

Possible enhancements: 
- wrap only request body params
- add request_type options