### PR TITLE
Allow to preconfigure a database for new apps

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   TargetRubyVersion: 3.1
   Exclude:
     - vendor/bundle/**/*
+    - lib/rage/templates/**/*
   DisabledByDefault: true
   SuggestExtensions: false
 

--- a/lib/rage-rb.rb
+++ b/lib/rage-rb.rb
@@ -82,6 +82,10 @@ module Rage
     end
   end
 
+  def self.load_tasks
+    Rage::Tasks.init
+  end
+
   # @private
   def self.with_middlewares(app, middlewares)
     middlewares.reverse.inject(app) do |next_in_chain, (middleware, args, block)|
@@ -113,6 +117,7 @@ module Rage
     end
   end
 
+  autoload :Tasks, "rage/tasks"
   autoload :Cookies, "rage/cookies"
   autoload :Session, "rage/session"
   autoload :Cable, "rage/cable/cable"

--- a/lib/rage/cli.rb
+++ b/lib/rage/cli.rb
@@ -211,11 +211,11 @@ module Rage
     end
 
     def set_env(options)
-      ENV["RAGE_ENV"] = options[:environment] if options[:environment]
+      ENV["RAGE_ENV"] = options[:environment] || ENV["RAGE_ENV"] || "development"
 
       # at this point we don't know whether the app is running in standalone or Rails mode;
       # we set both variables to make sure applications are running in the same environment;
-      ENV["RAILS_ENV"] = ENV["RAGE_ENV"] if ENV["RAGE_ENV"] && ENV["RAILS_ENV"] != ENV["RAGE_ENV"]
+      ENV["RAILS_ENV"] = ENV["RAGE_ENV"] if ENV["RAILS_ENV"] != ENV["RAGE_ENV"]
     end
 
     def linked_rake_tasks

--- a/lib/rage/cli.rb
+++ b/lib/rage/cli.rb
@@ -215,11 +215,11 @@ module Rage
     end
 
     def set_env(options)
-      ENV["RAGE_ENV"] = options[:environment] || ENV["RAGE_ENV"] || "development"
+      ENV["RAGE_ENV"] = options[:environment] if options[:environment]
 
       # at this point we don't know whether the app is running in standalone or Rails mode;
       # we set both variables to make sure applications are running in the same environment;
-      ENV["RAILS_ENV"] = ENV["RAGE_ENV"] if ENV["RAILS_ENV"] != ENV["RAGE_ENV"]
+      ENV["RAILS_ENV"] = ENV["RAGE_ENV"] if ENV["RAGE_ENV"] && ENV["RAILS_ENV"] != ENV["RAGE_ENV"]
     end
 
     def linked_rake_tasks

--- a/lib/rage/cli.rb
+++ b/lib/rage/cli.rb
@@ -134,6 +134,24 @@ module Rage
       puts Rage::VERSION
     end
 
+    map "--tasks" => :tasks
+    desc "--tasks", "See the list of available tasks."
+    def tasks
+      require "io/console"
+
+      tasks = linked_rake_tasks
+      return if tasks.empty?
+
+      _, max_width = IO.console.winsize
+      max_task_name = tasks.max_by { |task| task.name.length }.name.length + 2
+      max_comment = max_width - max_task_name - 8
+
+      tasks.each do |task|
+        comment = task.comment.length <= max_comment ? task.comment : "#{task.comment[0...max_comment - 5]}..."
+        puts sprintf("rage %-#{max_task_name}s # %s", task.name, comment)
+      end
+    end
+
     def method_missing(method, *, &)
       if linked_rake_tasks.any? { |task| task.name == method.to_s }
         Rake::Task[method].invoke

--- a/lib/rage/cli.rb
+++ b/lib/rage/cli.rb
@@ -215,11 +215,15 @@ module Rage
     end
 
     def set_env(options)
-      ENV["RAGE_ENV"] = options[:environment] if options[:environment]
-
-      # at this point we don't know whether the app is running in standalone or Rails mode;
-      # we set both variables to make sure applications are running in the same environment;
-      ENV["RAILS_ENV"] = ENV["RAGE_ENV"] if ENV["RAGE_ENV"] && ENV["RAILS_ENV"] != ENV["RAGE_ENV"]
+      if options[:environment]
+        ENV["RAGE_ENV"] = ENV["RAILS_ENV"] = options[:environment]
+      elsif ENV["RAGE_ENV"]
+        ENV["RAILS_ENV"] = ENV["RAGE_ENV"]
+      elsif ENV["RAILS_ENV"]
+        ENV["RAGE_ENV"] = ENV["RAILS_ENV"]
+      else
+        ENV["RAGE_ENV"] = ENV["RAILS_ENV"] = "development"
+      end
     end
 
     def linked_rake_tasks

--- a/lib/rage/cli.rb
+++ b/lib/rage/cli.rb
@@ -191,13 +191,17 @@ module Rage
       end
     end
 
-    def method_missing(method, *, &)
-      if linked_rake_tasks.any? { |task| task.name == method.to_s }
-        Rake::Task[method].invoke
+    def method_missing(method_name, *, &)
+      if respond_to?(method_name)
+        Rake::Task[method_name].invoke
       else
         suggestions = linked_rake_tasks.map(&:name)
-        raise UndefinedCommandError.new(method.to_s, suggestions, nil)
+        raise UndefinedCommandError.new(method_name.to_s, suggestions, nil)
       end
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      linked_rake_tasks.any? { |task| task.name == method_name.to_s } || super
     end
 
     private

--- a/lib/rage/cli.rb
+++ b/lib/rage/cli.rb
@@ -192,6 +192,8 @@ module Rage
     end
 
     def method_missing(method_name, *, &)
+      set_env({})
+
       if respond_to?(method_name)
         Rake::Task[method_name].invoke
       else

--- a/lib/rage/ext/setup.rb
+++ b/lib/rage/ext/setup.rb
@@ -91,11 +91,16 @@ if defined?(ActiveRecord) && !Rage.config.internal.rails_mode && (database_url |
   end
 
   ActiveRecord::Base.establish_connection(Rage.env.to_sym)
-  ActiveRecord::Base.logger = Rage.logger
-  ActiveRecord::Base.connection_pool.with_connection {} # validate the connection
+
+  if defined?(Rake)
+    ActiveRecord::Base.logger = nil
+  else
+    ActiveRecord::Base.logger = Rage.logger
+    ActiveRecord::Base.connection_pool.with_connection {} # validate the connection
+  end
 end
 
 # patch `ActiveRecord::ConnectionPool`
-if defined?(ActiveRecord) && Rage.config.internal.patch_ar_pool?
+if defined?(ActiveRecord) && !defined?(Rake) && Rage.config.internal.patch_ar_pool?
   Rage.patch_active_record_connection_pool
 end

--- a/lib/rage/ext/setup.rb
+++ b/lib/rage/ext/setup.rb
@@ -87,10 +87,8 @@ if defined?(ActiveRecord) && !Rage.config.internal.rails_mode && (database_url |
   ActiveRecord::Base.configurations = database_file_config || { Rage.env.to_s => database_url_config }
   ActiveRecord::Base.establish_connection(Rage.env.to_sym)
 
-  if defined?(Rake)
-    ActiveRecord::Base.logger = nil
-  else
-    ActiveRecord::Base.logger = Rage.logger
+  unless defined?(Rake)
+    ActiveRecord::Base.logger = Rage.logger if Rage.logger.debug?
     ActiveRecord::Base.connection_pool.with_connection {} # validate the connection
   end
 end

--- a/lib/rage/ext/setup.rb
+++ b/lib/rage/ext/setup.rb
@@ -84,12 +84,7 @@ if defined?(ActiveRecord) && !Rage.config.internal.rails_mode && (database_url |
     end
   end
 
-  if database_file_config
-    ActiveRecord::Base.configurations = database_file_config
-  else
-    ActiveRecord::Base.configurations = { Rage.env.to_s => database_url_config }
-  end
-
+  ActiveRecord::Base.configurations = database_file_config || { Rage.env.to_s => database_url_config }
   ActiveRecord::Base.establish_connection(Rage.env.to_sym)
 
   if defined?(Rake)

--- a/lib/rage/logger/logger.rb
+++ b/lib/rage/logger/logger.rb
@@ -82,7 +82,7 @@ class Rage::Logger
     end
 
     @formatter = formatter
-    @level = level
+    @level = @logdev ? level : Logger::UNKNOWN
     define_log_methods
   end
 

--- a/lib/rage/setup.rb
+++ b/lib/rage/setup.rb
@@ -9,9 +9,9 @@ end
 # Run application initializers
 Dir["#{Rage.root}/config/initializers/**/*.rb"].each { |initializer| load(initializer) }
 
+require "rage/ext/setup"
+
 # Load application classes
 Rage.code_loader.setup
 
 require_relative "#{Rage.root}/config/routes"
-
-require "rage/ext/setup"

--- a/lib/rage/tasks.rb
+++ b/lib/rage/tasks.rb
@@ -1,0 +1,33 @@
+begin
+  require "standalone_migrations"
+rescue LoadError
+end
+
+class Rage::Tasks
+  class << self
+    def init
+      load_db_tasks if defined?(StandaloneMigrations)
+    end
+
+    private
+
+    def load_db_tasks
+      StandaloneMigrations::Configurator.prepend(Module.new do
+        def configuration_file
+          @path ||= begin
+            @__tempfile = Tempfile.new
+            @__tempfile.write <<~YAML
+              config:
+                database: config/database.yml
+            YAML
+            @__tempfile.close
+
+            @__tempfile.path
+          end
+        end
+      end)
+
+      StandaloneMigrations::Tasks.load_tasks
+    end
+  end
+end

--- a/lib/rage/templates/Rakefile
+++ b/lib/rage/templates/Rakefile
@@ -1,1 +1,2 @@
 require_relative "config/application"
+Rage.load_tasks

--- a/lib/rage/templates/config-application.rb
+++ b/lib/rage/templates/config-application.rb
@@ -2,6 +2,9 @@ require "bundler/setup"
 require "rage"
 Bundler.require(*Rage.groups)
 
+<% if @use_database -%>
+require "active_record"
+<% end -%>
 require "rage/all"
 
 Rage.configure do

--- a/lib/rage/templates/db-templates/app-models-application_record.rb
+++ b/lib/rage/templates/db-templates/app-models-application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/lib/rage/templates/db-templates/db-seeds.rb
+++ b/lib/rage/templates/db-templates/db-seeds.rb
@@ -1,0 +1,9 @@
+# This file should ensure the existence of records required to run the application in every environment (production,
+# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
+# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
+#
+# Example:
+#
+#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
+#     MovieGenre.find_or_create_by!(name: genre_name)
+#   end

--- a/lib/rage/templates/db-templates/mysql/config-database.yml
+++ b/lib/rage/templates/db-templates/mysql/config-database.yml
@@ -1,0 +1,24 @@
+##
+# MySQL. Versions 5.5.8 and up are supported.
+#
+default: &default
+  adapter: mysql2
+  encoding: utf8mb4
+  pool: <%%= ENV.fetch("DB_MAX_CONNECTIONS") { 5 } %>
+  username: root
+  password:
+  socket: /tmp/mysql.sock
+
+development:
+  <<: *default
+  database: <%= @app_name %>_development
+
+test:
+  <<: *default
+  database: <%= @app_name %>_test
+
+production:
+  <<: *default
+  database: <%= @app_name %>_production
+  username: <%= @app_name %>
+  password: <%%= ENV["<%= @app_name.upcase %>_DATABASE_PASSWORD"] %>

--- a/lib/rage/templates/db-templates/postgresql/config-database.yml
+++ b/lib/rage/templates/db-templates/postgresql/config-database.yml
@@ -1,0 +1,21 @@
+##
+# PostgreSQL. Versions 9.3 and up are supported.
+#
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  pool: <%%= ENV.fetch("DB_MAX_CONNECTIONS") { 5 } %>
+
+development:
+  <<: *default
+  database: <%= @app_name %>_development
+
+test:
+  <<: *default
+  database: <%= @app_name %>_test
+
+production:
+  <<: *default
+  database: <%= @app_name %>_production
+  username: <%= @app_name %>
+  password: <%%= ENV["<%= @app_name.upcase %>_DATABASE_PASSWORD"] %>

--- a/lib/rage/templates/db-templates/sqlite3/config-database.yml
+++ b/lib/rage/templates/db-templates/sqlite3/config-database.yml
@@ -1,0 +1,19 @@
+##
+# SQLite. Versions 3.8.0 and up are supported.
+#
+default: &default
+  adapter: sqlite3
+  pool: <%%= ENV.fetch("DB_MAX_CONNECTIONS") { 5 } %>
+  timeout: 5000
+
+development:
+  <<: *default
+  database: storage/development.sqlite3
+
+test:
+  <<: *default
+  database: storage/test.sqlite3
+
+production:
+  <<: *default
+  database: storage/production.sqlite3

--- a/lib/rage/templates/db-templates/trilogy/config-database.yml
+++ b/lib/rage/templates/db-templates/trilogy/config-database.yml
@@ -1,0 +1,24 @@
+##
+# MySQL. Versions 5.5.8 and up are supported.
+#
+default: &default
+  adapter: trilogy
+  encoding: utf8mb4
+  pool: <%%= ENV.fetch("DB_MAX_THREADS") { 5 } %>
+  username: root
+  password:
+  socket: /tmp/mysql.sock
+
+development:
+  <<: *default
+  database: <%= @app_name %>_development
+
+test:
+  <<: *default
+  database: <%= @app_name %>_test
+
+production:
+  <<: *default
+  database: <%= @app_name %>_production
+  username: <%= @app_name %>
+  password: <%%= ENV["<%= @app_name.upcase %>_DATABASE_PASSWORD"] %>

--- a/lib/rage/templates/model-template/model.rb
+++ b/lib/rage/templates/model-template/model.rb
@@ -1,0 +1,2 @@
+class <%= @model_name %> < ApplicationRecord
+end

--- a/rage.gemspec
+++ b/rage.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rage-iodine", "~> 4.0"
   spec.add_dependency "zeitwerk", "~> 2.6"
   spec.add_dependency "rack-test", "~> 2.1"
+  spec.add_dependency "rake", ">= 12.0"
 end

--- a/spec/setup_spec.rb
+++ b/spec/setup_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Setup" do
 
   before do
     allow(Rage).to receive(:env).and_return(env)
-    allow(Rage).to receive(:root).and_return(File.expand_path("..", __dir__))
+    allow(Rage).to receive(:root).and_return(Pathname.new(File.expand_path("..", __dir__)))
     allow(Rage).to receive_message_chain(:code_loader, :setup).and_return(true)
     allow(Iodine).to receive(:patch_rack).and_return(true)
   end


### PR DESCRIPTION
### Description

This change allows to preconfigure the database for new apps.

* support `-d` option in `rage new` - available options are `mysql`, `trilogy`, `postgresql`, `sqlite3`;
* automatically connect to the database if `config/database.yml` or the `DATABASE_URL` env variable is present;
* support `rage --tasks`;
* support the following commands using [standalone_migrations](https://github.com/thuss/standalone-migrations):
  * `rage g migration`
  * `rage g model`
  * `rage db:migrate`
  * `rage db:seed`