### PR TITLE
Upgrade the checkout action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ext.yml
+++ b/.github/workflows/ext.yml
@@ -14,7 +14,7 @@ jobs:
           - '4.0'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           - '3.4'
           - '4.0'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Code Style
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Docs
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     name: CLI
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     name: CLI DB
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use a newer version of the `actions/checkout` action. The change is made across several workflow files to ensure consistency and to benefit from the latest features and security patches.