### PR TITLE
[Cable] Add `stop_stream_from` and `stop_stream_for` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+- [Cable] Add support for `stop_stream_from` and `stop_stream_for`  by [@Digvijay](https://github.com/Digvijay-x1) (#217).
+
 ## [1.21.1] - 2026-02-27
 
 - Improve styling for the `skills` CLI (#223).
@@ -414,4 +418,3 @@
     - support the `root`, `get`, `post`, `patch`, `put`, `delete` methods;
     - support the `scope` method with the `path` and `module` options;
     - support `host` constraint;
-

--- a/lib/rage/cable/cable.rb
+++ b/lib/rage/cable/cable.rb
@@ -162,6 +162,12 @@ module Rage::Cable
   #     def subscribe(name)
   #     end
   #
+  #     # Unsubscribe from a channel.
+  #     #
+  #     # @param name [String] the channel name
+  #     def unsubscribe(name)
+  #     end
+  #
   #     # Close the connection.
   #     def close
   #     end

--- a/lib/rage/cable/channel.rb
+++ b/lib/rage/cable/channel.rb
@@ -466,6 +466,40 @@ class Rage::Cable::Channel
     stream_from(self.class.__stream_name_for(streamable))
   end
 
+  # Unsubscribe from a global stream.
+  #
+  # @param stream [String] the name of the stream
+  # @raise [ArgumentError] if the stream name is not a String
+  # @example Unsubscribe from a stream and subscribe to a new one
+  #   class ChatChannel < Rage::Cable::Channel
+  #     def subscribed
+  #       stream_from "chat_#{params[:room]}"
+  #     end
+  #
+  #     def switch_room(data)
+  #       stop_stream_from "chat_#{params[:room]}"
+  #       stream_from "chat_#{data['new_room']}"
+  #     end
+  #   end
+  def stop_stream_from(stream)
+    raise ArgumentError, "Stream name must be a String" unless stream.is_a?(String)
+    Rage.cable.__protocol.unsubscribe(@__connection, stream, @__params)
+  end
+
+  # Unsubscribe from a local stream. The counterpart to {stream_for}.
+  #
+  # @param streamable [#id, String, Symbol, Numeric, Array] an object that will be used to generate the stream name
+  # @raise [ArgumentError] if the streamable object does not satisfy the type requirements
+  # @example Unsubscribe from a model stream
+  #   class NotificationsChannel < Rage::Cable::Channel
+  #     def unfollow(data)
+  #       stop_stream_for User.find(data['user_id'])
+  #     end
+  #   end
+  def stop_stream_for(streamable)
+    stop_stream_from(self.class.__stream_name_for(streamable))
+  end
+
   # Broadcast data to all the clients subscribed to a stream.
   #
   # @param stream [String] the name of the stream

--- a/lib/rage/cable/protocols/base.rb
+++ b/lib/rage/cable/protocols/base.rb
@@ -62,6 +62,15 @@ class Rage::Cable::Protocols::Base
       end
     end
 
+    # Unsubscribe from a stream.
+    #
+    # @param connection [Rage::Cable::WebSocketConnection] the connection object
+    # @param name [String] the stream name
+    # @param params [Hash] parameters associated with the client
+    def unsubscribe(connection, name, params)
+      connection.unsubscribe("cable:#{name}:#{stream_id(params)}")
+    end
+
     # Broadcast data to all clients connected to a stream.
     #
     # @param name [String] the stream name

--- a/lib/rage/cable/protocols/raw_web_socket_json.rb
+++ b/lib/rage/cable/protocols/raw_web_socket_json.rb
@@ -141,4 +141,9 @@ class Rage::Cable::Protocols::RawWebSocketJson < Rage::Cable::Protocols::Base
   def self.subscribe(connection, name, _)
     super(connection, name, "")
   end
+
+  # @private
+  def self.unsubscribe(connection, name, _)
+    super(connection, name, "")
+  end
 end

--- a/spec/cable/channel/stop_stream_for_spec.rb
+++ b/spec/cable/channel/stop_stream_for_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+module CableChannelStopStreamForSpec
+  class TestChannel < Rage::Cable::Channel
+    def subscribed
+      stream_for params[:user]
+    end
+
+    def unfollow
+      stop_stream_for params[:user]
+    end
+  end
+
+  class TestChannel2 < Rage::Cable::Channel
+    def subscribed
+      stream_for "global"
+    end
+
+    def leave
+      stop_stream_for "global"
+    end
+  end
+
+  class User
+    attr_reader :id
+
+    def initialize(id)
+      @id = id
+    end
+  end
+end
+
+RSpec.describe Rage::Cable::Channel do
+  let(:protocol) { double("protocol", supports_rpc?: true) }
+  let(:connection) { double("connection") }
+  let(:params) { {} }
+  let(:identified_by) { {} }
+
+  before do
+    allow(Rage.cable).to receive(:__protocol).and_return(protocol)
+    allow(Rage.cable).to receive(:broadcast)
+  end
+
+  describe "#stop_stream_for" do
+    subject { klass.tap(&:__register_actions).new(connection, params, identified_by) }
+
+    context "with an object that responds to id" do
+      let(:klass) { CableChannelStopStreamForSpec::TestChannel }
+      let(:user) { CableChannelStopStreamForSpec::User.new(123) }
+      let(:params) { { user: user } }
+
+      it "unsubscribes from a stream with the channel name and object id" do
+        allow(protocol).to receive(:subscribe)
+        expect(protocol).to receive(:unsubscribe).with(
+          connection,
+          "CableChannelStopStreamForSpec::TestChannel:CableChannelStopStreamForSpec::User:123",
+          params
+        )
+        subject.__run_action(:subscribed)
+        subject.__run_action(:unfollow)
+      end
+    end
+
+    context "with a string streamable" do
+      let(:klass) { CableChannelStopStreamForSpec::TestChannel2 }
+
+      it "unsubscribes from a stream with the channel name and string" do
+        allow(protocol).to receive(:subscribe)
+        expect(protocol).to receive(:unsubscribe).with(
+          connection,
+          "CableChannelStopStreamForSpec::TestChannel2:global",
+          params
+        )
+        subject.__run_action(:subscribed)
+        subject.__run_action(:leave)
+      end
+    end
+
+    context "with a symbol streamable" do
+      let(:klass) { CableChannelStopStreamForSpec::TestChannel }
+      let(:params) { { user: :admin } }
+
+      it "unsubscribes from a stream with the channel name and symbol" do
+        allow(protocol).to receive(:subscribe)
+        expect(protocol).to receive(:unsubscribe).with(
+          connection,
+          "CableChannelStopStreamForSpec::TestChannel:admin",
+          params
+        )
+        subject.__run_action(:subscribed)
+        subject.__run_action(:unfollow)
+      end
+    end
+
+    context "with a numeric streamable" do
+      let(:klass) { CableChannelStopStreamForSpec::TestChannel }
+      let(:params) { { user: 42 } }
+
+      it "unsubscribes from a stream with the channel name and number" do
+        allow(protocol).to receive(:subscribe)
+        expect(protocol).to receive(:unsubscribe).with(
+          connection,
+          "CableChannelStopStreamForSpec::TestChannel:42",
+          params
+        )
+        subject.__run_action(:subscribed)
+        subject.__run_action(:unfollow)
+      end
+    end
+
+    context "with an array of streamables" do
+      let(:klass) { CableChannelStopStreamForSpec::TestChannel }
+      let(:user) { CableChannelStopStreamForSpec::User.new(123) }
+      let(:params) { { user: [user, "room", 456] } }
+
+      it "unsubscribes from a stream with the channel name and joined stream parts" do
+        allow(protocol).to receive(:subscribe)
+        expect(protocol).to receive(:unsubscribe).with(
+          connection,
+          "CableChannelStopStreamForSpec::TestChannel:CableChannelStopStreamForSpec::User:123:room:456",
+          params
+        )
+        subject.__run_action(:subscribed)
+        subject.__run_action(:unfollow)
+      end
+    end
+
+    context "with an invalid streamable" do
+      let(:klass) { CableChannelStopStreamForSpec::TestChannel }
+      let(:params) { { user: Object.new } }
+
+      it "raises an ArgumentError" do
+        allow(protocol).to receive(:subscribe)
+        allow(protocol).to receive(:unsubscribe)
+        expect { subject.__run_action(:unfollow) }.to raise_error(
+          ArgumentError,
+          /Unable to generate stream name/
+        )
+      end
+    end
+  end
+end

--- a/spec/cable/channel/stop_stream_from_spec.rb
+++ b/spec/cable/channel/stop_stream_from_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module CableChannelStopStreamFromSpec
+  class TestChannel < Rage::Cable::Channel
+    def subscribed
+      stream_from "test_stream"
+    end
+
+    def leave
+      stop_stream_from "test_stream"
+    end
+  end
+end
+
+RSpec.describe Rage::Cable::Channel do
+  let(:protocol) { double("protocol", supports_rpc?: true) }
+  let(:connection) { double("connection") }
+  let(:params) { {} }
+  let(:identified_by) { {} }
+
+  before do
+    allow(Rage.cable).to receive(:__protocol).and_return(protocol)
+  end
+
+  describe "#stop_stream_from" do
+    subject { klass.tap(&:__register_actions).new(connection, params, identified_by) }
+
+    let(:klass) { CableChannelStopStreamFromSpec::TestChannel }
+
+    it "unsubscribes from the stream" do
+      allow(protocol).to receive(:subscribe)
+      expect(protocol).to receive(:unsubscribe).with(connection, "test_stream", params)
+      subject.__run_action(:subscribed)
+      subject.__run_action(:leave)
+    end
+
+    it "raises an ArgumentError if the stream name is not a String" do
+      expect { subject.send(:stop_stream_from, 123) }.to raise_error(
+        ArgumentError,
+        "Stream name must be a String"
+      )
+    end
+
+    it "raises an ArgumentError if the stream name is a Symbol" do
+      expect { subject.send(:stop_stream_from, :test) }.to raise_error(
+        ArgumentError,
+        "Stream name must be a String"
+      )
+    end
+  end
+end


### PR DESCRIPTION
Fixes: #217 

This PR introduces methods that allow channels to unsubscribe from specific streams without disconnecting. Mirrors the existing `stream_from`/`stream_for` API.


changes: - 

- added unsubscribe method in the protocol layer 
- added new public methods in the channel layer

To get familiar with RAGE and test my changes E2E, I created a RAGE API and connected a frontend (Discord-clone ) with it.

BEFORE:  Switching channels only updates the UI.

https://github.com/user-attachments/assets/a9b240f4-636c-4782-b244-4ddb6d1c274f

AFTER: Stream switching works at both the UI and backend levels.

https://github.com/user-attachments/assets/1c3b85df-4533-4069-9547-8d5e45931f1e


