### PR TITLE
Update app template to include all app rake tasks

### DIFF
--- a/lib/rage/tasks.rb
+++ b/lib/rage/tasks.rb
@@ -7,6 +7,7 @@ class Rage::Tasks
   class << self
     def init
       load_db_tasks if defined?(StandaloneMigrations)
+      load_app_tasks
     end
 
     private
@@ -28,6 +29,10 @@ class Rage::Tasks
       end)
 
       StandaloneMigrations::Tasks.load_tasks
+    end
+
+    def load_app_tasks
+      Dir[Rage.root.join("lib/tasks/**/*.rake")].each { |file| load file }
     end
   end
 end


### PR DESCRIPTION
When I generate a new rage app, it makes a lib/tasks directory. If I put a .rake file in there, the tasks defined in that file aren't available when I run rake. Should they be?

If I add this line to the Rakefile in the root of the project:

```
Dir[Rage.root.join("lib/tasks/**/*.rake")].each { |file| load file }
```

Then the tasks are available. If that is what users are expected to do, would it make sense to have that in that file then?

This pull request adds that to the template, but if there is a different way app rake tasks are intended to be loaded, let me know