### PR TITLE
Reload code in development based on filesystem updates

### DIFF
--- a/lib/rage/code_loader.rb
+++ b/lib/rage/code_loader.rb
@@ -5,16 +5,16 @@ require "zeitwerk"
 class Rage::CodeLoader
   def initialize
     @reloading = false
+    @autoload_path = Rage.root.join("app")
   end
 
   def setup
     @loader = Zeitwerk::Loader.new
 
-    autoload_path = "#{Rage.root}/app"
     enable_reloading = Rage.env.development?
     enable_eager_loading = !Rage.env.development? && !Rage.env.test?
 
-    @loader.push_dir(autoload_path)
+    @loader.push_dir(@autoload_path.to_s)
     # The first level of directories in app directory won't be treated as modules
     # e.g. app/controllers/pages_controller.rb will be linked to PagesController class
     # instead of Controllers::PagesController
@@ -61,5 +61,16 @@ class Rage::CodeLoader
 
   def reloading?
     @reloading
+  end
+
+  def check_updated!
+    current_watched = @autoload_path.glob("**/*.rb") + Rage.root.glob("config/routes.rb")
+    current_update_at = current_watched.max_by { |path| path.exist? ? path.mtime.to_f : 0 }&.mtime.to_f
+    return false if !@last_watched && !@last_update_at
+
+    current_watched.size != @last_watched.size || current_update_at != @last_update_at
+
+  ensure
+    @last_watched, @last_update_at = current_watched, current_update_at
   end
 end

--- a/lib/rage/middleware/reloader.rb
+++ b/lib/rage/middleware/reloader.rb
@@ -6,11 +6,25 @@ class Rage::Reloader
   end
 
   def call(env)
-    Rage.code_loader.reload
-    @app.call(env)
+    with_reload do
+      @app.call(env)
+    end
   rescue Exception => e
     exception_str = "#{e.class} (#{e.message}):\n#{e.backtrace.join("\n")}"
     puts(exception_str)
     [500, {}, [exception_str]]
+  end
+
+  private
+
+  def with_reload
+    if Rage.code_loader.check_updated!
+      Fiber.new(blocking: true) {
+        Rage.code_loader.reload
+        yield
+      }.resume
+    else
+      yield
+    end
   end
 end

--- a/lib/rage/middleware/reloader.rb
+++ b/lib/rage/middleware/reloader.rb
@@ -2,6 +2,9 @@
 
 class Rage::Reloader
   def initialize(app)
+    Iodine.on_state(:on_start) do
+      Rage.code_loader.check_updated!
+    end
     @app = app
   end
 

--- a/spec/code_loader_spec.rb
+++ b/spec/code_loader_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+RSpec.describe Rage::CodeLoader do
+  subject { Rage.code_loader }
+
+  let(:app_path) { "#{Dir.tmpdir}/app" }
+
+  before do
+    allow(Rage.root).to receive(:join).with("app").and_return(Pathname.new(app_path))
+    FileUtils.mkdir(app_path)
+  end
+
+  after do
+    FileUtils.remove_entry(app_path)
+  end
+
+  describe "check_updated!" do
+    context "when there are no files" do
+      it "returns false on the first call" do
+        expect(subject.check_updated!).to be(false)
+      end
+
+      context "when a new file is added" do
+        before do
+          subject.check_updated!
+          File.write("#{app_path}/test.rb", "")
+        end
+
+        it "returns true" do
+          expect(subject.check_updated!).to be(true)
+        end
+
+        it "updates internal state" do
+          expect(subject.check_updated!).to be(true)
+          expect(subject.check_updated!).to be(false)
+        end
+      end
+
+      context "when existing file is updated" do
+        before do
+          File.write("#{app_path}/test.rb", "")
+          subject.check_updated!
+          sleep 0.1
+          FileUtils.touch("#{app_path}/test.rb")
+        end
+
+        it "returns true" do
+          expect(subject.check_updated!).to be(true)
+        end
+
+        it "updates internal state" do
+          expect(subject.check_updated!).to be(true)
+          expect(subject.check_updated!).to be(false)
+        end
+      end
+
+      context "when existing file is removed" do
+        before do
+          File.write("#{app_path}/test.rb", "")
+          subject.check_updated!
+          FileUtils.rm("#{app_path}/test.rb")
+        end
+
+        it "returns true" do
+          expect(subject.check_updated!).to be(true)
+        end
+
+        it "updates internal state" do
+          expect(subject.check_updated!).to be(true)
+          expect(subject.check_updated!).to be(false)
+        end
+      end
+    end
+
+    context "when there are existing files" do
+      before do
+        File.write("#{app_path}/test.rb", "")
+        FileUtils.mkpath("#{app_path}/models/concerns")
+      end
+
+      after do
+        FileUtils.remove_entry("#{app_path}/models/concerns")
+      end
+
+      context "when a new file is added" do
+        before do
+          subject.check_updated!
+          File.write("#{app_path}/models/concerns/test.rb", "")
+        end
+
+        it "returns true" do
+          expect(subject.check_updated!).to be(true)
+        end
+
+        it "updates internal state" do
+          expect(subject.check_updated!).to be(true)
+          expect(subject.check_updated!).to be(false)
+        end
+      end
+
+      context "when existing file is updated" do
+        before do
+          File.write("#{app_path}/models/concerns/test.rb", "")
+          subject.check_updated!
+          sleep 0.1
+          FileUtils.touch("#{app_path}/models/concerns/test.rb")
+        end
+
+        it "returns true" do
+          expect(subject.check_updated!).to be(true)
+        end
+
+        it "updates internal state" do
+          expect(subject.check_updated!).to be(true)
+          expect(subject.check_updated!).to be(false)
+        end
+      end
+
+      context "when existing file is removed" do
+        before do
+          File.write("#{app_path}/models/concerns/test.rb", "")
+          subject.check_updated!
+          FileUtils.rm("#{app_path}/models/concerns/test.rb")
+        end
+
+        it "returns true" do
+          expect(subject.check_updated!).to be(true)
+        end
+
+        it "updates internal state" do
+          expect(subject.check_updated!).to be(true)
+          expect(subject.check_updated!).to be(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously, we would reload code in development on every request. The PR adds a file watcher to only reload the code when there are changes to the source code.