### PR TITLE
[OpenAPI] Ignore empty comments

### DIFF
--- a/lib/rage/openapi/parser.rb
+++ b/lib/rage/openapi/parser.rb
@@ -16,7 +16,7 @@ class Rage::OpenAPI::Parser
         else
           node.deprecated = true
         end
-        children = find_children(comments[i + 1..])
+        children = find_children(comments[i + 1..], node)
 
       elsif expression =~ /@private\b/
         if node.private
@@ -24,7 +24,7 @@ class Rage::OpenAPI::Parser
         else
           node.private = true
         end
-        children = find_children(comments[i + 1..])
+        children = find_children(comments[i + 1..], node)
 
       elsif expression =~ /@version\s/
         if node.root.version
@@ -45,7 +45,7 @@ class Rage::OpenAPI::Parser
 
       elsif expression =~ /@auth\s/
         method, name, tail_name = expression[6..].split(" ", 3)
-        children = find_children(comments[i + 1..])
+        children = find_children(comments[i + 1..], node)
 
         if tail_name
           Rage::OpenAPI.__log_warn "incorrect `@auth` name detected at #{location_msg(comments[i])}; security scheme name cannot contain spaces"
@@ -83,7 +83,9 @@ class Rage::OpenAPI::Parser
       children = nil
       expression = comments[i].slice.delete_prefix("#").strip
 
-      if !expression.start_with?("@")
+      if expression.empty?
+        # no-op
+      elsif !expression.start_with?("@")
         if node.summary
           Rage::OpenAPI.__log_warn "invalid summary entry detected at #{location_msg(comments[i])}; summary should only be one line"
         else
@@ -96,7 +98,7 @@ class Rage::OpenAPI::Parser
         else
           node.deprecated = true
         end
-        children = find_children(comments[i + 1..])
+        children = find_children(comments[i + 1..], node)
 
       elsif expression =~ /@private\b/
         if node.parents.any?(&:private)
@@ -104,10 +106,10 @@ class Rage::OpenAPI::Parser
         else
           node.private = true
         end
-        children = find_children(comments[i + 1..])
+        children = find_children(comments[i + 1..], node)
 
       elsif expression =~ /@description\s/
-        children = find_children(comments[i + 1..])
+        children = find_children(comments[i + 1..], node)
         node.description = [expression[13..]] + children
 
       elsif expression =~ /@response\s/
@@ -132,7 +134,7 @@ class Rage::OpenAPI::Parser
 
       elsif expression =~ /@internal\b/
         # no-op
-        children = find_children(comments[i + 1..])
+        children = find_children(comments[i + 1..], node)
 
       else
         Rage::OpenAPI.__log_warn "unrecognized `#{expression.split(" ")[0]}` tag detected at #{location_msg(comments[i])}"
@@ -148,13 +150,15 @@ class Rage::OpenAPI::Parser
 
   private
 
-  def find_children(comments)
+  def find_children(comments, node)
     children = []
 
     comments.each do |comment|
-      expression = comment.slice.sub(/^#\s/, "")
+      expression = comment.slice.sub(/^#\s?/, "")
 
-      if expression.start_with?(/\s{2}/)
+      if expression.empty?
+        # no-op
+      elsif expression.start_with?(/\s{2}/)
         children << expression.strip
       elsif expression.start_with?("@")
         break

--- a/lib/rage/openapi/parser.rb
+++ b/lib/rage/openapi/parser.rb
@@ -162,6 +162,9 @@ class Rage::OpenAPI::Parser
         children << expression.strip
       elsif expression.start_with?("@")
         break
+      elsif !node.summary
+        # no-op - this is likely the summary entry
+        break
       else
         Rage::OpenAPI.__log_warn "unrecognized expression detected at #{location_msg(comment)}; use two spaces to mark multi-line expressions"
         break

--- a/spec/openapi/builder/internal_spec.rb
+++ b/spec/openapi/builder/internal_spec.rb
@@ -67,5 +67,31 @@ RSpec.describe Rage::OpenAPI::Builder do
         expect(subject).to eq({ "openapi" => "3.0.0", "info" => { "version" => "1.0.0", "title" => "Rage" }, "components" => {}, "tags" => [{ "name" => "Users" }], "paths" => { "/users" => { "get" => { "summary" => "", "description" => "", "deprecated" => true, "security" => [], "tags" => ["Users"], "responses" => { "200" => { "description" => "" } } } } } })
       end
     end
+
+    context "with an empty comment" do
+      let_class("UsersController", parent: RageController::API) do
+        <<~'RUBY'
+          # Returns the list of all users.
+          # @deprecated
+          #
+          # @internal this is an internal comment
+          def index
+          end
+        RUBY
+      end
+
+      let(:routes) do
+        { "GET /users" => "UsersController#index" }
+      end
+
+      it "returns correct schema" do
+        expect(subject).to eq({ "openapi" => "3.0.0", "info" => { "version" => "1.0.0", "title" => "Rage" }, "components" => {}, "tags" => [{ "name" => "Users" }], "paths" => { "/users" => { "get" => { "summary" => "Returns the list of all users.", "description" => "", "deprecated" => true, "security" => [], "tags" => ["Users"], "responses" => { "200" => { "description" => "" } } } } } })
+      end
+
+      it "does not log error" do
+        expect(Rage::OpenAPI).not_to receive(:__log_warn)
+        subject
+      end
+    end
   end
 end

--- a/spec/openapi/builder/summary_spec.rb
+++ b/spec/openapi/builder/summary_spec.rb
@@ -161,5 +161,134 @@ RSpec.describe Rage::OpenAPI::Builder do
         subject
       end
     end
+
+    context "with empty commments" do
+      let_class("UsersController", parent: RageController::API) do
+        <<~'RUBY'
+          # Returns the list of all users.
+          #
+          # 
+          def index
+          end
+        RUBY
+      end
+
+      let(:routes) do
+        { "GET /users" => "UsersController#index" }
+      end
+
+      it "returns correct schema" do
+        expect(subject).to eq({ "openapi" => "3.0.0", "info" => { "version" => "1.0.0", "title" => "Rage" }, "components" => {}, "tags" => [{ "name" => "Users" }], "paths" => { "/users" => { "get" => { "summary" => "Returns the list of all users.", "description" => "", "deprecated" => false, "security" => [], "tags" => ["Users"], "responses" => { "200" => { "description" => "" } } } } } })
+      end
+
+      it "does not log error" do
+        expect(Rage::OpenAPI).not_to receive(:__log_warn)
+        subject
+      end
+    end
+
+    context "after another tags" do
+      let_class("UsersController", parent: RageController::API) do
+        <<~'RUBY'
+          # @deprecated
+          # Returns the list of all users.
+          #
+          # @internal this is an internal comment
+          def index
+          end
+        RUBY
+      end
+
+      let(:routes) do
+        { "GET /users" => "UsersController#index" }
+      end
+
+      it "returns correct schema" do
+        expect(subject).to eq({ "openapi" => "3.0.0", "info" => { "version" => "1.0.0", "title" => "Rage" }, "components" => {}, "tags" => [{ "name" => "Users" }], "paths" => { "/users" => { "get" => { "summary" => "Returns the list of all users.", "description" => "", "deprecated" => true, "security" => [], "tags" => ["Users"], "responses" => { "200" => { "description" => "" } } } } } })
+      end
+
+      it "does not log error" do
+        expect(Rage::OpenAPI).not_to receive(:__log_warn)
+        subject
+      end
+    end
+
+    context "as the last tag" do
+      let_class("UsersController", parent: RageController::API) do
+        <<~'RUBY'
+          # @deprecated
+          # @internal this is an internal comment
+          #
+          # Returns the list of all users.
+          def index
+          end
+        RUBY
+      end
+
+      let(:routes) do
+        { "GET /users" => "UsersController#index" }
+      end
+
+      it "returns correct schema" do
+        expect(subject).to eq({ "openapi" => "3.0.0", "info" => { "version" => "1.0.0", "title" => "Rage" }, "components" => {}, "tags" => [{ "name" => "Users" }], "paths" => { "/users" => { "get" => { "summary" => "Returns the list of all users.", "description" => "", "deprecated" => true, "security" => [], "tags" => ["Users"], "responses" => { "200" => { "description" => "" } } } } } })
+      end
+
+      it "does not log error" do
+        expect(Rage::OpenAPI).not_to receive(:__log_warn)
+        subject
+      end
+    end
+
+    context "after a text tag" do
+      let_class("UsersController", parent: RageController::API) do
+        <<~'RUBY'
+          # @description this is a test description
+          # Returns the list of all users.
+          def index
+          end
+        RUBY
+      end
+
+      let(:routes) do
+        { "GET /users" => "UsersController#index" }
+      end
+
+      it "returns correct schema" do
+        expect(subject).to eq({ "openapi" => "3.0.0", "info" => { "version" => "1.0.0", "title" => "Rage" }, "components" => {}, "tags" => [{ "name" => "Users" }], "paths" => { "/users" => { "get" => { "summary" => "Returns the list of all users.", "description" => "this is a test description", "deprecated" => false, "security" => [], "tags" => ["Users"], "responses" => { "200" => { "description" => "" } } } } } })
+      end
+
+      it "does not log error" do
+        expect(Rage::OpenAPI).not_to receive(:__log_warn)
+        subject
+      end
+    end
+
+    context "after a multi-line tag" do
+      let_class("UsersController", parent: RageController::API) do
+        <<~'RUBY'
+          # @description this
+          #   is
+          #   a
+          #   test
+          #   description
+          # Returns the list of all users.
+          def index
+          end
+        RUBY
+      end
+
+      let(:routes) do
+        { "GET /users" => "UsersController#index" }
+      end
+
+      it "returns correct schema" do
+        expect(subject).to eq({ "openapi" => "3.0.0", "info" => { "version" => "1.0.0", "title" => "Rage" }, "components" => {}, "tags" => [{ "name" => "Users" }], "paths" => { "/users" => { "get" => { "summary" => "Returns the list of all users.", "description" => "this is a test description", "deprecated" => false, "security" => [], "tags" => ["Users"], "responses" => { "200" => { "description" => "" } } } } } })
+      end
+
+      it "does not log error" do
+        expect(Rage::OpenAPI).not_to receive(:__log_warn)
+        subject
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

The PR updates the OpenAPI parser to ignore empty comments and correctly parse `summary` in case it is not the first tag, e.g.:

```ruby
class UsersController < ApplicationController
  # @deprecated
  # Returns the list of all users.
  #
  # @internal this is an internal comment
  def index
  end
end
```