### PR TITLE
Unknown Environment Error Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .DS_Store
 Gemfile.lock
 *.gem
+.idea
 
 # rspec failure tracking
 .rspec_status

--- a/lib/rage/setup.rb
+++ b/lib/rage/setup.rb
@@ -1,6 +1,10 @@
 Iodine.patch_rack
 
-require_relative "#{Rage.root}/config/environments/#{Rage.env}"
+begin
+  require_relative "#{Rage.root}/config/environments/#{Rage.env}"
+rescue LoadError
+  raise LoadError, "The <#{Rage.env}> environment could not be found. Please check the environment name."
+end
 
 # Run application initializers
 Dir["#{Rage.root}/config/initializers/**/*.rb"].each { |initializer| load(initializer) }

--- a/spec/setup_spec.rb
+++ b/spec/setup_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe 'Setup' do
+  let(:valid_env) { 'development' }
+  let(:invalid_env) { 'develop' }
+  let(:setup_file) { File.expand_path('../lib/rage/setup.rb', __dir__) }
+
+  before do
+    allow(Rage).to receive(:env).and_return(env)
+    allow(Rage).to receive(:root).and_return(File.expand_path('..', __dir__))
+    allow(Rage).to receive_message_chain(:code_loader, :setup).and_return(true)
+    allow(Iodine).to receive(:patch_rack).and_return(true)
+  end
+
+  context 'when environment name is valid' do
+    let(:env) { valid_env }
+
+    before do
+      allow_any_instance_of(Object).to receive(:require_relative).with("#{Rage.root}/config/environments/#{Rage.env}").and_return(true)
+      allow_any_instance_of(Object).to receive(:require_relative).with("#{Rage.root}/config/routes").and_return(true)
+    end
+
+    it 'loads the environment without error' do
+      expect { load setup_file }.not_to raise_error
+    end
+  end
+
+  context 'when environment name is invalid' do
+    let(:env) { invalid_env }
+
+    it 'raises a custom error with a meaningful message' do
+      expect { load setup_file }
+        .to raise_error(LoadError, "The <#{invalid_env}> environment could not be found. Please check the environment name.")
+    end
+  end
+end


### PR DESCRIPTION
## Unknown Environment Error Handling

### Description

This PR addresses the issue of Rage failing with a "cannot load such file" exception when an invalid environment name is provided. Instead of the generic error, this PR introduces a custom error with a meaningful message indicating that the specified environment could not be found.

### Issue Addressed

* Issue: Unknown environment error
* Rage creates new applications with three environments: development, production, and test. These environments are configured inside the `config/environments` folder.
* The environment can be set using either the `-e` option or the `RAGE_ENV` environment variable.
  * Example: `bundle exec rage s -e production`
  * Example: `RAGE_ENV=production bundle exec rage s`
* If a user makes a typo in the environment name, e.g., “producion”, Rage will fail with the “cannot load such file” exception.
* The goal is to raise a custom error with a meaningful message, e.g., “The <producion> environment could not be found”.

### Changes Made

1. **Error Handling in `setup.rb`**:
    - Wrapped the `require_relative` call in a `begin...rescue` block.
    - Caught the `LoadError` and raised a `LoadError` with a custom message indicating the invalid environment name.
    
2. **RSpec Test**:
    - Added tests to check if the custom error is raised correctly when an invalid environment name is provided.

### Screenshots
- **Before**
<img width="1632" alt="image" src="https://github.com/user-attachments/assets/bfebc4af-ac4d-4b9c-98ca-c5ea56002883">

- **After**
<img width="1562" alt="image" src="https://github.com/user-attachments/assets/66a7fc16-f45d-460d-91ba-c691e090bf61">

### Documentation

No documentation changes are necessary as this update enhances error handling for existing functionality.

