### PR TITLE
Compatibility with `Rack::Events`

### DIFF
--- a/lib/rage/all.rb
+++ b/lib/rage/all.rb
@@ -33,6 +33,7 @@ require_relative "middleware/fiber_wrapper"
 require_relative "middleware/cors"
 require_relative "middleware/reloader"
 require_relative "middleware/request_id"
+require_relative "middleware/body_finalizer"
 
 if defined?(Sidekiq)
   require_relative "sidekiq_session"

--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -863,6 +863,10 @@ class Rage::Configuration
       Rage.__log_processor.add_custom_tags(@log_tags.objects)
       @logger.dynamic_tags = Rage.__log_processor.dynamic_tags
     end
+
+    if defined?(::Rack::Events) && middleware.include?(::Rack::Events) && !middleware.include?(Rage::BodyFinalizer)
+      middleware.insert_after(0, Rage::BodyFinalizer)
+    end
   end
 end
 

--- a/lib/rage/middleware/body_finalizer.rb
+++ b/lib/rage/middleware/body_finalizer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Rage::BodyFinalizer
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    response = @app.call(env)
+    response[2].close
+
+    response
+  end
+end

--- a/spec/body_finalizer_middleware_spec.rb
+++ b/spec/body_finalizer_middleware_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe Rage::BodyFinalizer do
+  subject { described_class.new(app).call(env) }
+
+  let(:env) { {} }
+  let(:body) { double }
+  let(:response) { [200, {}, body] }
+  let(:app) { double(call: response) }
+
+  it "closes the body" do
+    expect(body).to receive(:close)
+    subject
+  end
+
+  it "returns the response" do
+    allow(body).to receive(:close)
+    expect(subject).to eq(response)
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -830,4 +830,41 @@ RSpec.describe Rage::Configuration do
       end
     end
   end
+
+  describe "Rack::Events" do
+    subject { config.__finalize }
+
+    let(:config) { described_class.new }
+
+    context "without Rack::Events" do
+      it "doesn't add Rage::BodyFinalizer" do
+        subject
+        expect(config.middleware).not_to include(Rage::BodyFinalizer)
+      end
+    end
+
+    context "with Rack::Events" do
+      before do
+        stub_const("Rack::Events", double)
+      end
+
+      context "if Rack::Events is in middleware stack" do
+        before do
+          config.middleware.use Rack::Events
+        end
+
+        it "adds Rage::BodyFinalizer" do
+          subject
+          expect(config.middleware).to include(Rage::BodyFinalizer)
+        end
+      end
+
+      context "if Rack::Events is not in middleware stack" do
+        it "doesn't add Rage::BodyFinalizer" do
+          subject
+          expect(config.middleware).not_to include(Rage::BodyFinalizer)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add the `Rage::BodyFinalizer` middleware, which ensures that response bodies are properly closed after each request when `Rack::Events` is present in the middleware stack.

ref #169 