### PR TITLE
Disable direct modifications of global log tags and context

### DIFF
--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -307,10 +307,12 @@ class Rage::Configuration
   end
 
   class LogContext
-    attr_reader :objects
-
     def initialize
       @objects = []
+    end
+
+    def objects
+      @objects.dup
     end
 
     def push(block_or_hash)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -146,6 +146,17 @@ RSpec.describe Rage::Configuration do
         end
       end
     end
+
+    describe "#objects" do
+      it "doesn't allow direct modifications of context" do
+        context = { user_id: 12345 }
+        subject << context
+
+        subject.objects.clear
+
+        expect(subject.objects).to eq([context])
+      end
+    end
   end
 
   describe "#log_tags" do
@@ -281,6 +292,15 @@ RSpec.describe Rage::Configuration do
           expect(Rage.__log_processor).to receive(:add_custom_tags).with(["staging"])
           config.__finalize
         end
+      end
+    end
+
+    describe "#objects" do
+      it "doesn't allow direct modifications of tags" do
+        subject << "staging"
+        subject.objects.clear
+
+        expect(subject.objects).to eq(["staging"])
       end
     end
   end


### PR DESCRIPTION
Improve the safety of the `LogContext` and `LogTags` configuration classes by preventing direct modification of the internal storage.