### PR TITLE
Improve `Rage.multi_application`

### DIFF
--- a/lib/rage/router/util.rb
+++ b/lib/rage/router/util.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rage::Router::Util
   class << self
     # converts controller name in a path form into a class
@@ -40,9 +42,13 @@ class Rage::Router::Util
 
     def call(env)
       result = @rage_app.call(env)
-      return result if result[0] == :__http_defer__ || result[1]["X-Cascade".freeze] != "pass".freeze
+      return result if result[0] == :__http_defer__
 
-      @rails_app.call(env)
+      if result[1]["X-Cascade"] == "pass" || env["PATH_INFO"].start_with?("/rails/")
+        @rails_app.call(env)
+      else
+        result
+      end
     end
   end
 end

--- a/spec/multi_application_spec.rb
+++ b/spec/multi_application_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.describe "Rage Multi App" do
+  subject { Rage.multi_application.call(env) }
+
+  let(:env) { { "PATH_INFO"=> "/" } }
+  let(:rails_verifier) { double }
+  let(:rage_verifier) { double }
+
+  before do
+    stub_const("Rails", double(application: rails_verifier))
+    allow(Rage).to receive(:application).and_return(rage_verifier)
+  end
+
+  context "with a 200 response" do
+    it "calls Rage app" do
+      expect(rage_verifier).to receive(:call).with(env).and_return([200, {}, []])
+      subject
+    end
+  end
+
+  context "with a 404 response" do
+    it "calls Rage app" do
+      expect(rage_verifier).to receive(:call).with(env).and_return([404, {}, []])
+      subject
+    end
+  end
+
+  context "with an async response" do
+    it "calls Rage app" do
+      expect(rage_verifier).to receive(:call).with(env).and_return([:__http_defer__, Fiber.new {}])
+      subject
+    end
+  end
+
+  context "with an X-Cascade response" do
+    it "calls both Rage and Rails apps" do
+      expect(rage_verifier).to receive(:call).with(env).and_return([200, { "X-Cascade" => "pass" }, []])
+      expect(rails_verifier).to receive(:call).with(env)
+      subject
+    end
+  end
+
+  context "with Rails internal request" do
+    let(:env) { { "PATH_INFO"=> "/rails/action_mailbox" } }
+
+    it "calls both Rage and Rails apps" do
+      expect(rage_verifier).to receive(:call).with(env).and_return([200, {}, []])
+      expect(rails_verifier).to receive(:call).with(env)
+      subject
+    end
+  end
+end


### PR DESCRIPTION
this updates `Rage.multi_application` to send to the Rails app the requests that hit `/rails/...` endpoints. These are internal Rails endpoints that are used by ActionMailbox (e.g. `/rails/action_mailbox/relay/inbound_emails`) or ActiveStorage (e.g. `/rails/active_storage/disk/:encoded_key/*filename`)