### PR TITLE
[Cable] Add RSpec test helpers

### DIFF
--- a/lib/rage/rspec.rb
+++ b/lib/rage/rspec.rb
@@ -2,6 +2,8 @@
 
 require "rack/test"
 require "json"
+require "uri"
+require "digest"
 
 # set up environment
 ENV["RAGE_ENV"] ||= "test"
@@ -50,20 +52,7 @@ module RageRequestHelpers
   end
 
   def request(method, path, params: {}, headers: {})
-    if headers.any?
-      headers = headers.transform_keys do |k|
-        if k.downcase == "content-type"
-          "CONTENT_TYPE"
-        elsif k.downcase == "content-length"
-          "CONTENT_LENGTH"
-        elsif k.upcase == k
-          k
-        else
-          "HTTP_#{k.tr("-", "_").upcase! || k}"
-        end
-      end
-    end
-
+    headers = __normalize_rack_headers(headers)
     custom_request(method, path, params, headers)
   end
 
@@ -74,11 +63,334 @@ module RageRequestHelpers
   def default_host
     @__host || "example.org"
   end
+
+  private
+
+  def __normalize_rack_headers(headers)
+    return {} if headers.nil? || headers.empty?
+
+    headers.transform_keys do |key|
+      key = key.to_s
+
+      if key.downcase == "content-type"
+        "CONTENT_TYPE"
+      elsif key.downcase == "content-length"
+        "CONTENT_LENGTH"
+      elsif key == "CONTENT_TYPE" || key == "CONTENT_LENGTH" || key.start_with?("HTTP_") || (key == key.upcase && key.include?("_") && !key.include?("-"))
+        key
+      else
+        "HTTP_#{key.tr("-", "_").upcase}"
+      end
+    end
+  end
+end
+
+module RageCableHelpers
+  include RageRequestHelpers
+
+  class MockWebSocketConnection
+    attr_reader :env, :messages
+
+    def initialize(env)
+      @env = env
+      @messages = []
+      @streams = []
+    end
+
+    def subscribe(stream)
+      @streams << stream.sub(/\Acable:/, "").sub(/:[0-9a-f]{32}\z/, "")
+      true
+    end
+
+    def write(data)
+      @messages << data
+      true
+    end
+
+    def close
+      true
+    end
+
+    def streams
+      @streams.uniq
+    end
+  end
+
+  class MockSubscription
+    attr_reader :channel, :connection
+
+    def initialize(channel, connection)
+      @channel = channel
+      @connection = connection
+    end
+
+    def confirmed?
+      !channel.subscription_rejected?
+    end
+
+    def rejected?
+      channel.subscription_rejected?
+    end
+
+    def streams
+      connection.streams
+    end
+
+    def has_streams?
+      streams.any?
+    end
+
+    def has_stream_from?(stream_name)
+      streams.include?(stream_name)
+    end
+
+    def has_stream_for?(streamable)
+      has_stream_from?(channel.class.__stream_name_for(streamable))
+    end
+
+    def inspect
+      "#<#{self.class.name}>"
+    end
+
+    def method_missing(method_name, *args, &block)
+      if channel.respond_to?(method_name)
+        channel.public_send(method_name, *args, &block)
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      channel.respond_to?(method_name, include_private) || super
+    end
+  end
+
+  class MockCookies
+    def initialize(context, modifiers = [])
+      @context = context
+      @modifiers = modifiers
+    end
+
+    def [](key)
+      jar, = build_jar
+      jar[key]
+    end
+
+    def []=(key, value)
+      jar, headers = build_jar
+      jar[key] = value
+      merge_set_cookie_header(headers)
+      value
+    end
+
+    def delete(*args, **kwargs)
+      jar, headers = build_jar
+      result = jar.delete(*args, **kwargs)
+      merge_set_cookie_header(headers)
+      result
+    end
+
+    def encrypted
+      self.class.new(@context, @modifiers + [:encrypted])
+    end
+
+    def permanent
+      self.class.new(@context, @modifiers + [:permanent])
+    end
+
+    private
+
+    def build_jar
+      uri = @context.send(:__cable_cookie_uri)
+      env = {
+        "HTTP_COOKIE" => @context.current_session.cookie_jar.for(uri),
+        "HTTP_HOST" => @context.default_host
+      }
+      headers = {}
+
+      jar = Rage::Cookies.new(env, headers)
+      @modifiers.each { |modifier| jar = jar.public_send(modifier) }
+
+      [jar, headers]
+    end
+
+    def merge_set_cookie_header(headers)
+      set_cookie = headers["set-cookie"]
+      return unless set_cookie
+
+      @context.set_cookie(set_cookie, @context.send(:__cable_cookie_uri))
+    end
+  end
+
+  def cookies
+    @__cable_cookies ||= MockCookies.new(self)
+  end
+
+  def session
+    @__cable_session ||= Rage::Session.new(cookies)
+  end
+
+  def connect(url, headers: nil)
+    env = __build_cable_env(url, headers || {})
+    @__cable_connection = __connection_class.new(env)
+    @__cable_connection.connect
+
+    unless @__cable_connection.rejected?
+      env["rage.identified_by"] = @__cable_connection.__identified_by_map
+      env["rage.cable"] = {}
+    end
+
+    @__cable_connection
+  end
+
+  def connection
+    raise "No connection found. Call `connect` before `connection`." unless @__cable_connection
+    @__cable_connection
+  end
+
+  def stub_connection(identified_by = {})
+    @__cable_stubbed_connection = MockWebSocketConnection.new({
+      "rage.cable" => {},
+      "rage.identified_by" => identified_by.transform_keys(&:to_sym)
+    })
+  end
+
+  def subscribe(params = {})
+    __stub_cable_protocol!
+    __stub_iodine_defer!
+
+    channel_class = __channel_class
+    channel_class.__register_actions
+
+    params = (params || {}).each_with_object({}) { |(k, v), memo| memo[k.to_sym] = v }
+    params[:channel] = channel_class.name
+
+    cable_connection = @__cable_stubbed_connection || stub_connection
+    channel = channel_class.new(cable_connection, params, cable_connection.env["rage.identified_by"])
+    channel.__run_action(:subscribed)
+
+    unless channel.subscription_rejected?
+      cable_connection.env["rage.cable"][params.to_json] = channel
+    end
+
+    @__subscription = MockSubscription.new(channel, cable_connection)
+  end
+
+  def subscription
+    raise "No subscription found. Call `subscribe` before `subscription`." unless @__subscription
+    @__subscription
+  end
+
+  def perform(action, data = {})
+    raise "No subscription found. Call `subscribe` before `perform`." unless subscription
+
+    payload = (data || {}).each_with_object({ "action" => action.to_s }) do |(key, value), memo|
+      memo[key.to_s] = value
+    end
+    action_name = action.to_sym
+
+    unless subscription.channel.__has_action?(action_name)
+      raise ArgumentError, "Unable to process #{subscription.channel.class.name}##{action_name}"
+    end
+
+    subscription.channel.__run_action(action_name, payload)
+  end
+
+  def transmissions
+    return [] unless subscription
+
+    subscription.connection.messages.map do |message|
+      parsed_message = begin
+        JSON.parse(message)
+      rescue JSON::ParserError, TypeError
+        message
+      end
+
+      if parsed_message.is_a?(Hash)
+        parsed_message["message"] || parsed_message[:message] || parsed_message
+      else
+        parsed_message
+      end
+    end
+  end
+
+  private
+
+  def __build_cable_env(url, headers)
+    uri = URI.parse(url)
+    uri.path = "/#{uri.path}" unless uri.path.start_with?("/")
+    uri.host ||= default_host
+    uri.scheme ||= "http"
+
+    env = Rack::MockRequest.env_for(uri.to_s, __normalize_rack_headers(headers))
+    env["REQUEST_METHOD"] = "GET"
+
+    cookie_header = current_session.cookie_jar.for(uri)
+    env["HTTP_COOKIE"] = cookie_header unless cookie_header.empty?
+
+    env
+  end
+
+  def __connection_class
+    if respond_to?(:described_class) && described_class.is_a?(Class) && described_class <= Rage::Cable::Connection
+      described_class
+    elsif Object.const_defined?("RageCable::Connection")
+      RageCable::Connection
+    elsif Object.const_defined?("ApplicationCable::Connection")
+      ApplicationCable::Connection
+    else
+      Rage::Cable::Connection
+    end
+  end
+
+  def __channel_class
+    if !respond_to?(:described_class) || !described_class.is_a?(Class) || !described_class.ancestors.include?(Rage::Cable::Channel)
+      raise ArgumentError, "`subscribe` expects the described class to inherit from Rage::Cable::Channel"
+    end
+
+    described_class
+  end
+
+  def __cable_cookie_uri
+    URI.parse("http://#{default_host}/")
+  end
+
+  def __stub_cable_protocol!
+    allow(Rage.cable).to receive(:__protocol).and_return(__cable_test_protocol)
+  end
+
+  def __stub_iodine_defer!
+    allow(Iodine).to receive(:defer) do |&block|
+      block&.call
+      true
+    end
+  end
+
+  def __cable_test_protocol
+    @__cable_test_protocol ||= Class.new do
+      def supports_rpc?
+        true
+      end
+
+      def subscribe(connection, stream, params)
+        stream_id = Digest::MD5.hexdigest(params.to_s)
+        connection.subscribe("cable:#{stream}:#{stream_id}")
+      end
+
+      def broadcast(*)
+      end
+
+      def serialize(params, data)
+        { identifier: params.to_json, message: data }.to_json
+      end
+    end.new
+  end
 end
 
 # include request helpers
 RSpec.configure do |config|
   config.include(RageRequestHelpers, type: :request)
+  config.include(RageCableHelpers, type: :channel)
 
   # mock fiber methods as RSpec tests don't run concurrently
   config.before do

--- a/spec/rspec/cable_helpers_spec.rb
+++ b/spec/rspec/cable_helpers_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require "domain_name"
+
+begin
+  require "rbnacl"
+  RBNACL_AVAILABLE = Gem::Version.create(RbNaCl::VERSION) >= Gem::Version.create("3.3.0") &&
+                     Gem::Version.create(RbNaCl::VERSION) < Gem::Version.create("8.0.0")
+rescue LoadError
+  RBNACL_AVAILABLE = false
+end
+
+module CableRspecHelpersSpec
+  class TestConnection < Rage::Cable::Connection
+    identified_by :user_id
+
+    def connect
+      if (header_user_id = request.headers["X-USER-ID"])
+        self.user_id = header_user_id
+      elsif (cookie_user_id = cookies[:user_id])
+        self.user_id = cookie_user_id
+      elsif (encrypted_user_id = cookies.encrypted[:encrypted_user_id])
+        self.user_id = encrypted_user_id
+      elsif (session_user_id = session[:user_id])
+        self.user_id = session_user_id
+      else
+        reject_unauthorized_connection
+      end
+    end
+  end
+
+  class TestChannel < Rage::Cable::Channel
+    def subscribed
+      if params[:room_id] == -1
+        reject
+      elsif params[:room_id]
+        stream_from("chat_#{params[:room_id]}")
+      end
+    end
+
+    def speak(data)
+      transmit({ text: data["message"] })
+    end
+  end
+
+  Room = Struct.new(:id)
+
+  class StreamForChannel < Rage::Cable::Channel
+    def subscribed
+      stream_for(params[:room])
+    end
+  end
+end
+
+RSpec.shared_context "rage cable test helpers setup" do
+  before :context do
+    Rage.instance_variable_set(:@root, Pathname.new(__dir__).expand_path)
+    Rage.instance_variable_set(:@env, Rage::Env.new("test"))
+    require "rage/rspec"
+
+    @original_secret_key_base = Rage.config.secret_key_base
+    Rage.config.secret_key_base = "a" * 128
+  end
+
+  after :context do
+    Rage.config.secret_key_base = @original_secret_key_base
+    Rage.instance_variable_set(:@root, nil)
+    Rage.instance_variable_set(:@env, nil)
+  end
+end
+
+RSpec.describe CableRspecHelpersSpec::TestConnection, type: :channel do
+  include_context "rage cable test helpers setup"
+
+  it "emulates a connection with headers" do
+    connect "/cable", headers: { "X-USER-ID" => "325" }
+
+    expect(connection.user_id).to eq("325")
+  end
+
+  it "supports encrypted cookies", if: RBNACL_AVAILABLE do
+    cookies.encrypted[:encrypted_user_id] = "42"
+    connect "/cable"
+
+    expect(connection.user_id).to eq("42")
+  end
+
+  it "supports plain cookies" do
+    cookies[:user_id] = "24"
+    connect "/cable"
+
+    expect(connection.user_id).to eq("24")
+  end
+
+  it "supports session data", if: RBNACL_AVAILABLE do
+    session[:user_id] = "17"
+    connect "/cable"
+
+    expect(connection.user_id).to eq("17")
+  end
+
+  it "exposes rejection state" do
+    connect "/cable"
+
+    expect(connection).to be_rejected
+  end
+end
+
+RSpec.describe CableRspecHelpersSpec::TestChannel, type: :channel do
+  include_context "rage cable test helpers setup"
+
+  before do
+    stub_connection user_id: 123
+  end
+
+  it "subscribes without streams when no room id is provided" do
+    subscribe
+
+    expect(subscription).to be_confirmed
+    expect(subscription).not_to have_streams
+  end
+
+  it "rejects subscription for an invalid room id" do
+    subscribe(room_id: -1)
+
+    expect(subscription).to be_rejected
+  end
+
+  it "tracks stream subscriptions" do
+    subscribe(room_id: 42)
+
+    expect(subscription).to be_confirmed
+    expect(subscription).to have_stream_from("chat_42")
+    expect(subscription.streams).to eq(["chat_42"])
+  end
+
+  it "performs channel actions and captures transmissions" do
+    subscribe(room_id: 42)
+    perform :speak, message: "Hello!"
+
+    expect(transmissions.last["text"]).to eq("Hello!")
+  end
+
+  it "hides internals in expectation output for mock subscription objects" do
+    subscribe(room_id: -1)
+
+    expect {
+      expect(subscription).not_to be_rejected
+    }.to raise_error(RSpec::Expectations::ExpectationNotMetError) { |error|
+      expect(error.message).to include("#<RageCableHelpers::MockSubscription>")
+      expect(error.message).not_to include("@__")
+    }
+  end
+end
+
+RSpec.describe CableRspecHelpersSpec::StreamForChannel, type: :channel do
+  include_context "rage cable test helpers setup"
+
+  before do
+    stub_connection user_id: 123
+  end
+
+  it "supports stream_for assertions" do
+    room = CableRspecHelpersSpec::Room.new(42)
+
+    subscribe(room: room)
+
+    expect(subscription).to be_confirmed
+    expect(subscription).to have_stream_for(room)
+  end
+end


### PR DESCRIPTION
This pull request introduces RSpec test helpers for `Rage::Cable` channels and connections, improving the ability to test Action Cable-like features in Rage.