### PR TITLE
Stop testing against Ruby 3.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ jobs:
       max-parallel: 1
       matrix:
         ruby:
-          - '3.1'
           - '3.2'
           - '3.3'
           - '3.4'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
   Exclude:
     - vendor/bundle/**/*
     - lib/rage/templates/**/*

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/rage-rb.svg)](https://badge.fury.io/rb/rage-rb)
 ![Tests](https://github.com/rage-rb/rage/actions/workflows/main.yml/badge.svg)
-![Ruby Requirement](https://img.shields.io/badge/Ruby-3.1%2B-%23f40000)
+![Ruby Requirement](https://img.shields.io/badge/Ruby-3.2%2B-%23f40000)
 
 Rage is a high-performance framework compatible with Rails, featuring [WebSocket](https://github.com/rage-rb/rage/wiki/WebSockets-guide) support and automatic generation of [OpenAPI](https://github.com/rage-rb/rage/wiki/OpenAPI-Guide) documentation for your APIs. The framework is built on top of [Iodine](https://github.com/rage-rb/iodine) and is based on the following design principles:
 

--- a/lib/rage/cable/channel.rb
+++ b/lib/rage/cable/channel.rb
@@ -1,5 +1,3 @@
-require "set"
-
 class Rage::Cable::Channel
   # @private
   INTERNAL_ACTIONS = [:subscribed, :unsubscribed]

--- a/lib/rage/cable/protocol/actioncable_v1_json.rb
+++ b/lib/rage/cable/protocol/actioncable_v1_json.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "zlib"
-require "set"
 
 ##
 # A protocol defines the structure, rules and semantics for exchanging data between the client and the server.

--- a/lib/rage/request.rb
+++ b/lib/rage/request.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "time"
-require "set" # required for ruby 3.1
+require "set"
 
 class Rage::Request
   # @private

--- a/lib/rage/request.rb
+++ b/lib/rage/request.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "time"
-require "set"
 
 class Rage::Request
   # @private

--- a/lib/rage/router/constrainer.rb
+++ b/lib/rage/router/constrainer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "set"
-
 class Rage::Router::Constrainer
   attr_reader :strategies
 

--- a/lib/rage/router/node.rb
+++ b/lib/rage/router/node.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "set"
-
 module Rage::Router
   class Node
     STATIC = 0

--- a/rage.gemspec
+++ b/rage.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Fast web framework compatible with Rails."
   spec.homepage = "https://github.com/rage-rb/rage"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/rage-rb/rage"


### PR DESCRIPTION
This removes Ruby 3.1 from the CI and updates the required Ruby version.

We are not using any Ruby 3.2+ specific features just yet, but the support for Ruby 3.1 ended on 31 Mar 2025.