### PR TITLE
Correctly patch AR pool in Rails mode

### DIFF
--- a/lib/rage-rb.rb
+++ b/lib/rage-rb.rb
@@ -63,7 +63,7 @@ module Rage
     patch = proc do
       is_connected = ActiveRecord::Base.connection_pool rescue false
       if is_connected
-        puts "INFO: Patching ActiveRecord::ConnectionPool"
+        Iodine.on_state(:pre_start) { puts "INFO: Patching ActiveRecord::ConnectionPool" }
         Iodine.on_state(:on_start) do
           ActiveRecord::Base.connection_handler.connection_pool_list(:all).each do |pool|
             pool.extend(Rage::Ext::ActiveRecord::ConnectionPool)

--- a/lib/rage/ext/setup.rb
+++ b/lib/rage/ext/setup.rb
@@ -94,6 +94,6 @@ if defined?(ActiveRecord) && !Rage.config.internal.rails_mode && (database_url |
 end
 
 # patch `ActiveRecord::ConnectionPool`
-if defined?(ActiveRecord) && !defined?(Rake) && Rage.config.internal.patch_ar_pool?
+if defined?(ActiveRecord) && Rage.config.internal.patch_ar_pool?
   Rage.patch_active_record_connection_pool
 end


### PR DESCRIPTION
we see that with some Rails applications, `Rake` is defined even outside Rake tasks. Could be some dependencies always requiring it...

Anyway, we are safe to remove the `defined?` check, as we patch the AR pool only after the reactor is started, and it's not started in Rake tasks.

Additionally, this changes the way we notify the user of the patch to make sure we only notify when the reactor is started (i.e. when we actually patch the pool)