### PR TITLE
DB Pool Updates

### DIFF
--- a/lib/rage-rb.rb
+++ b/lib/rage-rb.rb
@@ -65,8 +65,10 @@ module Rage
       if is_connected
         puts "INFO: Patching ActiveRecord::ConnectionPool"
         Iodine.on_state(:on_start) do
-          ActiveRecord::Base.connection_pool.extend(Rage::Ext::ActiveRecord::ConnectionPool)
-          ActiveRecord::Base.connection_pool.__init_rage_extension
+          ActiveRecord::Base.connection_handler.connection_pool_list(:all).each do |pool|
+            pool.extend(Rage::Ext::ActiveRecord::ConnectionPool)
+            pool.__init_rage_extension
+          end
         end
       else
         puts "WARNING: DB connection is not established - can't patch ActiveRecord::ConnectionPool"

--- a/lib/rage/cable/channel.rb
+++ b/lib/rage/cable/channel.rb
@@ -166,6 +166,7 @@ class Rage::Cable::Channel
           #{if activerecord_loaded
             <<~RUBY
             ensure
+              # TODO
               if ActiveRecord::Base.connection_pool.active_connection?
                 ActiveRecord::Base.connection_handler.clear_active_connections!
               end

--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -130,9 +130,13 @@
 #
 # > Disables the `io_write` hook to fix the ["zero-length iov"](https://bugs.ruby-lang.org/issues/19640) error on Ruby < 3.3.
 #
-# • _RAGE_PATCH_AR_POOL_
+# • _RAGE_DISABLE_AR_POOL_PATCH_
 #
-# > Enables the `ActiveRecord::ConnectionPool` patch to optimize database connection management. Use it to increase throughput under high load.
+# > Disables the `ActiveRecord::ConnectionPool` patch and makes Rage use the original ActiveRecord implementation.
+#
+# • _RAGE_DISABLE_AR_WEAK_CONNECTIONS_
+#
+# > Instructs Rage to not reuse Active Record connections between different fibers.
 #
 class Rage::Configuration
   attr_accessor :logger

--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -265,7 +265,7 @@ class Rage::Configuration
     attr_accessor :rails_mode
 
     def patch_ar_pool?
-      ENV["RAGE_PATCH_AR_POOL"] && !Rage.env.test?
+      !ENV["RAGE_DISABLE_AR_POOL_PATCH"] && !Rage.env.test?
     end
 
     def inspect

--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -268,6 +268,12 @@ class Rage::Configuration
       !ENV["RAGE_DISABLE_AR_POOL_PATCH"] && !Rage.env.test?
     end
 
+    # whether we should manually release AR connections;
+    # AR 7.2+ uses `with_connection` internaly, so we only need to do this for older versions;
+    def manually_release_ar_connections?
+      defined?(ActiveRecord) && ActiveRecord.version < Gem::Version.create("7.2.0")
+    end
+
     def inspect
       "#<#{self.class.name}>"
     end

--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -274,6 +274,12 @@ class Rage::Configuration
       defined?(ActiveRecord) && ActiveRecord.version < Gem::Version.create("7.2.0")
     end
 
+    # whether we should manually reconnect closed AR connections;
+    # AR 7.1+ does this automatically while executing the query;
+    def should_manually_restore_ar_connections?
+      defined?(ActiveRecord) && ActiveRecord.version < Gem::Version.create("7.1.0")
+    end
+
     def inspect
       "#<#{self.class.name}>"
     end

--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -264,6 +264,10 @@ class Rage::Configuration
   class Internal
     attr_accessor :rails_mode
 
+    def patch_ar_pool?
+      ENV["RAGE_PATCH_AR_POOL"] && !Rage.env.test?
+    end
+
     def inspect
       "#<#{self.class.name}>"
     end

--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -270,7 +270,7 @@ class Rage::Configuration
 
     # whether we should manually release AR connections;
     # AR 7.2+ uses `with_connection` internaly, so we only need to do this for older versions;
-    def manually_release_ar_connections?
+    def should_manually_release_ar_connections?
       defined?(ActiveRecord) && ActiveRecord.version < Gem::Version.create("7.2.0")
     end
 

--- a/lib/rage/controller/api.rb
+++ b/lib/rage/controller/api.rb
@@ -122,8 +122,8 @@ class RageController::API
           #{if activerecord_loaded
             <<~RUBY
               ActiveRecord::Base.connection_pool.disable_query_cache!
-              if ActiveRecord::Base.connection_pool.active_connection?
-                ActiveRecord::Base.connection_handler.clear_active_connections!
+              if ActiveRecord::Base.connection_handler.active_connections?(:all)
+                ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
               end
             RUBY
           end}

--- a/lib/rage/controller/api.rb
+++ b/lib/rage/controller/api.rb
@@ -128,9 +128,7 @@ class RageController::API
 
           #{if should_release_connections
             <<~RUBY
-              if ActiveRecord::Base.connection_handler.active_connections?
-                ActiveRecord::Base.connection_handler.clear_active_connections!
-              end
+              ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
             RUBY
           end}
 

--- a/lib/rage/controller/api.rb
+++ b/lib/rage/controller/api.rb
@@ -94,7 +94,7 @@ class RageController::API
       end
 
       query_cache_enabled = defined?(::ActiveRecord)
-      should_release_connections = Rage.config.internal.manually_release_ar_connections?
+      should_release_connections = Rage.config.internal.should_manually_release_ar_connections?
 
       class_eval <<~RUBY, __FILE__, __LINE__ + 1
         def __run_#{action}

--- a/lib/rage/controller/api.rb
+++ b/lib/rage/controller/api.rb
@@ -128,8 +128,8 @@ class RageController::API
 
           #{if should_release_connections
             <<~RUBY
-              if ActiveRecord::Base.connection_handler.active_connections?(:all)
-                ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+              if ActiveRecord::Base.connection_handler.active_connections?
+                ActiveRecord::Base.connection_handler.clear_active_connections!
               end
             RUBY
           end}

--- a/lib/rage/ext/active_record/connection_pool.rb
+++ b/lib/rage/ext/active_record/connection_pool.rb
@@ -160,6 +160,7 @@ module Rage::Ext::ActiveRecord::ConnectionPool
           @__in_use.delete(fiber)
           conn.disconnect!
           __remove__(conn)
+          self.automatic_reconnect = true
           @__connections += build_new_connections(1)
           Iodine.publish(@release_connection_channel, "", Iodine::PubSub::PROCESS) if @__blocked.length > 0
         end
@@ -260,6 +261,7 @@ module Rage::Ext::ActiveRecord::ConnectionPool
     end
 
     # create a new pool
+    self.automatic_reconnect = true
     @__connections = build_new_connections
 
     # notify blocked fibers that there are new connections available

--- a/lib/rage/ext/active_record/connection_pool.rb
+++ b/lib/rage/ext/active_record/connection_pool.rb
@@ -66,7 +66,7 @@ module Rage::Ext::ActiveRecord::ConnectionPool
     @__checkout_timeout = checkout_timeout
 
     # how long a connection can be idle for before disconnecting
-    @__idle_timeout = reaper.frequency
+    @__idle_timeout = respond_to?(:db_config) ? db_config.idle_timeout : @idle_timeout
 
     # how often should we check for fibers that wait for a connection for too long
     @__timeout_worker_frequency = 0.5

--- a/lib/rage/ext/setup.rb
+++ b/lib/rage/ext/setup.rb
@@ -34,7 +34,7 @@ if defined?(ActiveRecord) && Rage.config.internal.patch_ar_pool?
         if ActiveRecord::Base.connection_handler.active_connections?(:all)
           Iodine.defer do
             if fileno != f.__awaited_fileno || !f.alive?
-              ActiveRecord::Base.connection_handler.connection_pool_list(:all).each { |pool| pool.release_connection(Fiber.current) }
+              ActiveRecord::Base.connection_handler.connection_pool_list(:all).each { |pool| pool.release_connection(f) }
             end
           end
         end

--- a/lib/rage/ext/setup.rb
+++ b/lib/rage/ext/setup.rb
@@ -20,7 +20,7 @@ if defined?(ActiveRecord) && Rage.config.internal.patch_ar_pool?
 
         if ActiveRecord::Base.connection_handler.active_connections?
           Iodine.defer do
-            if fileno != f.__awaited_fileno
+            if fileno != f.__awaited_fileno || !f.alive?
               ActiveRecord::Base.connection_handler.connection_pools.each { |pool| pool.release_connection(f) }
             end
           end

--- a/lib/rage/ext/setup.rb
+++ b/lib/rage/ext/setup.rb
@@ -1,3 +1,7 @@
+if defined?(ActiveRecord) && ActiveRecord.version < Gem::Version.create("6")
+  fail "Rage is only compatible with Active Record 6+. Detected Active Record version: #{ActiveRecord.version}."
+end
+
 # set ActiveSupport isolation level
 if defined?(ActiveSupport::IsolatedExecutionState)
   ActiveSupport::IsolatedExecutionState.isolation_level = :fiber

--- a/lib/rage/ext/setup.rb
+++ b/lib/rage/ext/setup.rb
@@ -6,11 +6,11 @@ end
 # release ActiveRecord connections on yield
 if defined?(ActiveRecord) && Rage.config.internal.patch_ar_pool?
   if ENV["RAGE_DISABLE_AR_WEAK_CONNECTIONS"]
-    unless Rage.config.internal.manually_release_ar_connections?
+    unless Rage.config.internal.should_manually_release_ar_connections?
       puts "WARNING: The RAGE_DISABLE_AR_WEAK_CONNECTIONS setting does not have any effect with Active Record 7.2+"
     end
     # no-op
-  elsif Rage.config.internal.manually_release_ar_connections?
+  elsif Rage.config.internal.should_manually_release_ar_connections?
     class Fiber
       def self.defer(fileno)
         f = Fiber.current

--- a/lib/rage/ext/setup.rb
+++ b/lib/rage/ext/setup.rb
@@ -18,10 +18,10 @@ if defined?(ActiveRecord) && Rage.config.internal.patch_ar_pool?
 
         res = Fiber.yield
 
-        if ActiveRecord::Base.connection_handler.active_connections?(:all)
+        if ActiveRecord::Base.connection_handler.active_connections?
           Iodine.defer do
             if fileno != f.__awaited_fileno
-              ActiveRecord::Base.connection_handler.connection_pools(:all).each { |pool| pool.release_connection(f) }
+              ActiveRecord::Base.connection_handler.connection_pools.each { |pool| pool.release_connection(f) }
             end
           end
         end

--- a/lib/rage/ext/setup.rb
+++ b/lib/rage/ext/setup.rb
@@ -5,12 +5,12 @@ end
 
 # release ActiveRecord connections on yield
 if defined?(ActiveRecord) && Rage.config.internal.patch_ar_pool?
-  if ActiveRecord.version >= Gem::Version.create("7.2.0")
-    # yay! AR 7.2+ uses `with_connection` internaly - no need to use `Fiber.defer`
-    if ENV["RAGE_DISABLE_AR_WEAK_CONNECTIONS"]
-      puts "WARNING: The RAGE_DISABLE_AR_WEAK_CONNECTIONS setting does not have any effect in Rails 7.2+"
+  if ENV["RAGE_DISABLE_AR_WEAK_CONNECTIONS"]
+    unless Rage.config.internal.manually_release_ar_connections?
+      puts "WARNING: The RAGE_DISABLE_AR_WEAK_CONNECTIONS setting does not have any effect with Active Record 7.2+"
     end
-  elsif !ENV["RAGE_DISABLE_AR_WEAK_CONNECTIONS"]
+    # no-op
+  elsif Rage.config.internal.manually_release_ar_connections?
     class Fiber
       def self.defer(fileno)
         f = Fiber.current

--- a/lib/rage/ext/setup.rb
+++ b/lib/rage/ext/setup.rb
@@ -22,7 +22,6 @@ if defined?(ActiveRecord) && Rage.config.internal.patch_ar_pool?
     unless Rage.config.internal.should_manually_release_ar_connections?
       puts "WARNING: The RAGE_DISABLE_AR_WEAK_CONNECTIONS setting does not have any effect with Active Record 7.2+"
     end
-    # no-op
   elsif Rage.config.internal.should_manually_release_ar_connections?
     class Fiber
       def self.defer(fileno)

--- a/lib/rage/fiber.rb
+++ b/lib/rage/fiber.rb
@@ -141,7 +141,7 @@ class Fiber
       end
     end
 
-    Fiber.yield
+    Fiber.defer(-1)
     Iodine.defer { Iodine.unsubscribe("await:#{f.object_id}") }
 
     # if num_wait_for is not 0 means we exited prematurely because of an error

--- a/lib/rage/fiber.rb
+++ b/lib/rage/fiber.rb
@@ -82,6 +82,9 @@ class Fiber
   end
 
   # @private
+  attr_accessor :__awaited_fileno
+
+  # @private
   # pause a fiber and resume in the next iteration of the event loop
   def self.pause
     f = Fiber.current

--- a/lib/rage/fiber.rb
+++ b/lib/rage/fiber.rb
@@ -39,6 +39,43 @@
 # Many developers see fibers as "lightweight threads" that should be used in conjunction with fiber pools, the same way we use thread pools for threads.<br>
 # Instead, it makes sense to think of fibers as regular Ruby objects. We don't use a pool of arrays when we need to create an array - we create a new object and let Ruby and the GC do their job.<br>
 # Same applies to fibers. Feel free to create as many fibers as you need on demand.
+#
+# ## Active Record Connections
+#
+# Let's consider the following controller, where we update a record in the database:
+#
+# ```ruby
+# class UsersController < RageController::API
+#   def update
+#     User.update!(params[:id], email: params[:email])
+#     render status: :ok
+#   end
+# end
+# ```
+#
+# The `User.update!` call here checks out an Active Record connection, and Rage will automatically check it back in once the action is completed. So far so good!
+#
+# Let's consider another example:
+#
+# ```ruby
+# require "net/http"
+#
+# class UsersController < RageController::API
+#   def update
+#     User.update!(params[:id], email: params[:email]) # takes 5ms
+#     Net::HTTP.post_form(URI("https://mailing.service/update"), { user_id: params[:id] }) # takes 50ms
+#     render status: :ok
+#   end
+# end
+# ```
+#
+# Here, we've added another step: once the record is updated, we will send a request to update the user's data in the mailing list service.
+#
+# However, in this case, we want to release the Active Record connection before the action is completed. You can see that we need the connection only for the `User.update!` call.
+# The next 50ms the code will spend waiting for the HTTP request to finish, and if we don't release the Active Record connection right away, other fibers won't be able to use it.
+#
+# Active Record 7.2 handles this case by using [#with_connection](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/ConnectionPool.html#method-i-with_connection) internally.
+# With older Active Record versions, Rage handles this case on its own by keeping track of blocking calls and releasing Active Record connections between them.
 class Fiber
   # @private
   AWAIT_ERROR_MESSAGE = "err"

--- a/lib/rage/fiber_scheduler.rb
+++ b/lib/rage/fiber_scheduler.rb
@@ -14,7 +14,7 @@ class Rage::FiberScheduler
     f = Fiber.current
     ::Iodine::Scheduler.attach(io.fileno, events, timeout&.ceil || 0) { |err| f.resume(err) }
 
-    err = Fiber.defer
+    err = Fiber.defer(io.fileno)
     if err == Errno::ETIMEDOUT::Errno
       0
     else

--- a/lib/rage/fiber_scheduler.rb
+++ b/lib/rage/fiber_scheduler.rb
@@ -15,8 +15,8 @@ class Rage::FiberScheduler
     ::Iodine::Scheduler.attach(io.fileno, events, timeout&.ceil || 0) { |err| f.resume(err) }
 
     err = Fiber.defer(io.fileno)
-    if err == Errno::ETIMEDOUT::Errno
-      0
+    if err && err < 0
+      err
     else
       events
     end

--- a/rage.gemspec
+++ b/rage.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "thor", "~> 1.0"
   spec.add_dependency "rack", "~> 2.0"
-  spec.add_dependency "rage-iodine", "~> 3.0"
+  spec.add_dependency "rage-iodine", "~> 4.0"
   spec.add_dependency "zeitwerk", "~> 2.6"
   spec.add_dependency "rack-test", "~> 2.1"
 end


### PR DESCRIPTION
## DB Pool Updates

### Description

This is the prep work to have Rage's DB Pool enabled by default in **v1.10.0**.

#### Weak AR connections

The PR changes the logic behind `Fiber.defer` to automatically release Active Record connections without waiting for the request to complete. Previous approach (see #66 and #80) was unstable with AR 7.0+. The new approach keeps track of the file descriptors the scheduler waits on to release the connection once the code proceeds to the next blocking call.

#### Health checks for AR connections

With Active Record < 7.1, we enable active health checks for the DB connections that will run every second. If a connection is identified as unhealthy, the pool will reconnect the next time it is checked out. We are not going with the native Active Record approach of calling `verify!` every time the connection is checked out because active health checks strike a better balance between availability and performance.
The health checks are only enabled with AR < 7.1, as AR 7.1+ automatically reconnects to the database.

#### Other fixes

Some other fixes include the correct handling of the `idle_timeout` option and updating the code to automatically release AR connections from all connection pools. The Fiber Scheduler is also updated to correctly handle automatic reconnects and query retries in AR 7.1+.
