### PR TITLE
[OpenAPI]: Extend @response / @request tag syntax to accept serializer options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Added
 
 - Implement `FiberScheduler#fiber_interrupt` (#283).
-- Add Blueprinter parser scaffold and class detection (#287)
+- [OpenAPI] Add Blueprinter parser scaffold and class detection (#287)
+- [OpenAPI] Extend @response / @request tag syntax to accept serializer options (#299)
 
 ## [1.24.0] - 2026-05-12
 

--- a/lib/rage/openapi/openapi.rb
+++ b/lib/rage/openapi/openapi.rb
@@ -128,14 +128,15 @@ module Rage::OpenAPI
   end
 
   # @private
+  # @return [Array<Boolean, String, Hash>] a tuple of (is_collection, serializer, args)
   def self.__parse_serializer_args(str)
     is_collection, inner = __try_parse_collection(str)
 
     if is_collection
       # discard is_collection since we already know this is a collection from the outer call
-      _, clean_inner, options = __parse_serializer_args(inner)
-      if options.any?
-        [is_collection, clean_inner, options]
+      _, clean_inner, args = __parse_serializer_args(inner)
+      if args.any?
+        [is_collection, clean_inner, args]
       else
         [is_collection, clean_inner, {}]
       end

--- a/lib/rage/openapi/openapi.rb
+++ b/lib/rage/openapi/openapi.rb
@@ -128,6 +128,36 @@ module Rage::OpenAPI
   end
 
   # @private
+  def self.__parse_serializer_args(str)
+    is_collection, inner = __try_parse_collection(str)
+
+    if is_collection
+      # discard is_collection since we already know this is a collection from the outer call
+      _, clean_inner, options = __parse_serializer_args(inner)
+      if options.any?
+        [is_collection, clean_inner, options]
+      else
+        [is_collection, clean_inner, {}]
+      end
+    elsif str =~ /^([\w:]+)\(([^)]+)\)$/
+      [is_collection, $1, __parse_keywords($2)]
+    else
+      [is_collection, str, {}]
+    end
+  end
+
+  # @private
+  def self.__parse_keywords(str)
+    return {} if str.nil? || str.empty?
+
+    str.split(",").each_with_object({}) do |part, hash|
+      option = YAML.load(part)
+      return nil unless option.is_a?(Hash)
+      hash.merge!(option.transform_keys!(&:to_sym))
+    end
+  end
+
+  # @private
   def self.__module_parent(klass)
     klass.name =~ /::[^:]+\z/ ? Object.const_get($`) : Object
   rescue NameError

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -7,7 +7,7 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
   end
 
   def known_definition?(str)
-    _, str = Rage::OpenAPI.__try_parse_collection(str)
+    _, str, _ = Rage::OpenAPI.__parse_serializer_args(str)
     defined?(Blueprinter::Base) && @namespace.const_get(str).ancestors.include?(Blueprinter::Base)
   rescue NameError
     false

--- a/spec/openapi/openapi_spec.rb
+++ b/spec/openapi/openapi_spec.rb
@@ -179,6 +179,11 @@ RSpec.describe Rage::OpenAPI do
       let(:str) { "view: :extended, root: :user" }
       it { is_expected.to eq({ view: :extended, root: :user }) }
     end
+
+    context "with an invalid option (not a key value pair)" do
+      let(:str) { "extended" }
+      it { is_expected.to be_nil }
+    end
   end
 
   describe ".__module_parent" do

--- a/spec/openapi/openapi_spec.rb
+++ b/spec/openapi/openapi_spec.rb
@@ -73,6 +73,114 @@ RSpec.describe Rage::OpenAPI do
     end
   end
 
+  describe ".__parse_serializer_options" do
+    subject { described_class.__parse_serializer_args(str) }
+
+    context "with a plain class name" do
+      let(:str) { "UserBlueprint" }
+      it { is_expected.to eq([false, "UserBlueprint", {}]) }
+    end
+
+    context "with a view option" do
+      let(:str) { "UserBlueprint(view: :extended)" }
+      it { is_expected.to eq([false, "UserBlueprint", { view: :extended }]) }
+    end
+
+    context "with multiple options" do
+      let(:str) { "UserBlueprint(view: :extended, root: :user)" }
+      it { is_expected.to eq([false, "UserBlueprint", { view: :extended, root: :user }]) }
+    end
+
+    context "with a collection using square brackets without options" do
+      let(:str) { "[UserBlueprint]" }
+      it { is_expected.to eq([true, "UserBlueprint", {}]) }
+    end
+
+    context "with a collection using Array syntax without options" do
+      let(:str) { "Array<UserBlueprint>" }
+      it { is_expected.to eq([true, "UserBlueprint", {}]) }
+    end
+
+    context "with a collection using square brackets with options" do
+      let(:str) { "[UserBlueprint(view: :extended)]" }
+      it { is_expected.to eq([true, "UserBlueprint", { view: :extended }]) }
+    end
+
+    context "with a collection using Array syntax with options" do
+      let(:str) { "Array<UserBlueprint(view: :extended)>" }
+      it { is_expected.to eq([true, "UserBlueprint", { view: :extended }]) }
+    end
+
+    context "with unknown options" do
+      let(:str) { "UserBlueprint(unknown_option: :something)" }
+
+      it "does not raise" do
+        expect { subject }.not_to raise_error
+      end
+
+      it { is_expected.to eq([false, "UserBlueprint", { unknown_option: :something }]) }
+    end
+
+    context "with existing Alba syntax unchanged" do
+      let(:str) { "UserResource" }
+      it { is_expected.to eq([false, "UserResource", {}]) }
+    end
+
+    context "with a collection using Array syntax with multiple options" do
+      let(:str) { "Array<UserBlueprint(view: :extended, root: :user)>" }
+      it { is_expected.to eq([true, "UserBlueprint", { view: :extended, root: :user }]) }
+    end
+
+    context "with a plain string value without quotes" do
+      let(:str) { "UserBlueprint(root: users)" }
+      it { is_expected.to eq([false, "UserBlueprint", { root: "users" }]) }
+    end
+  end
+
+  describe ".__parse_keywords" do
+    subject { described_class.__parse_keywords(str) }
+
+    context "with nil" do
+      let(:str) { nil }
+      it { is_expected.to eq({}) }
+    end
+
+    context "with empty string" do
+      let(:str) { "" }
+      it { is_expected.to eq({}) }
+    end
+
+    context "with a symbol value" do
+      let(:str) { "view: :extended" }
+      it { is_expected.to eq({ view: :extended }) }
+    end
+
+    context "with a string value" do
+      let(:str) { 'name: "hello"' }
+      it { is_expected.to eq({ name: "hello" }) }
+    end
+
+    context "with a boolean true value" do
+      let(:str) { "active: true" }
+      it { is_expected.to eq({ active: true }) }
+    end
+
+    context "with a boolean false value" do
+      let(:str) { "admin: false" }
+      it { is_expected.to eq({ admin: false }) }
+    end
+
+    context "with a nil value" do
+      let(:str) { "key:" }
+      it { is_expected.to eq({ key: nil }) }
+    end
+
+    context "with multiple options" do
+      let(:str) { "view: :extended, root: :user" }
+      it { is_expected.to eq({ view: :extended, root: :user }) }
+    end
+  end
+
   describe ".__module_parent" do
     subject { described_class.__module_parent(klass) }
 


### PR DESCRIPTION
### What this PR does

Extends the tag parser to recognize serializer options like **(Few Examples)** :
a) `UserBlueprint`
b) `UserBlueprint(view: :extended)`
c)  `UserBlueprint(view: :extended, root: :user)`
d)  `Array<UserBlueprint>`
e)  `Array<UserBlueprint(view: :extended, root: :user)`
... .

As, recmoneded in the issue description changes have been made in a way so Alba and any future serializer can use the same syntax.

### References

- Blueprinter [Usage](https://github.com/procore-oss/blueprinter#usage) Documentation.

### AI usage

- Used AI for generating the the `test cases`. I also went through all the test cases that was generated by the AI just to be sure it's okay.