### PR TITLE
[OpenAPI] Support multipart/form-data params in the @param tag

### DIFF
--- a/lib/rage/openapi/converter.rb
+++ b/lib/rage/openapi/converter.rb
@@ -56,7 +56,47 @@ class Rage::OpenAPI::Converter
       }
 
       if node.parameters.any?
-        memo[path][method]["parameters"] = build_parameters(node)
+        has_file_param = node.parameters.values.any? { |p| !p.key?(:ref) && p[:type] && p[:type]["format"] == "binary" }
+
+        if has_file_param
+          schema_properties = {}
+          schema_required = []
+          query_ref_parameters = []
+
+          # When file params are present, non-ref params become part of the multipart/form-data
+          # request body schema. Shared refs (e.g., #/components/parameters/...) are kept as
+          # regular parameter references since we can't inline their definitions into the schema.
+          node.parameters.each do |param_name, param_info|
+            if param_info.key?(:ref)
+              # shared parameter refs stay as top-level parameters
+              query_ref_parameters << param_info[:ref]
+            else
+              # inline params become properties in the multipart schema
+              property_schema = get_param_type_spec(param_name, param_info[:type]).dup
+              if param_info[:description] && !param_info[:description].empty?
+                property_schema["description"] = param_info[:description]
+              end
+
+              schema_properties[param_name] = property_schema
+              schema_required << param_name if param_info[:required]
+            end
+          end
+
+          memo[path][method]["requestBody"] = {
+            "content" => {
+              "multipart/form-data" => {
+                "schema" => {
+                  "type" => "object",
+                  "properties" => schema_properties
+                }.tap { |s| s["required"] = schema_required if schema_required.any? }
+              }
+            }
+          }
+
+          memo[path][method]["parameters"] = query_ref_parameters if query_ref_parameters.any?
+        else
+          memo[path][method]["parameters"] = build_parameters(node)
+        end
       end
 
       responses = node.parents.reverse.map(&:responses).reduce(&:merge).merge(node.responses)
@@ -79,7 +119,8 @@ class Rage::OpenAPI::Converter
         if node.request.key?("$ref") && node.request["$ref"].start_with?("#/components/requestBodies")
           memo[path][method]["requestBody"] = node.request
         else
-          memo[path][method]["requestBody"] = { "content" => { "application/json" => { "schema" => node.request } } }
+          memo[path][method]["requestBody"] ||= {}
+          (memo[path][method]["requestBody"]["content"] ||= {})["application/json"] = { "schema" => node.request }
         end
       end
     end

--- a/lib/rage/openapi/openapi.rb
+++ b/lib/rage/openapi/openapi.rb
@@ -153,6 +153,8 @@ module Rage::OpenAPI
       { "type" => "string", "format" => "date-time" }
     when "String"
       { "type" => "string" }
+    when "File"
+      { "type" => "string", "format" => "binary" }
     else
       { "type" => "string" } if default
     end

--- a/spec/openapi/builder/params_spec.rb
+++ b/spec/openapi/builder/params_spec.rb
@@ -430,6 +430,103 @@ RSpec.describe Rage::OpenAPI::Builder do
       end
     end
 
+    context "with file param" do
+      let_class("PhotosController", parent: RageController::API) do
+        <<~'RUBY'
+          # @param image {File} The photo to upload
+          def create
+          end
+        RUBY
+      end
+
+      let(:routes) do
+        { "POST /photos" => "PhotosController#create" }
+      end
+
+      it "returns correct schema" do
+        expect(subject).to eq({ "openapi" => "3.0.0", "info" => { "version" => "1.0.0", "title" => "Rage" }, "components" => {}, "tags" => [{ "name" => "Photos" }], "paths" => { "/photos" => { "post" => { "summary" => "", "description" => "", "deprecated" => false, "requestBody" => { "content" => { "multipart/form-data" => { "schema" => { "type" => "object", "properties" => { "image" => { "type" => "string", "format" => "binary", "description" => "The photo to upload" } }, "required" => ["image"] } } } }, "security" => [], "tags" => ["Photos"], "responses" => { "200" => { "description" => "" } } } } } })
+      end
+    end
+
+    context "with file param and other params" do
+      let_class("PhotosController", parent: RageController::API) do
+        <<~'RUBY'
+          # @param image {File} The photo to upload
+          # @param caption? {String} An optional caption for the photo
+          def create
+          end
+        RUBY
+      end
+
+      let(:routes) do
+        { "POST /photos" => "PhotosController#create" }
+      end
+
+      it "returns correct schema" do
+        expect(subject).to eq({ "openapi" => "3.0.0", "info" => { "version" => "1.0.0", "title" => "Rage" }, "components" => {}, "tags" => [{ "name" => "Photos" }], "paths" => { "/photos" => { "post" => { "summary" => "", "description" => "", "deprecated" => false, "requestBody" => { "content" => { "multipart/form-data" => { "schema" => { "type" => "object", "properties" => { "image" => { "type" => "string", "format" => "binary", "description" => "The photo to upload" }, "caption" => { "type" => "string", "description" => "An optional caption for the photo" } }, "required" => ["image"] } } } }, "security" => [], "tags" => ["Photos"], "responses" => { "200" => { "description" => "" } } } } } })
+      end
+    end
+
+    context "with optional file param" do
+      let_class("PhotosController", parent: RageController::API) do
+        <<~'RUBY'
+          # @param image? {File} The photo to upload
+          def create
+          end
+        RUBY
+      end
+
+      let(:routes) do
+        { "POST /photos" => "PhotosController#create" }
+      end
+
+      it "returns correct schema" do
+        expect(subject).to eq({ "openapi" => "3.0.0", "info" => { "version" => "1.0.0", "title" => "Rage" }, "components" => {}, "tags" => [{ "name" => "Photos" }], "paths" => { "/photos" => { "post" => { "summary" => "", "description" => "", "deprecated" => false, "requestBody" => { "content" => { "multipart/form-data" => { "schema" => { "type" => "object", "properties" => { "image" => { "type" => "string", "format" => "binary", "description" => "The photo to upload" } } } } } }, "security" => [], "tags" => ["Photos"], "responses" => { "200" => { "description" => "" } } } } } })
+      end
+    end
+
+    context "with file param and request tag" do
+      let_class("PhotosController", parent: RageController::API) do
+        <<~'RUBY'
+          # @param image {File} The photo to upload
+          # @request { email: String, password: String }
+          def create
+          end
+        RUBY
+      end
+
+      let(:routes) do
+        { "POST /photos" => "PhotosController#create" }
+      end
+
+      it "returns correct schema" do
+        expect(subject).to eq({ "openapi" => "3.0.0", "info" => { "version" => "1.0.0", "title" => "Rage" }, "components" => {}, "tags" => [{ "name" => "Photos" }], "paths" => { "/photos" => { "post" => { "summary" => "", "description" => "", "deprecated" => false, "requestBody" => { "content" => { "multipart/form-data" => { "schema" => { "type" => "object", "properties" => { "image" => { "type" => "string", "format" => "binary", "description" => "The photo to upload" } }, "required" => ["image"] } }, "application/json" => { "schema" => { "type" => "object", "properties" => { "email" => { "type" => "string" }, "password" => { "type" => "string" } } } } } }, "security" => [], "tags" => ["Photos"], "responses" => { "200" => { "description" => "" } } } } } })
+      end
+    end
+
+    context "with file param and shared ref" do
+      before do
+        allow(Rage::OpenAPI).to receive(:__shared_components).and_return(shared_components)
+      end
+
+      let_class("PhotosController", parent: RageController::API) do
+        <<~'RUBY'
+          # @param image {File} The photo to upload
+          # @param #/components/parameters/perPageParam
+          def create
+          end
+        RUBY
+      end
+
+      let(:routes) do
+        { "POST /photos" => "PhotosController#create" }
+      end
+
+      it "returns correct schema" do
+        expect(subject).to eq({ "openapi" => "3.0.0", "info" => { "version" => "1.0.0", "title" => "Rage" }, "components" => { "parameters" => { "perPageParam" => { "in" => "query", "name" => "per_page", "required" => false, "schema" => { "type" => "integer", "minimum" => 1, "maximum" => 500, "default" => 100 }, "description" => "The number of records to return." } } }, "tags" => [{ "name" => "Photos" }], "paths" => { "/photos" => { "post" => { "summary" => "", "description" => "", "deprecated" => false, "requestBody" => { "content" => { "multipart/form-data" => { "schema" => { "type" => "object", "properties" => { "image" => { "type" => "string", "format" => "binary", "description" => "The photo to upload" } }, "required" => ["image"] } } } }, "parameters" => [{ "$ref" => "#/components/parameters/perPageParam" }], "security" => [], "tags" => ["Photos"], "responses" => { "200" => { "description" => "" } } } } } })
+      end
+    end
+
     context "with regular and implicit URL params" do
       let_class("UsersController", parent: RageController::API) do
         <<~'RUBY'

--- a/spec/openapi/openapi_spec.rb
+++ b/spec/openapi/openapi_spec.rb
@@ -118,6 +118,11 @@ RSpec.describe Rage::OpenAPI do
       it { is_expected.to eq({ "type" => "string" }) }
     end
 
+    context "with File" do
+      let(:type) { "File" }
+      it { is_expected.to eq({ "type" => "string", "format" => "binary" }) }
+    end
+
     context "with unknown type" do
       context "with fallback" do
         subject { described_class.__type_to_spec(type, default: true) }


### PR DESCRIPTION
Fixes: #214 

1. **Parser & Type Spec**: Added `"File" => { "type" => "string", "format" => "binary" }` to `__type_to_spec`. The parser just treats it like any other parsed parameter.
2. **Converter Logic**: While building the schema for an action, the converter now checks if any of the parsed query parameters have `format: "binary"`. 
   - If they do, it shifts all the body-bound parameters into a `multipart/form-data` requestBody block.
   - Any shared ref parameters (`#/components/...`) are preserved and left as normal query parameters.
   - If there is an existing `@request` tag on the action (like a JSON payload document), the converter merges the `multipart/form-data` content block with the `application/json` block rather than overwriting it via `||=`.


BEFORE: 
<img width="1421" height="474" alt="Screenshot 2026-03-07 at 00-41-09 SwaggerUI" src="https://github.com/user-attachments/assets/ac5a9116-70be-4d0f-be25-6fd7eb782d7a" />

AFTER: 
<img width="1418" height="709" alt="Screenshot 2026-03-07 at 00-40-25 SwaggerUI" src="https://github.com/user-attachments/assets/98ff9c7c-3756-4b7a-b9ee-9ce2a5091a31" />


Made a very simple app by following the docs to get the above result, [Code](https://github.com/Digvijay-x1/OpenAPI-on-Rage)