### PR TITLE
Add the `Request#route_uri_pattern` method

### DIFF
--- a/lib/rage/controller/api.rb
+++ b/lib/rage/controller/api.rb
@@ -448,7 +448,7 @@ class RageController::API
   # Get the request object. See {Rage::Request}.
   # @return [Rage::Request]
   def request
-    @request ||= Rage::Request.new(@__env)
+    @request ||= Rage::Request.new(@__env, controller: self)
   end
 
   # Get the response object. See {Rage::Response}.
@@ -633,6 +633,12 @@ class RageController::API
 
     head :not_modified if still_fresh
     !still_fresh
+  end
+
+  # Get the name of the currently executed action.
+  # @return [String] the name of the currently executed action
+  def action_name
+    @__params[:action]
   end
 
   # @private

--- a/lib/rage/request.rb
+++ b/lib/rage/request.rb
@@ -36,8 +36,11 @@ class Rage::Request
   KNOWN_HTTP_METHODS = (RFC2616 + RFC2518 + RFC3253 + RFC3648 + RFC3744 + RFC5323 + RFC4791 + RFC5789).to_set
 
   # @private
-  def initialize(env)
+  # @param env [Hash] Rack env
+  # @param controller [RageController::API]
+  def initialize(env, controller: nil)
     @env = env
+    @controller = controller
   end
 
   # Check if the request was made using TLS/SSL which is if http or https protocol is used inside the URL.
@@ -202,6 +205,20 @@ class Rage::Request
   end
 
   alias_method :uuid, :request_id
+
+  # Get the route URI pattern matched for this request.
+  # @return [String] the route URI pattern
+  # @example
+  #   # For a route defined as:
+  #   #   get "/users/:id", to: "users#show"
+  #   request.route_uri_pattern # => "/users/:id"
+  def route_uri_pattern
+    if @controller
+      Rage::Router::Util.route_uri_pattern(@controller.class, @controller.action_name)
+    else
+      path
+    end
+  end
 
   private
 

--- a/lib/rage/router/util.rb
+++ b/lib/rage/router/util.rb
@@ -31,6 +31,14 @@ class Rage::Router::Util
         @@names_map[str] = path_to_class(str).name
       end
     end
+
+    @@uri_patterns_map = Hash.new { |h, k| h[k] = {} }
+
+    def route_uri_pattern(controller_class, action_name)
+      @@uri_patterns_map[controller_class][action_name] ||= Rage.__router.routes.find { |route|
+        route[:meta][:controller_class] == controller_class && route[:meta][:action] == action_name
+      }[:path]
+    end
   end
 
   # @private

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -69,6 +69,18 @@ RSpec.describe "End-to-end" do
     expect(response.to_s).to start_with("RuntimeError (1155 test error)")
   end
 
+  it "correctly fetches current action name" do
+    response = HTTP.get("http://localhost:3000/get_action_name")
+    expect(response.code).to eq(200)
+    expect(response.to_s).to eq("get_action_name_action")
+  end
+
+  it "correctly fetches route URI pattern" do
+    response = HTTP.get("http://localhost:3000/get_route_uri_pattern/123")
+    expect(response.code).to eq(200)
+    expect(response.to_s).to eq("/get_route_uri_pattern/:id")
+  end
+
   it "sets correct headers" do
     response = HTTP.get("http://localhost:3000/get")
     expect(response.headers["content-type"]).to eq("text/plain; charset=utf-8")

--- a/spec/integration/test_app/app/controllers/application_controller.rb
+++ b/spec/integration/test_app/app/controllers/application_controller.rb
@@ -29,4 +29,12 @@ class ApplicationController < RageController::API
   def get_request_id
     render plain: request.request_id
   end
+
+  def get_action_name_action
+    render plain: action_name
+  end
+
+  def get_route_uri_pattern
+    render plain: request.route_uri_pattern
+  end
 end

--- a/spec/integration/test_app/config/routes.rb
+++ b/spec/integration/test_app/config/routes.rb
@@ -9,6 +9,8 @@ Rage.routes.draw do
   get "empty", to: "application#empty"
   get "raise_error", to: "application#raise_error"
   get "get_request_id", to: "application#get_request_id"
+  get "get_action_name", to: "application#get_action_name_action"
+  get "get_route_uri_pattern/:id", to: "application#get_route_uri_pattern"
 
   get "params/digest", to: "params#digest"
   post "params/digest", to: "params#digest"

--- a/spec/rage/request_spec.rb
+++ b/spec/rage/request_spec.rb
@@ -252,4 +252,29 @@ RSpec.describe Rage::Request do
   it "returns the correct request ID" do
     expect(request.request_id).to eq("5zfcwiy09bary01l")
   end
+
+  context "#route_uri_pattern" do
+    context "with no controller passed" do
+      it "returns the request path" do
+        expect(request.route_uri_pattern).to eq("/users")
+      end
+    end
+
+    context "with controller passed" do
+      subject(:request) { described_class.new(env, controller:) }
+
+      let(:controller) { double }
+
+      it "calls Rage::Router::Util" do
+        expect(controller).to receive(:class).and_return("test-class")
+        expect(controller).to receive(:action_name).and_return("test-action")
+
+        expect(Rage::Router::Util).to receive(:route_uri_pattern).
+          with("test-class", "test-action").
+          and_return("test-uri-pattern")
+
+        expect(request.route_uri_pattern).to eq("test-uri-pattern")
+      end
+    end
+  end
 end

--- a/spec/router/util_spec.rb
+++ b/spec/router/util_spec.rb
@@ -73,4 +73,33 @@ RSpec.describe Rage::Router::Util do
       expect(described_class.path_to_name("test")).to eq("test-name")
     end
   end
+
+  describe "#route_uri_pattern" do
+    let(:users_controller) { double }
+
+    let(:routes) do
+      [
+        {
+          method: "GET",
+          path: "/users",
+          meta: { controller: "users", action: "index", controller_class: users_controller }
+        },
+        {
+          method: "GET",
+          path: "/users/:id",
+          meta: { controller: "users", action: "show", controller_class: users_controller }
+        }
+      ]
+    end
+
+    it "returns the path property" do
+      expect(Rage.__router).to receive(:routes).and_return(routes)
+      expect(described_class.route_uri_pattern(users_controller, "show")).to eq("/users/:id")
+    end
+
+    it "caches the result" do
+      expect(Rage.__router).to receive(:routes).and_return(routes).once
+      2.times { described_class.route_uri_pattern(users_controller, "show") }
+    end
+  end
 end


### PR DESCRIPTION
This PR introduces two new methods to improve the ability to introspect routing and controller information at runtime:

* `RageController::API#action_name`
* `Rage::Request#route_uri_pattern`