### PR TITLE
Ensure correct logging for intersecting fibers

### DIFF
--- a/lib/rage/controller/api.rb
+++ b/lib/rage/controller/api.rb
@@ -155,11 +155,11 @@ class RageController::API
                 context = {}
                 append_info_to_payload(context)
 
-                log_context = Thread.current[:rage_logger][:context]
+                log_context = Fiber[:__rage_logger_context]
                 if log_context.empty?
-                  Thread.current[:rage_logger][:context] = context
+                  Fiber[:__rage_logger_context] = context
                 else
-                  Thread.current[:rage_logger][:context] = log_context.merge(context)
+                  Fiber[:__rage_logger_context] = log_context.merge(context)
                 end
               RUBY
             end}

--- a/lib/rage/deferred/context.rb
+++ b/lib/rage/deferred/context.rb
@@ -7,15 +7,13 @@
 # @private
 class Rage::Deferred::Context
   def self.build(task, args, kwargs)
-    logger = Thread.current[:rage_logger]
-
     [
       task,
       args.empty? ? nil : args,
       kwargs.empty? ? nil : kwargs,
       nil,
-      logger&.dig(:tags),
-      logger&.dig(:context),
+      Fiber[:__rage_logger_tags],
+      Fiber[:__rage_logger_context],
       nil
     ]
   end

--- a/lib/rage/deferred/task.rb
+++ b/lib/rage/deferred/task.rb
@@ -93,10 +93,10 @@ module Rage::Deferred::Task
     log_context = Rage::Deferred::Context.get_log_context(context)
 
     if log_tags.is_a?(Array)
-      Thread.current[:rage_logger] = { tags: log_tags, context: log_context }
+      Fiber[:__rage_logger_tags], Fiber[:__rage_logger_context] = log_tags, log_context
     elsif log_tags
       # support the previous format where only `request_id` was passed
-      Thread.current[:rage_logger] = { tags: [log_tags], context: {} }
+      Fiber[:__rage_logger_tags], Fiber[:__rage_logger_context] = [log_tags], {}
     end
   end
 

--- a/lib/rage/fiber_scheduler.rb
+++ b/lib/rage/fiber_scheduler.rb
@@ -126,10 +126,7 @@ class Rage::FiberScheduler
       end
     else
       # the fiber was created in the user code
-      logger = Thread.current[:rage_logger]
-
       Fiber.new(blocking: false) do
-        Thread.current[:rage_logger] = logger
         Rage::Telemetry.tracer.span_core_fiber_spawn(parent:) do
           Fiber.current.__set_result(block.call)
         end

--- a/lib/rage/logger/json_formatter.rb
+++ b/lib/rage/logger/json_formatter.rb
@@ -26,8 +26,7 @@ class Rage::JSONFormatter
   end
 
   def call(severity, timestamp, _, message)
-    logger = Thread.current[:rage_logger] || { tags: [], context: {} }
-    tags, context = logger[:tags], logger[:context]
+    tags, context = Fiber[:__rage_logger_tags] || [], Fiber[:__rage_logger_context] || {}
 
     if !context.empty?
       context_msg = ""
@@ -50,7 +49,7 @@ class Rage::JSONFormatter
       msg << "],"
     end
 
-    if (final = logger[:final])
+    if (final = Fiber[:__rage_logger_final])
       params, env = final[:params], final[:env]
       if params && params[:controller]
         return "#{tags_msg}\"timestamp\":\"#{timestamp}\",\"pid\":\"#{@pid}\",\"level\":\"info\",\"method\":\"#{env["REQUEST_METHOD"]}\",\"path\":\"#{env["PATH_INFO"]}\",\"controller\":\"#{Rage::Router::Util.path_to_name(params[:controller])}\",\"action\":\"#{params[:action]}\",#{context_msg}\"status\":#{final[:response][0]},\"duration\":#{final[:duration]}}\n"

--- a/lib/rage/logger/text_formatter.rb
+++ b/lib/rage/logger/text_formatter.rb
@@ -24,15 +24,14 @@ class Rage::TextFormatter
   end
 
   def call(severity, timestamp, _, message)
-    logger = Thread.current[:rage_logger] || { tags: [], context: {} }
-    tags, context = logger[:tags], logger[:context]
+    tags, context = Fiber[:__rage_logger_tags] || [], Fiber[:__rage_logger_context] || {}
 
     if !context.empty?
       context_msg = ""
       context.each { |k, v| context_msg << "#{k}=#{v} " }
     end
 
-    if (final = logger[:final])
+    if (final = Fiber[:__rage_logger_final])
       params, env = final[:params], final[:env]
       tags = tags.map { |tag| "[#{tag}]" }.join
 

--- a/spec/deferred/context_spec.rb
+++ b/spec/deferred/context_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe Rage::Deferred::Context do
     let(:kwargs) { { key: "value" } }
 
     after do
-      Thread.current[:rage_logger] = nil
+      Fiber[:__rage_logger_tags] = nil
     end
 
-    context "when Thread.current[:rage_logger] is not set" do
+    context "when rage_logger is not set" do
       it "builds context with nil request_id" do
         context = described_class.build(task, args, kwargs)
         expect(context[0]).to eq(task)
@@ -25,9 +25,9 @@ RSpec.describe Rage::Deferred::Context do
       end
     end
 
-    context "when Thread.current[:rage_logger] is set" do
+    context "when rage_logger is set" do
       before do
-        Thread.current[:rage_logger] = { tags: ["req-123", "test"] }
+        Fiber[:__rage_logger_tags] = ["req-123", "test"]
       end
 
       it "builds context including log tags" do

--- a/spec/deferred/task_spec.rb
+++ b/spec/deferred/task_spec.rb
@@ -86,7 +86,8 @@ RSpec.describe Rage::Deferred::Task do
       end
 
       after do
-        Thread.current[:rage_logger] = nil
+        Fiber[:__rage_logger_tags] = nil
+        Fiber[:__rage_logger_context] = nil
       end
 
       it "calls perform with correct arguments" do
@@ -97,7 +98,8 @@ RSpec.describe Rage::Deferred::Task do
       it "logs with context and tag" do
         task.__perform(context)
         expect(logger).to have_received(:with_context).with({ task: "MyTask", attempt: 2 })
-        expect(Thread.current[:rage_logger]).to eq({ tags: ["request-id"], context: {} })
+        expect(Fiber[:__rage_logger_tags]).to eq(["request-id"])
+        expect(Fiber[:__rage_logger_context]).to eq({})
       end
 
       it "returns true" do

--- a/spec/json_formatter_spec.rb
+++ b/spec/json_formatter_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe Rage::JSONFormatter do
   let(:message) { "test message" }
 
   after do
-    Thread.current[:rage_logger] = nil
+    Fiber[:__rage_logger_tags] = nil
+    Fiber[:__rage_logger_context] = nil
+    Fiber[:__rage_logger_final] = nil
   end
 
   context "with no logger info" do
@@ -37,7 +39,8 @@ RSpec.describe Rage::JSONFormatter do
 
   context "with one tag" do
     before do
-      Thread.current[:rage_logger] = { tags: ["json-test-tag"], context: {} }
+      Fiber[:__rage_logger_tags] = ["json-test-tag"]
+      Fiber[:__rage_logger_context] = {}
     end
 
     it "correctly formats the message" do
@@ -52,7 +55,8 @@ RSpec.describe Rage::JSONFormatter do
 
     context "with custom context" do
       before do
-        Thread.current[:rage_logger] = { tags: ["json-test-tag"], context: { user_id: "test-1", account_id: "test-2" } }
+        Fiber[:__rage_logger_tags] = ["json-test-tag"]
+        Fiber[:__rage_logger_context] = { user_id: "test-1", account_id: "test-2" }
       end
 
       it "correctly formats the message" do
@@ -71,10 +75,8 @@ RSpec.describe Rage::JSONFormatter do
 
   context "with multiple tags" do
     before do
-      Thread.current[:rage_logger] = {
-        tags: ["json-test-tag-1", "json-test-tag-2"],
-        context: {}
-      }
+      Fiber[:__rage_logger_tags] = ["json-test-tag-1", "json-test-tag-2"]
+      Fiber[:__rage_logger_context] = {}
     end
 
     it "correctly formats the message" do
@@ -89,10 +91,8 @@ RSpec.describe Rage::JSONFormatter do
 
     context "with custom context" do
       before do
-        Thread.current[:rage_logger] = {
-          tags: ["json-test-tag-1", "json-test-tag-2"],
-          context: { user_id: "test-1", account_id: "test-2" }
-        }
+        Fiber[:__rage_logger_tags] = ["json-test-tag-1", "json-test-tag-2"]
+        Fiber[:__rage_logger_context] = { user_id: "test-1", account_id: "test-2" }
       end
 
       it "correctly formats the message" do
@@ -113,15 +113,13 @@ RSpec.describe Rage::JSONFormatter do
     before do
       stub_const("UserProfilesController", double(name: "UserProfilesController"))
 
-      Thread.current[:rage_logger] = {
-        tags: ["json-test-tag"],
-        context: {},
-        final: {
-          env: { "REQUEST_METHOD" => "POST", "PATH_INFO" => "/user_profiles/12345" },
-          params: { controller: "user_profiles", action: "create" },
-          response: [207, {}, []],
-          duration: 1.234
-        }
+      Fiber[:__rage_logger_tags] = ["json-test-tag"]
+      Fiber[:__rage_logger_context] = {}
+      Fiber[:__rage_logger_final] = {
+        env: { "REQUEST_METHOD" => "POST", "PATH_INFO" => "/user_profiles/12345" },
+        params: { controller: "user_profiles", action: "create" },
+        response: [207, {}, []],
+        duration: 1.234
       }
     end
 
@@ -142,7 +140,7 @@ RSpec.describe Rage::JSONFormatter do
 
     context "with custom tags" do
       before do
-        Thread.current[:rage_logger][:tags] << "custom-tag-1" << "custom-tag-2"
+        Fiber[:__rage_logger_tags] << "custom-tag-1" << "custom-tag-2"
       end
 
       it "correctly formats the message" do
@@ -162,7 +160,7 @@ RSpec.describe Rage::JSONFormatter do
 
       context "with custom context" do
         before do
-          Thread.current[:rage_logger][:context] = { user_id: "test-1", account_id: "test-2" }
+          Fiber[:__rage_logger_context] = { user_id: "test-1", account_id: "test-2" }
         end
 
         it "correctly formats the message" do
@@ -186,7 +184,7 @@ RSpec.describe Rage::JSONFormatter do
 
     context "with custom context" do
       before do
-        Thread.current[:rage_logger][:context] = { user_id: "test-1", account_id: "test-2" }
+        Fiber[:__rage_logger_context] = { user_id: "test-1", account_id: "test-2" }
       end
 
       it "correctly formats the message" do
@@ -209,15 +207,13 @@ RSpec.describe Rage::JSONFormatter do
 
     context "with no controller/action info" do
       before do
-        Thread.current[:rage_logger] = {
-          tags: ["json-test-tag"],
-          context: {},
-          final: {
-            env: { "REQUEST_METHOD" => "POST", "PATH_INFO" => "/user_profiles/12345" },
-            params: nil,
-            response: [207, {}, []],
-            duration: 1.234
-          }
+        Fiber[:__rage_logger_tags] = ["json-test-tag"]
+        Fiber[:__rage_logger_context] = {}
+        Fiber[:__rage_logger_final] = {
+          env: { "REQUEST_METHOD" => "POST", "PATH_INFO" => "/user_profiles/12345" },
+          params: nil,
+          response: [207, {}, []],
+          duration: 1.234
         }
       end
 
@@ -236,8 +232,8 @@ RSpec.describe Rage::JSONFormatter do
 
       context "with custom tags and context" do
         before do
-          Thread.current[:rage_logger][:tags] << "custom-tag"
-          Thread.current[:rage_logger][:context] = { user_id: "test-1", account_id: "test-2" }
+          Fiber[:__rage_logger_tags] << "custom-tag"
+          Fiber[:__rage_logger_context] = { user_id: "test-1", account_id: "test-2" }
         end
 
         it "correctly formats the message" do

--- a/spec/log_processor_spec.rb
+++ b/spec/log_processor_spec.rb
@@ -4,7 +4,13 @@
 RSpec.describe Rage::LogProcessor do
   describe "#init_request_logger" do
     let(:log_processor) { described_class.new }
-    let(:log_context) { Thread.current[:rage_logger] }
+    let(:log_context) do
+      {
+        tags: Fiber[:__rage_logger_tags],
+        context: Fiber[:__rage_logger_context],
+        request_start: Fiber[:__rage_logger_request_start]
+      }
+    end
 
     let(:env) { {} }
     let(:request_tag) { "test-request-id-tag" }
@@ -22,7 +28,9 @@ RSpec.describe Rage::LogProcessor do
     end
 
     after do
-      Thread.current[:rage_logger] = nil
+      Fiber[:__rage_logger_tags] = nil
+      Fiber[:__rage_logger_context] = nil
+      Fiber[:__rage_logger_request_start] = nil
     end
 
     it "correctly initializes static logger" do


### PR DESCRIPTION
This refactor improves the reliability and correctness of Rage logging by ensuring that each fiber maintains its own isolated logging context.
