### PR TITLE
docs: Mark internal classes as private

### DIFF
--- a/lib/rage/deferred/context.rb
+++ b/lib/rage/deferred/context.rb
@@ -4,6 +4,7 @@
 # Context for deferred tasks.
 # The class encapsulates the context associated with a deferred task, and allows to store it without modifying the task instance.
 #
+# @private
 class Rage::Deferred::Context
   def self.build(task, args, kwargs)
     logger = Thread.current[:rage_logger]

--- a/lib/rage/openapi/collector.rb
+++ b/lib/rage/openapi/collector.rb
@@ -4,6 +4,7 @@
 # Collect all global comments or comments attached to methods in a class.
 # At this point we don't care whether these are Rage OpenAPI comments or not.
 #
+# @private
 class Rage::OpenAPI::Collector < Prism::Visitor
   # @param comments [Array<Prism::InlineComment>]
   def initialize(comments)

--- a/lib/rage/telemetry/tracer.rb
+++ b/lib/rage/telemetry/tracer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# @private
 class Rage::Telemetry::Tracer
   DEFAULT_SPAN_RESULT = Rage::Telemetry::SpanResult.new.freeze
   private_constant :DEFAULT_SPAN_RESULT


### PR DESCRIPTION
## Description
This PR marks several internal classes as private to exclude them from the public API documentation.

## Issue Addressed
Issue: Internal implementation details (`Rage::Telemetry::Tracer`, `Rage::Deferred::Context`, `Rage::OpenAPI::Collector`) were leaking into the public API docs. 
These classes are not intended for public use and should be hidden from the default documentation generation.

## Changes Made
**lib/rage/telemetry/tracer.rb**: Added `@private` YARD tag.
**lib/rage/deferred/context.rb**: Added `@private` YARD tag.
**lib/rage/openapi/collector.rb**: Added `@private` YARD tag.

## RSpec Test:
N/A - This is a documentation change only.

## Documentation
The classes have been marked with `@private`, ensuring they are excluded from `bundle exec yard doc` output by default.