### PR TITLE
Add the `form_actions` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [Deferred] Add tests for log context capture and backward-compatible restore by [@jsxs0](https://github.com/jsxs0) (#274).
 - [OpenAPI] Add support for per-endpoint OAuth2/OpenID scopes via `@auth_scope` tag by [@Piyush-Goenka](https://github.com/Piyush-Goenka) (#272).
 - Reuse `define_dynamic_method` and `define_maybe_yield` methods in `RageController::API` from `Rage::Internal` by [@numice](https://github.com/numice) (#273).
+- Add the `form_actions` router configuration (#278).
 
 ## [1.23.0] - 2026-04-15
 

--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -265,6 +265,14 @@ class Rage::Configuration
   end
   # @!endgroup
 
+  # @!group Router Configuration
+  # Allows configuring router settings.
+  # @return [Rage::Configuration::Router]
+  def router
+    @router ||= Router.new
+  end
+  # @!endgroup
+
   # @private
   def pubsub
     @pubsub ||= PubSub.new
@@ -986,6 +994,17 @@ class Rage::Configuration
     #       config.session.key = "_myapp_session"
     #     end
     attr_accessor :key
+  end
+
+  class Router
+    # @!attribute form_actions
+    #   Enable the automatic generation of `new` and `edit` routes via resource helpers.
+    #   @return [Boolean]
+    #   @example Enable form actions
+    #     Rage.configure do
+    #       config.router.form_actions = true
+    #     end
+    attr_accessor :form_actions
   end
 
   # @private

--- a/lib/rage/router/dsl.rb
+++ b/lib/rage/router/dsl.rb
@@ -62,6 +62,8 @@ class Rage::Router::DSL
       @router = router
 
       @default_actions = %i(index create show update destroy)
+      @default_actions += %i(new edit) if Rage.config.router.form_actions
+
       @default_match_methods = %i(get post put patch delete head)
       @scope_opts = %i(module path controller)
 
@@ -359,6 +361,8 @@ class Rage::Router::DSL
         get("/:#{_param}", to: "#{resource}#show") if actions.include?(:show)
         patch("/:#{_param}", to: "#{resource}#update") if actions.include?(:update)
         put("/:#{_param}", to: "#{resource}#update") if actions.include?(:update)
+        get("/new", to: "#{resource}#new") if actions.include?(:new)
+        get("/:#{_param}/edit", to: "#{resource}#edit") if actions.include?(:edit)
         delete("/:#{_param}", to: "#{resource}#destroy") if actions.include?(:destroy)
 
         scope(path: ":#{to_singular(resource)}_#{_param}", controller: resource, &block) if block
@@ -379,7 +383,6 @@ class Rage::Router::DSL
     #   # PATCH  /photo => photos#update
     #   # PUT    /photo => photos#update
     #   # DELETE /photo => photos#destroy
-    # @note This helper doesn't generate the `new` and `edit` routes.
     # @note :param is not supported for singular resources.
     def resource(*_resources, **opts, &block)
       if _resources.length > 1
@@ -389,7 +392,7 @@ class Rage::Router::DSL
 
       _module, _path, _only, _except = opts.values_at(:module, :path, :only, :except)
 
-      actions = __filter_actions(%i(create show update destroy), _only, _except)
+      actions = __filter_actions(@default_actions - [:index], _only, _except)
 
       resource_name = _resources[0].to_s
       controller_name = to_plural(resource_name)
@@ -398,6 +401,8 @@ class Rage::Router::DSL
         get("/", to: "#{controller_name}#show") if actions.include?(:show)
         patch("/", to: "#{controller_name}#update") if actions.include?(:update)
         put("/", to: "#{controller_name}#update") if actions.include?(:update)
+        get("/new", to: "#{controller_name}#new") if actions.include?(:new)
+        get("/edit", to: "#{controller_name}#edit") if actions.include?(:edit)
         delete("/", to: "#{controller_name}#destroy") if actions.include?(:destroy)
 
         scope(controller: controller_name, &block) if block

--- a/spec/router/dsl_spec.rb
+++ b/spec/router/dsl_spec.rb
@@ -1076,4 +1076,104 @@ RSpec.describe Rage::Router::DSL do
       expect { dsl.draw { get("test", action: "index") } }.to raise_error(/Could not derive/)
     end
   end
+
+  context "with form_actions enabled" do
+    before do
+      allow(Rage.config.router).to receive(:form_actions).and_return(true)
+    end
+
+    context "with resources" do
+      it "creates new and edit routes" do
+        expect(router).to receive(:on).with("GET", "/photos", "photos#index", instance_of(Hash))
+        expect(router).to receive(:on).with("POST", "/photos", "photos#create", instance_of(Hash))
+        expect(router).to receive(:on).with("GET", "/photos/:id", "photos#show", instance_of(Hash))
+        expect(router).to receive(:on).with("PATCH", "/photos/:id", "photos#update", instance_of(Hash))
+        expect(router).to receive(:on).with("PUT", "/photos/:id", "photos#update", instance_of(Hash))
+        expect(router).to receive(:on).with("GET", "/photos/new", "photos#new", instance_of(Hash))
+        expect(router).to receive(:on).with("GET", "/photos/:id/edit", "photos#edit", instance_of(Hash))
+        expect(router).to receive(:on).with("DELETE", "/photos/:id", "photos#destroy", instance_of(Hash))
+
+        dsl.draw do
+          resources :photos
+        end
+      end
+
+      it "respects the :only option for new and edit" do
+        expect(router).to receive(:on).with("GET", "/photos/new", "photos#new", instance_of(Hash))
+        expect(router).to receive(:on).with("GET", "/photos/:id/edit", "photos#edit", instance_of(Hash))
+
+        dsl.draw do
+          resources :photos, only: %i(new edit)
+        end
+      end
+
+      it "respects the :except option for new and edit" do
+        expect(router).to receive(:on).with("GET", "/photos", "photos#index", instance_of(Hash))
+        expect(router).to receive(:on).with("POST", "/photos", "photos#create", instance_of(Hash))
+        expect(router).to receive(:on).with("GET", "/photos/:id", "photos#show", instance_of(Hash))
+        expect(router).to receive(:on).with("PATCH", "/photos/:id", "photos#update", instance_of(Hash))
+        expect(router).to receive(:on).with("PUT", "/photos/:id", "photos#update", instance_of(Hash))
+        expect(router).to receive(:on).with("DELETE", "/photos/:id", "photos#destroy", instance_of(Hash))
+
+        dsl.draw do
+          resources :photos, except: %i(new edit)
+        end
+      end
+
+      it "uses custom param for edit route" do
+        expect(router).to receive(:on).with("GET", "/photos/new", "photos#new", instance_of(Hash))
+        expect(router).to receive(:on).with("GET", "/photos/:slug/edit", "photos#edit", instance_of(Hash))
+
+        dsl.draw do
+          resources :photos, only: %i(new edit), param: :slug
+        end
+      end
+    end
+
+    context "with resource" do
+      it "creates new and edit routes" do
+        expect(router).to receive(:on).with("POST", "/photo", "photos#create", instance_of(Hash))
+        expect(router).to receive(:on).with("GET", "/photo", "photos#show", instance_of(Hash))
+        expect(router).to receive(:on).with("PATCH", "/photo", "photos#update", instance_of(Hash))
+        expect(router).to receive(:on).with("PUT", "/photo", "photos#update", instance_of(Hash))
+        expect(router).to receive(:on).with("GET", "/photo/new", "photos#new", instance_of(Hash))
+        expect(router).to receive(:on).with("GET", "/photo/edit", "photos#edit", instance_of(Hash))
+        expect(router).to receive(:on).with("DELETE", "/photo", "photos#destroy", instance_of(Hash))
+
+        dsl.draw do
+          resource :photo
+        end
+      end
+
+      it "respects the :only option for new and edit" do
+        expect(router).to receive(:on).with("GET", "/photo/new", "photos#new", instance_of(Hash))
+        expect(router).to receive(:on).with("GET", "/photo/edit", "photos#edit", instance_of(Hash))
+
+        dsl.draw do
+          resource :photo, only: %i(new edit)
+        end
+      end
+
+      it "respects the :except option for new and edit" do
+        expect(router).to receive(:on).with("POST", "/photo", "photos#create", instance_of(Hash))
+        expect(router).to receive(:on).with("GET", "/photo", "photos#show", instance_of(Hash))
+        expect(router).to receive(:on).with("PATCH", "/photo", "photos#update", instance_of(Hash))
+        expect(router).to receive(:on).with("PUT", "/photo", "photos#update", instance_of(Hash))
+        expect(router).to receive(:on).with("DELETE", "/photo", "photos#destroy", instance_of(Hash))
+
+        dsl.draw do
+          resource :photo, except: %i(new edit)
+        end
+      end
+
+      it "creates routes under module" do
+        expect(router).to receive(:on).with("GET", "/photo/new", "api/photos#new", instance_of(Hash))
+        expect(router).to receive(:on).with("GET", "/photo/edit", "api/photos#edit", instance_of(Hash))
+
+        dsl.draw do
+          resource :photo, only: %i(new edit), module: "api"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This pull request adds support for automatically generating `new` and `edit` routes in the router's `resources` and `resource` helpers, controlled by a new `form_actions` configuration setting. If enabled, the router will include these routes by default.