### PR TITLE
Use different channels in `Fiber.await`

### DIFF
--- a/lib/rage/fiber_scheduler.rb
+++ b/lib/rage/fiber_scheduler.rb
@@ -130,10 +130,10 @@ class Rage::FiberScheduler
         Thread.current[:rage_logger] = logger
         Fiber.current.__set_result(block.call)
         # send a message for `Fiber.await` to work
-        Iodine.publish("await:#{parent.object_id}", "", Iodine::PubSub::PROCESS) if parent.alive?
+        Iodine.publish(parent.__await_channel, "", Iodine::PubSub::PROCESS) if parent.alive?
       rescue Exception => e
         Fiber.current.__set_err(e)
-        Iodine.publish("await:#{parent.object_id}", Fiber::AWAIT_ERROR_MESSAGE, Iodine::PubSub::PROCESS) if parent.alive?
+        Iodine.publish(parent.__await_channel, Fiber::AWAIT_ERROR_MESSAGE, Iodine::PubSub::PROCESS) if parent.alive?
       end
     end
 

--- a/spec/fiber_spec.rb
+++ b/spec/fiber_spec.rb
@@ -183,4 +183,14 @@ RSpec.describe Fiber do
       -> { expect(e).to be_a(StandardError) }
     end
   end
+
+  it "correctly processes several awaits in a row" do
+    within_reactor do
+      Fiber.await(Fiber.schedule { sleep 0.1 })
+      Fiber.await(Fiber.schedule { sleep 0.2 })
+      Fiber.await(Fiber.schedule { sleep 0.3 })
+
+      -> {}
+    end
+  end
 end


### PR DESCRIPTION
This fixes the case when `Fiber.await` is called several times in a row.
