### PR TITLE
[OpenAPI] Correctly handle the `key` option in associations

### DIFF
--- a/lib/rage/openapi/parsers/ext/alba.rb
+++ b/lib/rage/openapi/parsers/ext/alba.rb
@@ -135,12 +135,13 @@ class Rage::OpenAPI::Parsers::Ext::Alba
       when :many, :has_many, :one, :has_one, :association
         is_array = node.name == :many || node.name == :has_many
         context = with_context { visit(node.arguments) }
-        key = context.keywords["key"] || context.symbols[0]
+        association = context.symbols[0]
+        key = context.keywords["key"] || association
 
         if node.block
           with_inner_segment(key, is_array:) { visit(node.block) }
         else
-          resource = context.keywords["resource"] || (::Alba.inflector && "#{::Alba.inflector.classify(key.to_s)}Resource")
+          resource = context.keywords["resource"] || (::Alba.inflector && "#{::Alba.inflector.classify(association.to_s)}Resource")
           is_valid_resource = @parser.namespace.const_get(resource) rescue false
 
           @segment[key] = if is_array

--- a/spec/openapi/parsers/ext/alba_spec.rb
+++ b/spec/openapi/parsers/ext/alba_spec.rb
@@ -246,6 +246,25 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Alba do
       it do
         is_expected.to eq({ "type" => "object", "properties" => { "id" => { "type" => "string" }, "name" => { "type" => "string" }, "my_articles" => { "type" => "array", "items" => { "type" => "object", "properties" => { "title" => { "type" => "string" }, "content" => { "type" => "string" } } } } } })
       end
+
+      context "with inflector set" do
+        before do
+          stub_const("Alba", double(inflector: double))
+          allow(Alba.inflector).to receive(:classify).with("articles").and_return("Article")
+        end
+
+        let_class("UserResource") do
+          <<~'RUBY'
+            include Alba::Resource
+            attributes :id, :name
+            many :articles, key: "my_articles"
+          RUBY
+        end
+
+        it do
+          is_expected.to eq({ "type" => "object", "properties" => { "id" => { "type" => "string" }, "name" => { "type" => "string" }, "my_articles" => { "type" => "array", "items" => { "type" => "object", "properties" => { "title" => { "type" => "string" }, "content" => { "type" => "string" } } } } } })
+        end
+      end
     end
 
     context "with a proc resource" do
@@ -409,6 +428,25 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Alba do
 
       it do
         is_expected.to eq({ "type" => "object", "properties" => { "id" => { "type" => "string" }, "name" => { "type" => "string" }, "my_article" => { "type" => "object", "properties" => { "title" => { "type" => "string" }, "body" => { "type" => "string" } } } } })
+      end
+
+      context "with inflector set" do
+        before do
+          stub_const("Alba", double(inflector: double))
+          allow(Alba.inflector).to receive(:classify).with("article").and_return("Article")
+        end
+
+        let_class("UserResource") do
+          <<~'RUBY'
+            include Alba::Resource
+            attributes :id, :name
+            has_one :article, key: "my_article"
+          RUBY
+        end
+
+        it do
+          is_expected.to eq({ "type" => "object", "properties" => { "id" => { "type" => "string" }, "name" => { "type" => "string" }, "my_article" => { "type" => "object", "properties" => { "title" => { "type" => "string" }, "body" => { "type" => "string" } } } } })
+        end
       end
     end
 


### PR DESCRIPTION
This fixes the case where an association has the `key` option and doesn't have the `resource` option.

Example:

```ruby
class ArticleResource
  include Alba::Resource

  attributes :id, :name
  many :articles, key: "my_articles"
end
```