### PR TITLE
Fix SystemStackError in Alba parser with circular associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- [OpenAPI] Fix SystemStackError in Alba parser with circular associations.
 - Only parse request body as multipart if the request is multipart by [p8](https://github.com/p8) (#256).
 
 ## [1.22.0] - 2026-03-12

--- a/lib/rage/openapi/builder.rb
+++ b/lib/rage/openapi/builder.rb
@@ -21,6 +21,7 @@ class Rage::OpenAPI::Builder
   end
 
   def run
+    Rage::OpenAPI.__reset_data_cache
     parser = Rage::OpenAPI::Parser.new
 
     @routes.each do |controller, routes|

--- a/lib/rage/openapi/builder.rb
+++ b/lib/rage/openapi/builder.rb
@@ -21,9 +21,7 @@ class Rage::OpenAPI::Builder
   end
 
   def run
-    # reset the data cache at the beginning of each build to prevent data leakage between builds in long-running processes
-    Rage::OpenAPI.__reset_data_cache
-    parser = Rage::OpenAPI::Parser.new
+    parser = Rage::OpenAPI::Parser.new(@nodes)
 
     @routes.each do |controller, routes|
       next if skip_controller?(controller)

--- a/lib/rage/openapi/builder.rb
+++ b/lib/rage/openapi/builder.rb
@@ -21,6 +21,7 @@ class Rage::OpenAPI::Builder
   end
 
   def run
+    # reset the data cache at the beginning of each build to prevent data leakage between builds in long-running processes
     Rage::OpenAPI.__reset_data_cache
     parser = Rage::OpenAPI::Parser.new
 

--- a/lib/rage/openapi/converter.rb
+++ b/lib/rage/openapi/converter.rb
@@ -137,6 +137,10 @@ class Rage::OpenAPI::Converter
       end
     end
 
+    if (dynamic_schemas = Rage::OpenAPI.__schema_registry).any?
+      (@spec["components"]["schemas"] ||= {}).merge!(dynamic_schemas)
+    end
+
     @spec["tags"] = @used_tags.sort.map { |tag| { "name" => tag } }
 
     @spec

--- a/lib/rage/openapi/converter.rb
+++ b/lib/rage/openapi/converter.rb
@@ -137,7 +137,7 @@ class Rage::OpenAPI::Converter
       end
     end
 
-    if (dynamic_schemas = Rage::OpenAPI.__schema_registry).any?
+    if (dynamic_schemas = @nodes.schema_registry).any?
       (@spec["components"]["schemas"] ||= {}).merge!(dynamic_schemas)
     end
 

--- a/lib/rage/openapi/nodes/root.rb
+++ b/lib/rage/openapi/nodes/root.rb
@@ -20,12 +20,13 @@
 #            Nodes::Method<index>   Nodes::Method<show>                  Nodes::Method<show>
 #
 class Rage::OpenAPI::Nodes::Root
-  attr_reader :leaves
+  attr_reader :leaves, :schema_registry
   attr_accessor :version, :title
 
   def initialize
     @parent_nodes_cache = {}
     @leaves = []
+    @schema_registry = {}
   end
 
   # @return [Array<Rage::OpenAPI::Nodes::Parent>]

--- a/lib/rage/openapi/openapi.rb
+++ b/lib/rage/openapi/openapi.rb
@@ -114,6 +114,11 @@ module Rage::OpenAPI
   end
 
   # @private
+  def self.__schema_registry
+    __data_cache[:schema_registry] ||= {}
+  end
+
+  # @private
   def self.__reset_data_cache
     __data_cache.clear
   end

--- a/lib/rage/openapi/parser.rb
+++ b/lib/rage/openapi/parser.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class Rage::OpenAPI::Parser
+  # @param root [Rage::OpenAPI::Nodes::Root]
+  def initialize(root)
+    @root = root
+  end
+
   # @param node [Rage::OpenAPI::Nodes::Parent]
   # @param comments [Array<Prism::InlineComment>]
   def parse_dangling_comments(node, comments)
@@ -125,7 +130,8 @@ class Rage::OpenAPI::Parser
         else
           parsed = Rage::OpenAPI::Parsers::Request.parse(
             request,
-            namespace: Rage::OpenAPI.__module_parent(node.controller)
+            namespace: Rage::OpenAPI.__module_parent(node.controller),
+            root: @root
           )
 
           if parsed
@@ -203,7 +209,8 @@ class Rage::OpenAPI::Parser
     else
       parsed = Rage::OpenAPI::Parsers::Response.parse(
         response_data,
-        namespace: Rage::OpenAPI.__module_parent(node.controller)
+        namespace: Rage::OpenAPI.__module_parent(node.controller),
+        root: @root
       )
 
       if parsed

--- a/lib/rage/openapi/parsers/ext/alba.rb
+++ b/lib/rage/openapi/parsers/ext/alba.rb
@@ -16,10 +16,27 @@ class Rage::OpenAPI::Parsers::Ext::Alba
   end
 
   def parse(klass_str)
-    __parse(klass_str).build_schema
+    _, raw_klass_str = Rage::OpenAPI.__try_parse_collection(klass_str)
+    visitor = __parse(klass_str)
+
+    if Rage::OpenAPI.__schema_registry.key?(raw_klass_str)
+      clean = { "type" => "object" }
+      clean["properties"] = visitor.schema if visitor.schema.any?
+      Rage::OpenAPI.__schema_registry[raw_klass_str] = clean
+    end
+
+    visitor.build_schema
   end
 
   def __parse_nested(klass_str)
+    is_collection, raw_klass_str = Rage::OpenAPI.__try_parse_collection(klass_str)
+
+    if @parsing_stack.include?(raw_klass_str)
+      Rage::OpenAPI.__schema_registry[raw_klass_str] ||= nil
+      ref = { "$ref" => "#/components/schemas/#{raw_klass_str}" }
+      return is_collection ? { "type" => "array", "items" => ref } : ref
+    end
+
     __parse(klass_str).tap { |visitor|
       visitor.root_key = visitor.root_key_for_collection = visitor.root_key_proc = visitor.key_transformer = nil
     }.build_schema

--- a/lib/rage/openapi/parsers/ext/alba.rb
+++ b/lib/rage/openapi/parsers/ext/alba.rb
@@ -48,7 +48,6 @@ class Rage::OpenAPI::Parsers::Ext::Alba
     if @parsing_stack.include?(klass_str)
       return Visitor.new(self, is_collection)
     end
-    
     @parsing_stack.add(klass_str)
 
     klass = @namespace.const_get(klass_str)

--- a/lib/rage/openapi/parsers/ext/alba.rb
+++ b/lib/rage/openapi/parsers/ext/alba.rb
@@ -45,6 +45,8 @@ class Rage::OpenAPI::Parsers::Ext::Alba
   def __parse(klass_str)
     is_collection, klass_str = Rage::OpenAPI.__try_parse_collection(klass_str)
 
+    # return an empty visitor if we're already parsing this class;
+    # this serves as a recursion guard, specifically for the inheritance logic in `Visitor#visit_class_node`
     if @parsing_stack.include?(klass_str)
       return Visitor.new(self, is_collection)
     end

--- a/lib/rage/openapi/parsers/ext/alba.rb
+++ b/lib/rage/openapi/parsers/ext/alba.rb
@@ -5,6 +5,7 @@ class Rage::OpenAPI::Parsers::Ext::Alba
 
   def initialize(namespace: Object, **)
     @namespace = namespace
+    @parsing_stack = Set.new
   end
 
   def known_definition?(str)
@@ -27,12 +28,20 @@ class Rage::OpenAPI::Parsers::Ext::Alba
   def __parse(klass_str)
     is_collection, klass_str = Rage::OpenAPI.__try_parse_collection(klass_str)
 
+    if @parsing_stack.include?(klass_str)
+      return Visitor.new(self, is_collection)
+    end
+    
+    @parsing_stack.add(klass_str)
+
     klass = @namespace.const_get(klass_str)
     source_path, _ = Object.const_source_location(klass.name)
     ast = Prism.parse_file(source_path)
 
     visitor = Visitor.new(self, is_collection)
     ast.value.accept(visitor)
+
+    @parsing_stack.delete(klass_str)
 
     visitor
   end

--- a/lib/rage/openapi/parsers/ext/alba.rb
+++ b/lib/rage/openapi/parsers/ext/alba.rb
@@ -3,8 +3,9 @@
 class Rage::OpenAPI::Parsers::Ext::Alba
   attr_reader :namespace
 
-  def initialize(namespace: Object, **)
+  def initialize(namespace: Object, root: Rage::OpenAPI::Nodes::Root.new, **)
     @namespace = namespace
+    @root = root
     @parsing_stack = Set.new
   end
 
@@ -19,10 +20,10 @@ class Rage::OpenAPI::Parsers::Ext::Alba
     _, raw_klass_str = Rage::OpenAPI.__try_parse_collection(klass_str)
     visitor = __parse(klass_str)
 
-    if Rage::OpenAPI.__schema_registry.key?(raw_klass_str)
+    if @root.schema_registry.key?(raw_klass_str)
       clean = { "type" => "object" }
       clean["properties"] = visitor.schema if visitor.schema.any?
-      Rage::OpenAPI.__schema_registry[raw_klass_str] = clean
+      @root.schema_registry[raw_klass_str] = clean
     end
 
     visitor.build_schema
@@ -32,7 +33,7 @@ class Rage::OpenAPI::Parsers::Ext::Alba
     is_collection, raw_klass_str = Rage::OpenAPI.__try_parse_collection(klass_str)
 
     if @parsing_stack.include?(raw_klass_str)
-      Rage::OpenAPI.__schema_registry[raw_klass_str] ||= nil
+      @root.schema_registry[raw_klass_str] ||= nil
       ref = { "$ref" => "#/components/schemas/#{raw_klass_str}" }
       return is_collection ? { "type" => "array", "items" => ref } : ref
     end

--- a/lib/rage/openapi/parsers/request.rb
+++ b/lib/rage/openapi/parsers/request.rb
@@ -7,9 +7,9 @@ class Rage::OpenAPI::Parsers::Request
     Rage::OpenAPI::Parsers::Ext::ActiveRecord
   ]
 
-  def self.parse(request_tag, namespace:)
+  def self.parse(request_tag, namespace:, root:)
     parser = AVAILABLE_PARSERS.find do |parser_class|
-      parser = parser_class.new(namespace:)
+      parser = parser_class.new(namespace:, root:)
       break parser if parser.known_definition?(request_tag)
     end
 

--- a/lib/rage/openapi/parsers/response.rb
+++ b/lib/rage/openapi/parsers/response.rb
@@ -8,9 +8,9 @@ class Rage::OpenAPI::Parsers::Response
     Rage::OpenAPI::Parsers::YAML
   ]
 
-  def self.parse(response_tag, namespace:)
+  def self.parse(response_tag, namespace:, root:)
     parser = AVAILABLE_PARSERS.find do |parser_class|
-      parser = parser_class.new(namespace:)
+      parser = parser_class.new(namespace:, root:)
       break parser if parser.known_definition?(response_tag)
     end
 

--- a/spec/openapi/builder/cache_leakage_spec.rb
+++ b/spec/openapi/builder/cache_leakage_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe "Rage::OpenAPI cache leakage" do
+  include_context "mocked_rage_routes"
+
+  let(:routes) { {} }
+
+  it "clears the schema registry when Builder#run is called" do
+    # Manually populate the registry
+    Rage::OpenAPI.__schema_registry["UserResource"] = { "type" => "object" }
+    expect(Rage::OpenAPI.__schema_registry).not_to be_empty
+
+    # Run the builder, which should trigger __reset_data_cache
+    Rage::OpenAPI::Builder.new.run
+
+    expect(Rage::OpenAPI.__schema_registry).to be_empty
+  end
+end

--- a/spec/openapi/builder/cache_leakage_spec.rb
+++ b/spec/openapi/builder/cache_leakage_spec.rb
@@ -1,18 +1,34 @@
 # frozen_string_literal: true
 
-RSpec.describe "Rage::OpenAPI cache leakage" do
+require "prism"
+
+RSpec.describe "Rage::OpenAPI registry isolation" do
+  include_context "mocked_classes"
   include_context "mocked_rage_routes"
 
-  let(:routes) { {} }
+  let_class("UserResource") do
+    <<~RUBY
+      include Alba::Resource
+      attributes :id
+    RUBY
+  end
 
-  it "clears the schema registry when Builder#run is called" do
-    # Manually populate the registry
-    Rage::OpenAPI.__schema_registry["UserResource"] = { "type" => "object" }
-    expect(Rage::OpenAPI.__schema_registry).not_to be_empty
+  let_class("UsersController", parent: RageController::API) do
+    <<~RUBY
+      # @response {Any} UserResource
+      def index; end
+    RUBY
+  end
 
-    # Run the builder, which should trigger __reset_data_cache
-    Rage::OpenAPI::Builder.new.run
+  let(:routes) do
+    { "GET /users" => "UsersController#index" }
+  end
 
+  it "does not use a global registry for circular definitions" do
+    # Build the spec
+    Rage::OpenAPI.build
+
+    # The global registry should remain empty because we used the Root node's registry
     expect(Rage::OpenAPI.__schema_registry).to be_empty
   end
 end

--- a/spec/openapi/parsers/ext/alba_recursion_spec.rb
+++ b/spec/openapi/parsers/ext/alba_recursion_spec.rb
@@ -5,8 +5,8 @@ require "prism"
 RSpec.describe Rage::OpenAPI::Parsers::Ext::Alba do
   include_context "mocked_classes"
 
-  subject { described_class.new.parse(resource) }
-
+  subject { described_class.new(root: root).parse(resource) }
+  let(:root) { Rage::OpenAPI::Nodes::Root.new }
   let(:resource) { "UserResource" }
 
   context "with direct circular associations (UserResource ↔ PostResource)" do
@@ -52,7 +52,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Alba do
 
     it "registers the referenced schema in the registry" do
       subject
-      expect(Rage::OpenAPI.__schema_registry["UserResource"]).to eq({
+      expect(root.schema_registry["UserResource"]).to eq({
         "type" => "object",
         "properties" => {
           "id" => { "type" => "string" },
@@ -103,7 +103,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Alba do
 
     it "registers the self-referencing schema" do
       subject
-      expect(Rage::OpenAPI.__schema_registry).to have_key("CategoryResource")
+      expect(root.schema_registry).to have_key("CategoryResource")
     end
   end
 
@@ -162,7 +162,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Alba do
 
     it "registers the referenced schema" do
       subject
-      expect(Rage::OpenAPI.__schema_registry).to have_key("AResource")
+      expect(root.schema_registry).to have_key("AResource")
     end
   end
 
@@ -179,7 +179,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Alba do
 
     it "correctly registers the referenced schema in the registry" do
       subject
-      expect(Rage::OpenAPI.__schema_registry["CategoryResource"]).to eq({
+      expect(root.schema_registry["CategoryResource"]).to eq({
         "type" => "object",
         "properties" => {
           "id" => { "type" => "string" },

--- a/spec/openapi/parsers/ext/alba_recursion_spec.rb
+++ b/spec/openapi/parsers/ext/alba_recursion_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Alba do
 
   let(:resource) { "UserResource" }
 
-
   context "with direct circular associations (UserResource ↔ PostResource)" do
     let_class("UserResource") do
       <<~'RUBY'

--- a/spec/openapi/parsers/ext/alba_recursion_spec.rb
+++ b/spec/openapi/parsers/ext/alba_recursion_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Alba do
 
   let(:resource) { "UserResource" }
 
-  # Clear the schema registry between tests so $ref registrations don't leak
-  before { Rage::OpenAPI.__schema_registry.clear }
 
   context "with direct circular associations (UserResource ↔ PostResource)" do
     let_class("UserResource") do
@@ -166,6 +164,33 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Alba do
     it "registers the referenced schema" do
       subject
       expect(Rage::OpenAPI.__schema_registry).to have_key("AResource")
+    end
+  end
+
+  context "with a collection as top-level resource and recursion" do
+    let(:resource) { "[CategoryResource]" }
+
+    let_class("CategoryResource") do
+      <<~'RUBY'
+        include Alba::Resource
+        attributes :id, :name
+        has_many :subcategories, resource: "CategoryResource"
+      RUBY
+    end
+
+    it "correctly registers the referenced schema in the registry" do
+      subject
+      expect(Rage::OpenAPI.__schema_registry["CategoryResource"]).to eq({
+        "type" => "object",
+        "properties" => {
+          "id" => { "type" => "string" },
+          "name" => { "type" => "string" },
+          "subcategories" => {
+            "type" => "array",
+            "items" => { "$ref" => "#/components/schemas/CategoryResource" }
+          }
+        }
+      })
     end
   end
 end

--- a/spec/openapi/parsers/ext/alba_recursion_spec.rb
+++ b/spec/openapi/parsers/ext/alba_recursion_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require "prism"
+
+RSpec.describe Rage::OpenAPI::Parsers::Ext::Alba do
+  include_context "mocked_classes"
+
+  subject { described_class.new.parse(resource) }
+
+  let(:resource) { "UserResource" }
+
+  context "with direct circular associations (UserResource ↔ PostResource)" do
+    let_class("UserResource") do
+      <<~'RUBY'
+        include Alba::Resource
+        attributes :id, :name
+        has_many :posts, resource: "PostResource"
+      RUBY
+    end
+
+    let_class("PostResource") do
+      <<~'RUBY'
+        include Alba::Resource
+        attributes :title
+        has_one :author, resource: "UserResource"
+      RUBY
+    end
+
+    it "does not raise SystemStackError" do
+      expect { subject }.not_to raise_error
+    end
+
+    it "stops recursion with a fallback object schema" do
+      is_expected.to eq({
+        "type" => "object",
+        "properties" => {
+          "id" => { "type" => "string" },
+          "name" => { "type" => "string" },
+          "posts" => {
+            "type" => "array",
+            "items" => {
+              "type" => "object",
+              "properties" => {
+                "title" => { "type" => "string" },
+                "author" => { "type" => "object" }
+              }
+            }
+          }
+        }
+      })
+    end
+  end
+
+  context "with a self-referencing resource" do
+    let(:resource) { "CategoryResource" }
+
+    let_class("CategoryResource") do
+      <<~'RUBY'
+        include Alba::Resource
+        attributes :id, :name
+        has_many :subcategories, resource: "CategoryResource"
+      RUBY
+    end
+
+    it "does not raise SystemStackError" do
+      expect { subject }.not_to raise_error
+    end
+
+    it "stops recursion on the self-reference" do
+      is_expected.to eq({
+        "type" => "object",
+        "properties" => {
+          "id" => { "type" => "string" },
+          "name" => { "type" => "string" },
+          "subcategories" => {
+            "type" => "array",
+            "items" => { "type" => "object" }
+          }
+        }
+      })
+    end
+  end
+
+  context "with transitive circular associations (A → B → C → A)" do
+    let(:resource) { "AResource" }
+
+    let_class("AResource") do
+      <<~'RUBY'
+        include Alba::Resource
+        attributes :a_id
+        has_one :b, resource: "BResource"
+      RUBY
+    end
+
+    let_class("BResource") do
+      <<~'RUBY'
+        include Alba::Resource
+        attributes :b_id
+        has_one :c, resource: "CResource"
+      RUBY
+    end
+
+    let_class("CResource") do
+      <<~'RUBY'
+        include Alba::Resource
+        attributes :c_id
+        has_one :a, resource: "AResource"
+      RUBY
+    end
+
+    it "does not raise SystemStackError" do
+      expect { subject }.not_to raise_error
+    end
+
+    it "stops recursion at the cycle point" do
+      is_expected.to eq({
+        "type" => "object",
+        "properties" => {
+          "a_id" => { "type" => "string" },
+          "b" => {
+            "type" => "object",
+            "properties" => {
+              "b_id" => { "type" => "string" },
+              "c" => {
+                "type" => "object",
+                "properties" => {
+                  "c_id" => { "type" => "string" },
+                  "a" => { "type" => "object" }
+                }
+              }
+            }
+          }
+        }
+      })
+    end
+  end
+end

--- a/spec/openapi/parsers/ext/alba_recursion_spec.rb
+++ b/spec/openapi/parsers/ext/alba_recursion_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Alba do
 
   let(:resource) { "UserResource" }
 
+  # Clear the schema registry between tests so $ref registrations don't leak
+  before { Rage::OpenAPI.__schema_registry.clear }
+
   context "with direct circular associations (UserResource ↔ PostResource)" do
     let_class("UserResource") do
       <<~'RUBY'
@@ -30,7 +33,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Alba do
       expect { subject }.not_to raise_error
     end
 
-    it "stops recursion with a fallback object schema" do
+    it "uses $ref for the circular association" do
       is_expected.to eq({
         "type" => "object",
         "properties" => {
@@ -42,7 +45,28 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Alba do
               "type" => "object",
               "properties" => {
                 "title" => { "type" => "string" },
-                "author" => { "type" => "object" }
+                "author" => { "$ref" => "#/components/schemas/UserResource" }
+              }
+            }
+          }
+        }
+      })
+    end
+
+    it "registers the referenced schema in the registry" do
+      subject
+      expect(Rage::OpenAPI.__schema_registry["UserResource"]).to eq({
+        "type" => "object",
+        "properties" => {
+          "id" => { "type" => "string" },
+          "name" => { "type" => "string" },
+          "posts" => {
+            "type" => "array",
+            "items" => {
+              "type" => "object",
+              "properties" => {
+                "title" => { "type" => "string" },
+                "author" => { "$ref" => "#/components/schemas/UserResource" }
               }
             }
           }
@@ -66,7 +90,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Alba do
       expect { subject }.not_to raise_error
     end
 
-    it "stops recursion on the self-reference" do
+    it "uses $ref for the self-reference" do
       is_expected.to eq({
         "type" => "object",
         "properties" => {
@@ -74,10 +98,15 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Alba do
           "name" => { "type" => "string" },
           "subcategories" => {
             "type" => "array",
-            "items" => { "type" => "object" }
+            "items" => { "$ref" => "#/components/schemas/CategoryResource" }
           }
         }
       })
+    end
+
+    it "registers the self-referencing schema" do
+      subject
+      expect(Rage::OpenAPI.__schema_registry).to have_key("CategoryResource")
     end
   end
 
@@ -112,7 +141,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Alba do
       expect { subject }.not_to raise_error
     end
 
-    it "stops recursion at the cycle point" do
+    it "uses $ref at the cycle point" do
       is_expected.to eq({
         "type" => "object",
         "properties" => {
@@ -125,13 +154,18 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Alba do
                 "type" => "object",
                 "properties" => {
                   "c_id" => { "type" => "string" },
-                  "a" => { "type" => "object" }
+                  "a" => { "$ref" => "#/components/schemas/AResource" }
                 }
               }
             }
           }
         }
       })
+    end
+
+    it "registers the referenced schema" do
+      subject
+      expect(Rage::OpenAPI.__schema_registry).to have_key("AResource")
     end
   end
 end

--- a/spec/openapi/parsers/request_spec.rb
+++ b/spec/openapi/parsers/request_spec.rb
@@ -3,15 +3,16 @@
 require "prism"
 
 RSpec.describe Rage::OpenAPI::Parsers::Request do
-  subject { described_class.parse(tag, namespace:) }
+  subject { described_class.parse(tag, namespace:, root:) }
 
   let(:tag) { "test_tag" }
   let(:namespace) { double }
+  let(:root) { Rage::OpenAPI::Nodes::Root.new }
 
   before do
     described_class::AVAILABLE_PARSERS.each do |parser_class|
       parser = double
-      allow(parser_class).to receive(:new).with(namespace:).and_return(parser)
+      allow(parser_class).to receive(:new).with(namespace:, root:).and_return(parser)
       allow(parser).to receive(:known_definition?).and_return(false)
     end
   end
@@ -24,7 +25,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Request do
     let(:parser) { double }
 
     before do
-      allow(Rage::OpenAPI::Parsers::YAML).to receive(:new).with(namespace:).and_return(parser)
+      allow(Rage::OpenAPI::Parsers::YAML).to receive(:new).with(namespace:, root:).and_return(parser)
       allow(parser).to receive(:known_definition?).and_return(true)
     end
 

--- a/spec/openapi/parsers/response_spec.rb
+++ b/spec/openapi/parsers/response_spec.rb
@@ -3,15 +3,16 @@
 require "prism"
 
 RSpec.describe Rage::OpenAPI::Parsers::Response do
-  subject { described_class.parse(tag, namespace:) }
+  subject { described_class.parse(tag, namespace:, root:) }
 
   let(:tag) { "test_tag" }
   let(:namespace) { double }
+  let(:root) { Rage::OpenAPI::Nodes::Root.new }
 
   before do
     described_class::AVAILABLE_PARSERS.each do |parser_class|
       parser = double
-      allow(parser_class).to receive(:new).with(namespace:).and_return(parser)
+      allow(parser_class).to receive(:new).with(namespace:, root:).and_return(parser)
       allow(parser).to receive(:known_definition?).and_return(false)
     end
   end
@@ -24,7 +25,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Response do
     let(:parser) { double }
 
     before do
-      allow(Rage::OpenAPI::Parsers::Ext::ActiveRecord).to receive(:new).with(namespace:).and_return(parser)
+      allow(Rage::OpenAPI::Parsers::Ext::ActiveRecord).to receive(:new).with(namespace:, root:).and_return(parser)
       allow(parser).to receive(:known_definition?).and_return(true)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,4 +36,8 @@ RSpec.configure do |config|
 
   config.include_context "mocked_classes", include_shared: true
   config.include_context "mocked_rage_routes", include_shared: true
+
+  config.after(:each) do
+    Rage::OpenAPI.__reset_data_cache
+  end
 end


### PR DESCRIPTION
## Description
The Alba parser in **Rage::OpenAPI** currently lacks a recursion guard for associations. When two resources reference each other circularly (e.g., **UserResource ↔ PostResource**), the parser enters an infinite loop while attempting to recursively nest the schemas, eventually resulting in a **SystemStackError**.

This PR introduces a dynamic schema registry and switches the Alba parser to use **$ref** pointers for circular associations. This prevents infinite recursion while preserving full schema information and aligning with OpenAPI best practices.

----
## Changes

- Added `__schema_registry` (a **Hash**) to Rage::OpenAPI to store dynamically discovered schemas.
- Updated **Rage::OpenAPI::Parsers::Ext::Alba**:

  - __parse_nested now returns a $ref pointer (e.g., { "**$ref":"#/components/schemas/UserResource**" }) when a circular reference is detected.
  - parse registers the full clean schema if it was referenced via **$ref** during the parsing process.

- Updated **Rage::OpenAPI::Converter** to merge these dynamic schemas into **components/schemas**.

----
## Testing
Automated Tests

- Added `spec/openapi/parsers/ext/alba_recursion_spec.rb`
- Commands:
``` ruby
bundle exec rspec spec/openapi/parsers/ext/alba_recursion_spec.rb
bundle exec rspec spec/openapi/parsers/ext/alba_spec.rb spec/openapi/parsers/ext/alba_fallback_spec.rb
```

----
Closes: #265 