### PR TITLE
[Deferred] Apply backpressure to every `enqueue` call

### DIFF
--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -443,7 +443,7 @@ class Rage::Configuration
         return
       end
 
-      if opts.except(:high_water_mark, :low_water_mark, :timeout).any?
+      if config.except(:high_water_mark, :low_water_mark, :timeout).any?
         raise ArgumentError, "unsupported backpressure options; supported keys are `:high_water_mark`, `:low_water_mark`, `:timeout`"
       end
 

--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -164,7 +164,7 @@ require "erb"
 # > Enables the backpressure for deferred tasks. The backpressure is used to limit the number of pending tasks in the queue. It accepts a hash with the following options:
 # >
 # > - `:high_water_mark` - the maximum number of pending tasks in the queue. Defaults to `1000`.
-# > - `:low_water_mark` - the minimum number of pending tasks in the queue before the backpressure is released. Defaults to `800`.
+# > - `:low_water_mark` - the minimum number of pending tasks in the queue before the backpressure is released. Defaults to `high_water_mark * 0.8`.
 # > - `:timeout` - the timeout for the backpressure in seconds. Defaults to `2`.
 #
 # > ```ruby

--- a/lib/rage/deferred/queue.rb
+++ b/lib/rage/deferred/queue.rb
@@ -61,9 +61,7 @@ class Rage::Deferred::Queue
   private
 
   def apply_backpressure
-    if @backlog_size > @backpressure.high_water_mark && !Fiber[:rage_backpressure_applied]
-      Fiber[:rage_backpressure_applied] = true
-
+    if @backlog_size > @backpressure.high_water_mark
       i, target_backlog_size = 0, @backpressure.low_water_mark
       while @backlog_size > target_backlog_size && i < @backpressure.timeout_iterations
         sleep @backpressure.sleep_interval


### PR DESCRIPTION
This adds several fixes to the backpressure logic:

* Update docs.
* Correctly parse backpressure configuration.
* Apply backpressure to every `enqueue` call instead of once per request.