### PR TITLE
[OpenAPI] Explicitly load Prism

### DIFF
--- a/lib/rage/openapi/openapi.rb
+++ b/lib/rage/openapi/openapi.rb
@@ -16,6 +16,15 @@ if !defined?(Prism)
   end
 end
 
+if Gem::Version.create(Prism::VERSION) < Gem::Version.create("0.25.0")
+  fail <<~ERR
+
+    Rage::OpenAPI is only compatible with Prism >= 0.25.0. Detected Prism version: #{Prism::VERSION}. Add the following line to your Gemfile:
+    gem "prism", ">= 0.25.0"
+
+  ERR
+end
+
 module Rage::OpenAPI
   # Create a new OpenAPI application.
   #

--- a/lib/rage/openapi/openapi.rb
+++ b/lib/rage/openapi/openapi.rb
@@ -4,12 +4,16 @@ require "erb"
 require "yaml"
 
 if !defined?(Prism)
-  fail <<~ERR
+  begin
+    require "prism"
+  rescue LoadError
+    fail <<~ERR
 
-    rage-rb depends on Prism to build OpenAPI specifications. Add the following line to your Gemfile:
-    gem "prism"
+      Rage::OpenAPI depends on Prism to build OpenAPI specifications. Add the following line to your Gemfile:
+      gem "prism"
 
-  ERR
+    ERR
+  end
 end
 
 module Rage::OpenAPI


### PR DESCRIPTION
Prism is part of the bundle starting with Ruby 3.3, and it doesn't make sense to ask users to add Prism to the Gemfile.