### PR TITLE
Use class name in `stream_for` streams

### DIFF
--- a/lib/rage/cable/channel.rb
+++ b/lib/rage/cable/channel.rb
@@ -304,7 +304,7 @@ class Rage::Cable::Channel
     def __stream_name_for(streamables)
       stream_name = Array(streamables).map do |streamable|
         if streamable.respond_to?(:id)
-          streamable.id
+          "#{streamable.class.name}:#{streamable.id}"
         elsif streamable.is_a?(String) || streamable.is_a?(Symbol) || streamable.is_a?(Numeric)
           streamable
         else

--- a/spec/cable/channel/stream_for_spec.rb
+++ b/spec/cable/channel/stream_for_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Rage::Cable::Channel do
       it "subscribes to a stream with the channel name and object id" do
         expect(protocol).to receive(:subscribe).with(
           connection,
-          "CableChannelStreamForSpec::TestChannel:123",
+          "CableChannelStreamForSpec::TestChannel:CableChannelStreamForSpec::User:123",
           params
         )
         subject.__run_action(:subscribed)
@@ -100,7 +100,7 @@ RSpec.describe Rage::Cable::Channel do
       it "subscribes to a stream with the channel name and joined stream parts" do
         expect(protocol).to receive(:subscribe).with(
           connection,
-          "CableChannelStreamForSpec::TestChannel:123:room:456",
+          "CableChannelStreamForSpec::TestChannel:CableChannelStreamForSpec::User:123:room:456",
           params
         )
         subject.__run_action(:subscribed)
@@ -127,7 +127,7 @@ RSpec.describe Rage::Cable::Channel do
 
       it "broadcasts to the correct stream" do
         expect(Rage.cable).to receive(:broadcast).with(
-          "CableChannelStreamForSpec::TestChannel:123",
+          "CableChannelStreamForSpec::TestChannel:CableChannelStreamForSpec::User:123",
           { message: "Hello!" }
         )
         CableChannelStreamForSpec::TestChannel.broadcast_to(user, { message: "Hello!" })
@@ -169,7 +169,7 @@ RSpec.describe Rage::Cable::Channel do
 
       it "broadcasts to the correct stream" do
         expect(Rage.cable).to receive(:broadcast).with(
-          "CableChannelStreamForSpec::TestChannel:123:room:456",
+          "CableChannelStreamForSpec::TestChannel:CableChannelStreamForSpec::User:123:room:456",
           { message: "Hello!" }
         )
         CableChannelStreamForSpec::TestChannel.broadcast_to([user, "room", 456], { message: "Hello!" })


### PR DESCRIPTION
This pull request updates the way stream names are constructed for cable channel broadcasting and subscriptions to include both the class name and the object ID, rather than just the ID.