### PR TITLE
Support per-endpoint OAuth2/OpenID scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Ensure task ID seed is always greater than timestamps in existing WAL files by [@Abishekcs](https://github.com/Abishekcs) (#255)
 
 ### Added
+- [OpenAPI] Add support for per-endpoint OAuth2/OpenID scopes via `@auth_scope` tag by [@Piyush-Goenka](https://github.com/Piyush-Goenka) (#269).
 - [SSE] Add tests for log context propagation across fiber boundaries by [@jsxs0](https://github.com/jsxs0) (#267).
 
 - Add singular `resource` routing with plural controller mapping and document the helper by [@anuj-pal27](https://github.com/anuj-pal27).

--- a/lib/rage/openapi/converter.rb
+++ b/lib/rage/openapi/converter.rb
@@ -177,7 +177,7 @@ class Rage::OpenAPI::Converter
           @used_security_schemes << auth_entry.merge(name: auth_name)
         end
 
-        { auth_name => [] }
+        { auth_name => node.auth_scopes.fetch(auth_name, []) }
       end
     end
   end

--- a/lib/rage/openapi/nodes/method.rb
+++ b/lib/rage/openapi/nodes/method.rb
@@ -3,7 +3,7 @@
 class Rage::OpenAPI::Nodes::Method
   attr_reader :controller, :action, :parents
   attr_accessor :http_method, :http_path, :summary, :tag, :deprecated, :private, :description,
-    :request, :responses, :parameters
+    :request, :responses, :parameters, :auth_scopes
 
   # @param controller [RageController::API]
   # @param action [String]
@@ -15,6 +15,7 @@ class Rage::OpenAPI::Nodes::Method
 
     @responses = {}
     @parameters = {}
+    @auth_scopes = {}
   end
 
   def root

--- a/lib/rage/openapi/parser.rb
+++ b/lib/rage/openapi/parser.rb
@@ -138,6 +138,9 @@ class Rage::OpenAPI::Parser
       elsif expression =~ /@param\s/
         parse_param_tag(expression, node, comments[i])
 
+      elsif expression =~ /@auth_scope\s/
+        parse_auth_scope_tag(expression, node, comments[i])
+
       elsif expression =~ /@internal\b/
         # no-op
         children = find_children(comments[i + 1..], node)
@@ -254,6 +257,62 @@ class Rage::OpenAPI::Parser
       Rage::OpenAPI.__log_warn "invalid shared reference detected at #{location_msg(comment)}"
       nil
     end
+  end
+
+  def parse_auth_scope_tag(expression, node, comment)
+    parts = expression.split(" ")
+    # parts[0] = "@auth_scope"
+    # parts[1] = scheme name or start of "[scopes]"
+    # parts[1..] or parts[2..] = scopes portion
+
+    if parts.length < 2
+      Rage::OpenAPI.__log_warn "invalid `@auth_scope` tag detected at #{location_msg(comment)}; expected [scope1, scope2] syntax"
+      return
+    end
+
+    if parts[1].start_with?("[")
+      scheme_name = nil
+      scopes_str = parts[1..].join(" ")
+    else
+      scheme_name = parts[1]
+      if parts[2].nil?
+        Rage::OpenAPI.__log_warn "invalid `@auth_scope` tag detected at #{location_msg(comment)}; expected [scope1, scope2] syntax"
+        return
+      end
+      scopes_str = parts[2..].join(" ")
+    end
+
+    unless scopes_str =~ /^\[([^\]]*)\]$/
+      Rage::OpenAPI.__log_warn "invalid `@auth_scope` tag detected at #{location_msg(comment)}; expected [scope1, scope2] syntax"
+      return
+    end
+
+    scopes = $1.split(",").map(&:strip).reject(&:empty?)
+
+    if scheme_name.nil?
+      auth_entries = node.auth
+      if auth_entries.empty?
+        Rage::OpenAPI.__log_warn "no auth schemes found for `@auth_scope` shorthand at #{location_msg(comment)}; define an @auth tag on the controller first"
+        return
+      elsif auth_entries.length > 1
+        Rage::OpenAPI.__log_warn "ambiguous `@auth_scope` shorthand at #{location_msg(comment)}; multiple auth schemes found, specify the scheme name explicitly"
+        return
+      end
+      scheme_name = auth_entries[0][:name]
+    else
+      auth_names = node.auth.map { |e| e[:name] }
+      unless auth_names.include?(scheme_name)
+        Rage::OpenAPI.__log_warn "unknown scheme `#{scheme_name}` in `@auth_scope` tag at #{location_msg(comment)}; available schemes: #{auth_names.join(", ")}"
+        return
+      end
+    end
+
+    if node.auth_scopes.key?(scheme_name)
+      Rage::OpenAPI.__log_warn "duplicate `@auth_scope` tag for `#{scheme_name}` detected at #{location_msg(comment)}"
+      return
+    end
+
+    node.auth_scopes[scheme_name] = scopes
   end
 
   def parse_param_tag(expression, node, comment)

--- a/lib/rage/openapi/parser.rb
+++ b/lib/rage/openapi/parser.rb
@@ -260,34 +260,39 @@ class Rage::OpenAPI::Parser
   end
 
   def parse_auth_scope_tag(expression, node, comment)
-    parts = expression.split(" ")
-    # parts[0] = "@auth_scope"
-    # parts[1] = scheme name or start of "[scopes]"
-    # parts[1..] or parts[2..] = scopes portion
+    content = expression.split(" ", 2)[1]
 
-    if parts.length < 2
+    unless content
       Rage::OpenAPI.__log_warn "invalid `@auth_scope` tag detected at #{location_msg(comment)}; expected [scope1, scope2] syntax"
       return
     end
 
-    if parts[1].start_with?("[")
+    parsed = YAML.safe_load(content)
+
+    if parsed.is_a?(Array)
       scheme_name = nil
-      scopes_str = parts[1..].join(" ")
-    else
-      scheme_name = parts[1]
-      if parts[2].nil?
+      scopes = parsed.map(&:to_s)
+    elsif parsed.is_a?(String)
+      scheme_name = parsed.split(" ", 2)[0]
+      scopes_str = content.split(" ", 2)[1]
+
+      unless scopes_str
         Rage::OpenAPI.__log_warn "invalid `@auth_scope` tag detected at #{location_msg(comment)}; expected [scope1, scope2] syntax"
         return
       end
-      scopes_str = parts[2..].join(" ")
-    end
 
-    unless scopes_str =~ /^\[([^\]]*)\]$/
+      scopes = YAML.safe_load(scopes_str)
+
+      unless scopes.is_a?(Array)
+        Rage::OpenAPI.__log_warn "invalid `@auth_scope` tag detected at #{location_msg(comment)}; expected [scope1, scope2] syntax"
+        return
+      end
+
+      scopes = scopes.map(&:to_s)
+    else
       Rage::OpenAPI.__log_warn "invalid `@auth_scope` tag detected at #{location_msg(comment)}; expected [scope1, scope2] syntax"
       return
     end
-
-    scopes = $1.split(",").map(&:strip).reject(&:empty?)
 
     if scheme_name.nil?
       auth_entries = node.auth

--- a/spec/openapi/builder/auth_spec.rb
+++ b/spec/openapi/builder/auth_spec.rb
@@ -598,6 +598,258 @@ RSpec.describe Rage::OpenAPI::Builder do
       end
     end
 
+    context "with @auth_scope and scheme ID" do
+      before do
+        allow(RageController::API).to receive(:__before_action_exists?).with(:authenticate_user).and_return(true)
+        allow(RageController::API).to receive(:__before_actions_for).with(:update).and_return([{ name: :authenticate_user }])
+
+        allow(Rage::OpenAPI).to receive(:__shared_components).and_return(YAML.safe_load(<<~YAML
+          components:
+            securitySchemes:
+              OAuth2:
+                type: oauth2
+                flows:
+                  authorizationCode:
+                    authorizationUrl: https://example.com/oauth/authorize
+                    tokenUrl: https://example.com/oauth/token
+                    scopes:
+                      read:users: Read users
+                      write:users: Write users
+        YAML
+                                                                                       ))
+      end
+
+      let_class("UsersController", parent: RageController::API) do
+        <<~'RUBY'
+          # @auth authenticate_user #/components/securitySchemes/OAuth2
+
+          # @auth_scope OAuth2 [read:users, write:users]
+          def update
+          end
+        RUBY
+      end
+
+      let(:routes) do
+        { "PUT /users/:id" => "UsersController#update" }
+      end
+
+      it "returns correct schema" do
+        expect(subject).to eq({ "openapi" => "3.0.0", "info" => { "version" => "1.0.0", "title" => "Rage" }, "components" => { "securitySchemes" => { "OAuth2" => { "type" => "oauth2", "flows" => { "authorizationCode" => { "authorizationUrl" => "https://example.com/oauth/authorize", "tokenUrl" => "https://example.com/oauth/token", "scopes" => { "read:users" => "Read users", "write:users" => "Write users" } } } } } }, "tags" => [{ "name" => "Users" }], "paths" => { "/users/{id}" => { "parameters" => [{ "in" => "path", "name" => "id", "required" => true, "description" => "", "schema" => { "type" => "integer" } }], "put" => { "summary" => "", "description" => "", "deprecated" => false, "security" => [{ "OAuth2" => ["read:users", "write:users"] }], "tags" => ["Users"], "responses" => { "200" => { "description" => "" } } } } } })
+      end
+    end
+
+    context "with @auth_scope shorthand" do
+      before do
+        allow(RageController::API).to receive(:__before_action_exists?).with(:authenticate!).and_return(true)
+        allow(RageController::API).to receive(:__before_actions_for).with(:index).and_return([{ name: :authenticate! }])
+
+        allow(Rage::OpenAPI).to receive(:__shared_components).and_return(YAML.safe_load(<<~YAML
+          components:
+            securitySchemes:
+              OAuth2:
+                type: oauth2
+                flows:
+                  authorizationCode:
+                    authorizationUrl: https://example.com/oauth/authorize
+                    tokenUrl: https://example.com/oauth/token
+                    scopes:
+                      read:users: Read users
+        YAML
+                                                                                       ))
+      end
+
+      let_class("UsersController", parent: RageController::API) do
+        <<~'RUBY'
+          # @auth authenticate! #/components/securitySchemes/OAuth2
+
+          # @auth_scope [read:users]
+          def index
+          end
+        RUBY
+      end
+
+      let(:routes) do
+        { "GET /users" => "UsersController#index" }
+      end
+
+      it "returns correct schema" do
+        expect(subject).to eq({ "openapi" => "3.0.0", "info" => { "version" => "1.0.0", "title" => "Rage" }, "components" => { "securitySchemes" => { "OAuth2" => { "type" => "oauth2", "flows" => { "authorizationCode" => { "authorizationUrl" => "https://example.com/oauth/authorize", "tokenUrl" => "https://example.com/oauth/token", "scopes" => { "read:users" => "Read users" } } } } } }, "tags" => [{ "name" => "Users" }], "paths" => { "/users" => { "get" => { "summary" => "", "description" => "", "deprecated" => false, "security" => [{ "OAuth2" => ["read:users"] }], "tags" => ["Users"], "responses" => { "200" => { "description" => "" } } } } } })
+      end
+    end
+
+    context "with @auth_scope shorthand and ambiguous schemes" do
+      before do
+        allow(RageController::API).to receive(:__before_action_exists?).with(:auth_internal).and_return(true)
+        allow(RageController::API).to receive(:__before_action_exists?).with(:auth_external).and_return(true)
+        allow(RageController::API).to receive(:__before_actions_for).with(:index).and_return([
+          { name: :auth_internal },
+          { name: :auth_external }
+        ])
+      end
+
+      let_class("UsersController", parent: RageController::API) do
+        <<~'RUBY'
+          # @auth auth_internal
+          # @auth auth_external
+
+          # @auth_scope [read:users]
+          def index
+          end
+        RUBY
+      end
+
+      let(:routes) do
+        { "GET /users" => "UsersController#index" }
+      end
+
+      it "logs error" do
+        expect(Rage::OpenAPI).to receive(:__log_warn).with(/ambiguous `@auth_scope` shorthand/)
+        subject
+      end
+
+      it "returns schema without scopes" do
+        expect(subject.dig("paths", "/users", "get", "security")).to eq([{ "auth_internal" => [] }, { "auth_external" => [] }])
+      end
+    end
+
+    context "with @auth_scope and unknown scheme" do
+      before do
+        allow(RageController::API).to receive(:__before_action_exists?).with(:authenticate!).and_return(true)
+        allow(RageController::API).to receive(:__before_actions_for).with(:index).and_return([{ name: :authenticate! }])
+      end
+
+      let_class("UsersController", parent: RageController::API) do
+        <<~'RUBY'
+          # @auth authenticate!
+
+          # @auth_scope UnknownScheme [read:users]
+          def index
+          end
+        RUBY
+      end
+
+      let(:routes) do
+        { "GET /users" => "UsersController#index" }
+      end
+
+      it "logs error" do
+        expect(Rage::OpenAPI).to receive(:__log_warn).with(/unknown scheme `UnknownScheme`/)
+        subject
+      end
+
+      it "returns schema without scopes" do
+        expect(subject.dig("paths", "/users", "get", "security")).to eq([{ "authenticate" => [] }])
+      end
+    end
+
+    context "with duplicate @auth_scope" do
+      before do
+        allow(RageController::API).to receive(:__before_action_exists?).with(:authenticate!).and_return(true)
+        allow(RageController::API).to receive(:__before_actions_for).with(:index).and_return([{ name: :authenticate! }])
+
+        allow(Rage::OpenAPI).to receive(:__shared_components).and_return(YAML.safe_load(<<~YAML
+          components:
+            securitySchemes:
+              OAuth2:
+                type: oauth2
+                flows:
+                  authorizationCode:
+                    authorizationUrl: https://example.com/oauth/authorize
+                    tokenUrl: https://example.com/oauth/token
+                    scopes: {}
+        YAML
+                                                                                       ))
+      end
+
+      let_class("UsersController", parent: RageController::API) do
+        <<~'RUBY'
+          # @auth authenticate! #/components/securitySchemes/OAuth2
+
+          # @auth_scope OAuth2 [read:users]
+          # @auth_scope OAuth2 [write:users]
+          def index
+          end
+        RUBY
+      end
+
+      let(:routes) do
+        { "GET /users" => "UsersController#index" }
+      end
+
+      it "logs error" do
+        expect(Rage::OpenAPI).to receive(:__log_warn).with(/duplicate `@auth_scope` tag for `OAuth2`/)
+        subject
+      end
+    end
+
+    context "with @auth_scope and no auth schemes" do
+      let_class("UsersController", parent: RageController::API) do
+        <<~'RUBY'
+          # @auth_scope [read:users]
+          def index
+          end
+        RUBY
+      end
+
+      let(:routes) do
+        { "GET /users" => "UsersController#index" }
+      end
+
+      it "logs error" do
+        expect(Rage::OpenAPI).to receive(:__log_warn).with(/no auth schemes found/)
+        subject
+      end
+    end
+
+    context "with @auth_scope on one endpoint and not another" do
+      before do
+        allow(RageController::API).to receive(:__before_action_exists?).with(:authenticate!).and_return(true)
+        allow(RageController::API).to receive(:__before_actions_for).with(:index).and_return([{ name: :authenticate! }])
+        allow(RageController::API).to receive(:__before_actions_for).with(:create).and_return([{ name: :authenticate! }])
+
+        allow(Rage::OpenAPI).to receive(:__shared_components).and_return(YAML.safe_load(<<~YAML
+          components:
+            securitySchemes:
+              OAuth2:
+                type: oauth2
+                flows:
+                  authorizationCode:
+                    authorizationUrl: https://example.com/oauth/authorize
+                    tokenUrl: https://example.com/oauth/token
+                    scopes:
+                      read:users: Read users
+                      write:users: Write users
+        YAML
+                                                                                       ))
+      end
+
+      let_class("UsersController", parent: RageController::API) do
+        <<~'RUBY'
+          # @auth authenticate! #/components/securitySchemes/OAuth2
+
+          # @auth_scope OAuth2 [read:users]
+          def index
+          end
+
+          # @auth_scope OAuth2 [read:users, write:users]
+          def create
+          end
+        RUBY
+      end
+
+      let(:routes) do
+        {
+          "GET /users" => "UsersController#index",
+          "POST /users" => "UsersController#create"
+        }
+      end
+
+      it "returns correct per-endpoint scopes" do
+        expect(subject.dig("paths", "/users", "get", "security")).to eq([{ "OAuth2" => ["read:users"] }])
+        expect(subject.dig("paths", "/users", "post", "security")).to eq([{ "OAuth2" => ["read:users", "write:users"] }])
+      end
+    end
+
     context "with no before_actions" do
       let_class("UsersController", parent: RageController::API) do
         <<~'RUBY'


### PR DESCRIPTION
This PR adds the support for the per endpoint OAuth2/OpenID scopes.
Closes #269 

New support syntax:
```
# @auth_scope OAuth2 [read:users, write:users]
def update
end

-- ShortHand --

# @auth_scope [read:users, write:users]
def update
end
```
1. Add `@auth_scope` tag support for specifying per-endpoint OAuth2/OpenID scopes
2. Two syntax forms: `@auth_scope OAuth2 [read:users, write:users]` (with scheme ID) and `@auth_scope [read:users]` (shorthand when single auth scheme exists)
3. Produces `"security": [{ "OAuth2": ["read:users", "write:users"] }]` instead of hardcoded empty scopes

**Changes**
- **lib/rage/openapi/nodes/method.rb** - Added `auth_scopes` attribute to store per-endpoint scopes
- **lib/rage/openapi/parser.rb** - Added `@auth_scope` parsing in `parse_method_comments` with validation (unknown scheme, ambiguous shorthand, duplicates)
- **lib/rage/openapi/converter.rb** - Replaced `{ auth_name => [] }` with `{ auth_name => node.auth_scopes.fetch(auth_name, []) }`
- **spec/openapi/builder/auth_spec.rb** - Added unit tests for scheme ID syntax, shorthand, ambiguous shorthand, unknown scheme, duplicates, no auth schemes, and per-endpoint mixed scopes