### PR TITLE
Add tests for Deferred log context capture and backward-compatible restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+### Added
+- [Deferred] Add tests for log context capture and backward-compatible restore by [@jsxs0](https://github.com/jsxs0) (#274).
 
 ### Fixed
 - [SSE] Ensure connection is closed for single-value SSE streams by [@jsxs0](https://github.com/jsxs0) (#264).

--- a/spec/deferred/context_spec.rb
+++ b/spec/deferred/context_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Rage::Deferred::Context do
 
     after do
       Fiber[:__rage_logger_tags] = nil
+      Fiber[:__rage_logger_context] = nil
     end
 
     context "when rage_logger is not set" do
@@ -28,11 +29,17 @@ RSpec.describe Rage::Deferred::Context do
     context "when rage_logger is set" do
       before do
         Fiber[:__rage_logger_tags] = ["req-123", "test"]
+        Fiber[:__rage_logger_context] = { user_id: 42 }
       end
 
       it "builds context including log tags" do
         context = described_class.build(task, args, kwargs)
         expect(context[4]).to eq(["req-123", "test"])
+      end
+
+      it "builds context including log context" do
+        context = described_class.build(task, args, kwargs)
+        expect(context[5]).to eq({ user_id: 42 })
       end
     end
   end

--- a/spec/deferred/task_spec.rb
+++ b/spec/deferred/task_spec.rb
@@ -284,6 +284,29 @@ RSpec.describe Rage::Deferred::Task do
       end
     end
 
+    context "when log tags are in the legacy string format" do
+      before do
+        allow(Rage::Deferred::Context).to receive(:get_log_tags).with(context).and_return("old-request-id")
+        allow(Rage::Deferred::Context).to receive(:get_log_context).with(context).and_return(nil)
+        allow(task).to receive(:perform)
+      end
+
+      after do
+        Fiber[:__rage_logger_tags] = nil
+        Fiber[:__rage_logger_context] = nil
+      end
+
+      it "wraps the string in an array" do
+        task.__perform(context)
+        expect(Fiber[:__rage_logger_tags]).to eq(["old-request-id"])
+      end
+
+      it "defaults log context to an empty hash" do
+        task.__perform(context)
+        expect(Fiber[:__rage_logger_context]).to eq({})
+      end
+    end
+
     context "when request_id is not present" do
       before do
         allow(Rage::Deferred::Context).to receive(:get_log_tags).with(context).and_return(nil)


### PR DESCRIPTION
### Summary

While working on the SSE context propagation tests in #267, I traced how log context flows across fiber boundaries in the Deferred system, specifically `Context.build` (capture) and `restore_log_info` in `Task` (restore). I noticed two paths without test coverage:

**1. `Context.build` log context capture**

The `"when rage_logger is set"` context verified `context[4]` (log tags) but not `context[5]` (log context). Added a test confirming `Fiber[:__rage_logger_context]` is captured, and fixed the `after` block to clean up both fiber-locals.

**2. `restore_log_info` backward compatibility**

`restore_log_info` has three branches: the current Array format, a legacy string format (older versions stored `request_id` as a plain string at index 4), and nil. The Array and nil branches were tested, but the legacy string path, which wraps the value into an array and defaults context to `{}`, had no coverage.

### Test plan

```
bundle exec rspec spec/deferred/context_spec.rb spec/deferred/task_spec.rb
58 examples, 0 failures
```