### PR TITLE
[OpenAPI] Correctly handle global comments

### DIFF
--- a/lib/rage/openapi/parser.rb
+++ b/lib/rage/openapi/parser.rb
@@ -165,11 +165,10 @@ class Rage::OpenAPI::Parser
         children << expression.strip
       elsif expression.start_with?("@")
         break
-      elsif !node.summary
-        # no-op - this is likely the summary entry
+      elsif node.is_a?(Rage::OpenAPI::Nodes::Method) && node.summary
+        Rage::OpenAPI.__log_warn "unrecognized expression detected at #{location_msg(comment)}; use two spaces to mark multi-line expressions"
         break
       else
-        Rage::OpenAPI.__log_warn "unrecognized expression detected at #{location_msg(comment)}; use two spaces to mark multi-line expressions"
         break
       end
     end


### PR DESCRIPTION
Correctly handle the case with regular comments going after global comments:

```ruby
class ApplicationController < RageController:API
  # @deprecated use V2::UsersController instead

  # some comment

  def index
  end
end
```