### PR TITLE
Rename the `error_handlers` config to `error_reporters`

### DIFF
--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -219,11 +219,11 @@ class Rage::Configuration
   end
   # @!endgroup
 
-  # @!group Error Handler Configuration
-  # Allows configuring error handlers.
-  # @return [Rage::Configuration::ErrorHandlers]
-  def error_handlers
-    @error_handlers ||= ErrorHandlers.new
+  # @!group Error Reporter Configuration
+  # Allows configuring error reporters.
+  # @return [Rage::Configuration::ErrorReporters]
+  def error_reporters
+    @error_reporters ||= ErrorReporters.new
   end
   # @!endgroup
 
@@ -394,7 +394,7 @@ class Rage::Configuration
     end
   end
 
-  class ErrorHandlers
+  class ErrorReporters
     # @private
     def initialize
       @objects = []
@@ -405,46 +405,46 @@ class Rage::Configuration
       @objects.dup
     end
 
-    # Add a new error handler.
-    # Error handlers should respond to `#call` and accept one of:
+    # Add a new error reporter.
+    # Error reporters should respond to `#call` and accept one of:
     # - `call(exception)`
     # - `call(exception, context: {})`
     #
-    # @param handler [#call]
+    # @param reporter [#call]
     # @return [self]
     # @example
     #   Rage.configure do
-    #     config.error_handlers << SentryReporter.new
+    #     config.error_reporters << SentryReporter.new
     #   end
-    def <<(handler)
-      validate_input!(handler)
-      return self if @objects.include?(handler)
+    def <<(reporter)
+      validate_input!(reporter)
+      return self if @objects.include?(reporter)
 
-      @objects << handler
-      Rage::Errors.__send__(:__register_reporter, handler)
+      @objects << reporter
+      Rage::Errors.__send__(:__register_reporter, reporter)
 
       self
     end
 
     alias_method :push, :<<
 
-    # Remove an error handler.
-    # @param handler [#call] the handler to remove
+    # Remove an error reporter.
+    # @param reporter [#call] the reporter to remove
     # @example
-    #   handler = SentryReporter.new
+    #   reporter = SentryReporter.new
     #   Rage.configure do
-    #     config.error_handlers.delete(handler)
+    #     config.error_reporters.delete(reporter)
     #   end
-    def delete(handler)
-      deleted = @objects.delete(handler)
-      Rage::Errors.__send__(:__unregister_reporter, handler) if deleted
+    def delete(reporter)
+      deleted = @objects.delete(reporter)
+      Rage::Errors.__send__(:__unregister_reporter, reporter) if deleted
       deleted
     end
 
     private
 
-    def validate_input!(handler)
-      raise ArgumentError, "error handler must respond to #call" unless handler.respond_to?(:call)
+    def validate_input!(reporter)
+      raise ArgumentError, "error reporter must respond to #call" unless reporter.respond_to?(:call)
     end
   end
 

--- a/lib/rage/errors.rb
+++ b/lib/rage/errors.rb
@@ -32,7 +32,7 @@ module Rage::Errors
 
     # @private
     def __register_reporter(reporter)
-      raise ArgumentError, "error handler must respond to #call" unless reporter.respond_to?(:call)
+      raise ArgumentError, "error reporter must respond to #call" unless reporter.respond_to?(:call)
 
       reporter_id = @next_reporter_id
       @next_reporter_id += 1

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -12,31 +12,31 @@ RSpec.describe Rage::Errors do
     described_class.instance_variable_set(:@next_reporter_id, original_next_reporter_id)
   end
 
-  let(:error_handlers) { Rage::Configuration.new.error_handlers }
+  let(:error_reporters) { Rage::Configuration.new.error_reporters }
 
   describe "configuration integration" do
-    it "is available via config.error_handlers" do
-      expect(Rage::Configuration.new.error_handlers).to be_an_instance_of(Rage::Configuration::ErrorHandlers)
+    it "is available via config.error_reporters" do
+      expect(Rage::Configuration.new.error_reporters).to be_an_instance_of(Rage::Configuration::ErrorReporters)
     end
 
     it "is available via Rage.errors" do
       expect(Rage.errors).to eq(described_class)
     end
 
-    it "requires error handlers to respond to #call" do
+    it "requires error reporters to respond to #call" do
       expect {
-        error_handlers << Object.new
-      }.to raise_error(ArgumentError, "error handler must respond to #call")
+        error_reporters << Object.new
+      }.to raise_error(ArgumentError, "error reporter must respond to #call")
     end
 
-    it "allows removing a registered error handler" do
+    it "allows removing a registered error reporter" do
       call_count = 0
       reporter = Class.new do
         define_method(:call) { |_exception| call_count += 1 }
       end.new
 
-      error_handlers << reporter
-      error_handlers.delete(reporter)
+      error_reporters << reporter
+      error_reporters.delete(reporter)
 
       described_class.report(StandardError.new("test"))
 
@@ -65,7 +65,7 @@ RSpec.describe Rage::Errors do
       end.new
 
       error = StandardError.new("test")
-      error_handlers << reporter
+      error_reporters << reporter
       described_class.report(error, context: { user_id: 42 })
 
       expect(reporter.exception).to be(error)
@@ -82,7 +82,7 @@ RSpec.describe Rage::Errors do
       end.new
 
       error = StandardError.new("test")
-      error_handlers << reporter
+      error_reporters << reporter
       described_class.report(error, context: { user_id: 42 })
 
       expect(reporter.exception).to be(error)
@@ -101,7 +101,7 @@ RSpec.describe Rage::Errors do
       error = StandardError.new("test")
       expect(error.backtrace).to be_nil
 
-      error_handlers << reporter
+      error_reporters << reporter
       described_class.report(error)
 
       expect(reporter.exception.backtrace).to be_an(Array)
@@ -124,8 +124,8 @@ RSpec.describe Rage::Errors do
       end.new
 
       error = StandardError.new("test")
-      error_handlers << failed_reporter
-      error_handlers << successful_reporter
+      error_reporters << failed_reporter
+      error_reporters << successful_reporter
 
       described_class.report(error)
 
@@ -140,7 +140,7 @@ RSpec.describe Rage::Errors do
       end.new
 
       error = StandardError.new("test")
-      error_handlers << reporter
+      error_reporters << reporter
 
       described_class.report(error)
       described_class.report(error)


### PR DESCRIPTION
This pull request refactors the error handling configuration to use the term "error reporters" instead of "error handlers" throughout the codebase. The goal is to clarify the responsibility of these objects and improve naming consistency.

ref #275 