### PR TITLE
Fix reloading in dev with user-level fibers

### DIFF
--- a/spec/integration/test_app/app/controllers/reload_controller.rb
+++ b/spec/integration/test_app/app/controllers/reload_controller.rb
@@ -1,0 +1,4 @@
+class ReloadController < RageController::API
+  def verify
+  end
+end

--- a/spec/integration/test_app/config/environments/development.rb
+++ b/spec/integration/test_app/config/environments/development.rb
@@ -8,4 +8,6 @@ Rage.configure do
   # Specify the logger
   config.logger = Rage::Logger.new("log/development.log")
   config.log_level = Logger::INFO
+
+  config.middleware.use Rage::Reloader
 end

--- a/spec/integration/test_app/config/routes.rb
+++ b/spec/integration/test_app/config/routes.rb
@@ -26,6 +26,8 @@ Rage.routes.draw do
   get "logs/custom", to: "logs#custom"
   get "logs/fiber", to: "logs#fiber"
 
+  get "reload/verify", to: "reload#verify"
+
   mount ->(_) { [200, {}, ""] }, at: "/admin"
 
   namespace :api do


### PR DESCRIPTION
This fixes the case where reloading the app with user-level fibers in dev would respond with 500 on the first request.