### PR TITLE
Correctly handle `0` timeouts

### DIFF
--- a/lib/rage/fiber_scheduler.rb
+++ b/lib/rage/fiber_scheduler.rb
@@ -12,10 +12,10 @@ class Rage::FiberScheduler
 
   def io_wait(io, events, timeout = nil)
     f = Fiber.current
-    ::Iodine::Scheduler.attach(io.fileno, events, timeout&.ceil || 0) { |err| f.resume(err) }
+    ::Iodine::Scheduler.attach(io.fileno, events, timeout&.ceil) { |err| f.resume(err) }
 
     err = Fiber.defer(io.fileno)
-    if err && err < 0
+    if err == false || (err && err < 0)
       err
     else
       events

--- a/rage.gemspec
+++ b/rage.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "thor", "~> 1.0"
   spec.add_dependency "rack", "~> 2.0"
-  spec.add_dependency "rage-iodine", "~> 4.0"
+  spec.add_dependency "rage-iodine", "~> 4.1"
   spec.add_dependency "zeitwerk", "~> 2.6"
   spec.add_dependency "rack-test", "~> 2.1"
   spec.add_dependency "rake", ">= 12.0"

--- a/spec/fiber_scheduler_spec.rb
+++ b/spec/fiber_scheduler_spec.rb
@@ -110,6 +110,23 @@ RSpec.describe Rage::FiberScheduler do
     end
   end
 
+  it "works correctly with persistent connections" do
+    uri = URI(TEST_HTTP_URL)
+
+    within_reactor do
+      connection = Net::HTTP.new(uri.hostname, uri.port)
+      connection.use_ssl = true
+      connection.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      connection.start
+
+      responses = 3.times.map do
+        connection.get("/instant-http-get")
+      end
+
+      -> { expect(responses).to all(be_a(Net::HTTPOK)) }
+    end
+  end
+
   context "with Postgres" do
     let(:conn) { PG.connect(TEST_PG_URL) }
 


### PR DESCRIPTION
Initially, zero timeouts were handled as "no timeout". Instead, calls with zero timeouts should be considered non-blocking and return instantly.

The change updates the scheduler to work correctly with persistent HTTP connections.