### PR TITLE
Fix using fiber in IRB with mock of fiber schedule method

### DIFF
--- a/spec/rage/cli_spec.rb
+++ b/spec/rage/cli_spec.rb
@@ -35,4 +35,71 @@ RSpec.describe Rage::CLI do
       expect { rage_cli.version }.to output("1.0.0\n").to_stdout
     end
   end
+
+  describe "#console" do
+    context "when Fiber is monkey patched" do
+      before do
+        # Save the original methods to revert them before a test.
+        # The patch_fiber_for_irb method affects the Fiber class between tests.
+        Fiber.singleton_class.class_eval do
+          alias_method :original_schedule_backup, :schedule
+          alias_method :original_await_backup, :await
+        end
+
+        require "irb"
+        allow(rage_cli).to receive(:environment)
+        allow(IRB).to receive(:start)
+        rage_cli.console
+      end
+
+      after do
+        # Revert the original Fiber methods and drop backups after a test.
+        Fiber.singleton_class.class_eval do
+          alias_method :schedule, :original_schedule_backup
+          alias_method :await, :original_await_backup
+          remove_method :original_schedule_backup
+          remove_method :original_await_backup
+        end
+      end
+
+      it "Fiber.schedule and Fiber.await work during the rage console (binding.irb)" do
+        expect {
+          Fiber.schedule { :test }
+          Fiber.await(Fiber.schedule { :test })
+        }.not_to raise_error
+      end
+
+      it "executes Fibers in strict sequential order" do
+        execution_order = []
+
+        Fiber.schedule { execution_order << 1 }
+        Fiber.schedule { execution_order << 2 }
+        Fiber.schedule { execution_order << 3 }
+
+        expect(execution_order).to eq([1, 2, 3])
+      end
+    end
+
+    context "when Fiber is not monkey patched" do
+      before do
+        require "irb"
+        allow(rage_cli).to receive(:patch_fiber_for_irb)
+        allow(rage_cli).to receive(:environment)
+        allow(IRB).to receive(:start)
+        rage_cli.console
+      end
+
+      it "Fiber.await raises an error during the rage console (binding.irb)" do
+        expect {
+          Fiber.await(Fiber.schedule { :test })
+        }.to raise_error(RuntimeError, "No scheduler is available!")
+      end
+
+      it "Fiber.schedule raises an error during the rage console (binding.irb)" do
+        expect {
+          Fiber.schedule { :test }
+        }.to raise_error(RuntimeError, "No scheduler is available!")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes https://github.com/rage-rb/rage/issues/115

This change monkey patches the existing Fiber class to address a specific issue.

### Other Possible Approaches

1. We can create an **_.irbrc_** file as a template for the rage project. This file executes before IRB starts.
2. There is a proc: `IRB.conf[:IRB_RC] = proc {}`. However, it is not working as expected. I expected it to run every time `IRB.start` is called, but that is not happening. It may be an issue related to the IRB workspace or session, requiring further investigation.
3. We can define a class in an initialisation file like **_irb/init.rb_** and require it somewhere during app initialisation, with a condition like if defined?(IRB).

### Additional Note
Since we evaluate the same logic for both tests and IRB (console), it might make sense to have a shared place for this piece of code.