### PR TITLE
Separate test gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,12 +8,13 @@ gemspec
 gem "rake", "~> 13.0"
 
 gem "rspec", "~> 3.0"
-gem "http"
 gem "yard"
 
-gem "pg"
-gem "mysql2"
-gem "connection_pool", "~> 2.0"
-
-gem "rbnacl"
-gem "domain_name"
+group :test do
+  gem "http"
+  gem "pg"
+  gem "mysql2"
+  gem "connection_pool", "~> 2.0"
+  gem "rbnacl"
+  gem "domain_name"
+end

--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,6 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
-bundle install
+BUNDLE_WITHOUT=test bundle install
 
 # Do any other automated setup that you need to do here


### PR DESCRIPTION
This ensures we don't require gems like `pg` or `mysql2` for local development.