### PR TITLE
[OpenAPI]: Parse basic Blueprinter fields: identifier, field, and fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [OpenAPI] Add Blueprinter parser scaffold and class detection (#287)
 - [OpenAPI] Extend @response / @request tag syntax to accept serializer options (#299)
 - Add `FiberScheduler#blocking_operation_wait` (#303).
+- [OpenAPI] Added static parsing of basic Blueprinter fields (`identifier`, `field`, `fields`) for OpenAPI schema generation. (#289)
 
 ### Fixed
 

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -36,7 +36,6 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
 
     def initialize
       @symbols = []
-      @hashes = []
       @keywords = {}
     end
   end
@@ -69,8 +68,8 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
       when :fields, :field
         context = with_context { visit(node.arguments) }
 
-        if context.keywords.any?
-          @segment[context.keywords["name"].delete_prefix(":")] = { "type" => "string" }
+        if context.keywords["name"]
+          @segment[context.keywords["name"]] = { "type" => "string" }
         elsif node.block
           @segment[context.symbols.first] = { "type" => "string" }
         else
@@ -80,7 +79,7 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
     end
 
     def visit_assoc_node(node)
-      @context.keywords[node.key.value] = node.value.slice
+      @context.keywords[node.key.value] = node.value.unescaped
     end
 
     def visit_symbol_node(node)

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -14,8 +14,85 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
   end
 
   def parse(klass_str)
-    # for now just return empty hash
-    # this is where visitor will plug in later
-    { "type" => "object" }
+    visitor = __parse(klass_str)
+    visitor.build_schema
+  end
+
+  def __parse(klass_str)
+    is_collection, klass_str, _ = Rage::OpenAPI.__parse_serializer_args(klass_str)
+
+    klass = @namespace.const_get(klass_str)
+    source_path, _ = Object.const_source_location(klass.name)
+    ast = Prism.parse_file(source_path)
+
+    visitor = Visitor.new(self, is_collection)
+    ast.value.accept(visitor)
+
+    visitor
+  end
+
+  class VisitorContext
+    attr_accessor :symbols, :hashes, :keywords
+
+    def initialize
+      @symbols = []
+      @hashes = []
+      @keywords = {}
+    end
+  end
+
+  class Visitor < Prism::Visitor
+    attr_accessor :schema
+
+    def initialize(parser, is_collection)
+      @parser = parser
+      @is_collection = is_collection
+
+      @context = nil
+      @schema = {}
+      @segment = @schema
+    end
+
+    def build_schema
+      result = { "type" => "object" }
+      result["properties"] = @schema if @schema.any?
+      result = { "type" => "array", "items" => result } if @is_collection
+      result
+    end
+
+    def visit_call_node(node)
+      case node.name
+      when :identifier
+        context = with_context { visit(node.arguments) }
+        @segment[context.symbols.first] = { "type" => "string" }
+
+      when :fields, :field
+        context = with_context { visit(node.arguments) }
+
+        if context.keywords.any?
+          @segment[context.keywords["name"].delete_prefix(":")] = { "type" => "string" }
+        elsif node.block
+          @segment[context.symbols.first] = { "type" => "string" }
+        else
+          context.symbols.each { |symbol| @segment[symbol] = { "type" => "string" } }
+        end
+      end
+    end
+
+    def visit_assoc_node(node)
+      @context.keywords[node.key.value] = node.value.slice
+    end
+
+    def visit_symbol_node(node)
+      @context.symbols << node.value
+    end
+
+    private
+
+    def with_context
+      @context = VisitorContext.new
+      yield
+      @context
+    end
   end
 end

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -32,10 +32,11 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
   end
 
   class VisitorContext
-    attr_accessor :symbols, :keywords
+    attr_accessor :symbols, :keywords, :strings
 
     def initialize
       @symbols = []
+      @strings = []
       @keywords = {}
     end
   end
@@ -50,11 +51,17 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
       @context = nil
       @schema = {}
       @segment = @schema
+      @identifier = {}
     end
 
     def build_schema
       result = { "type" => "object" }
-      result["properties"] = @schema if @schema.any?
+
+      properties = {}
+      properties.merge!(@identifier)
+      properties.merge!(@schema.sort.to_h)
+
+      result["properties"] = properties if properties.any?
       result = { "type" => "array", "items" => result } if @is_collection
       result
     end
@@ -63,7 +70,7 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
       case node.name
       when :identifier
         context = with_context { visit(node.arguments) }
-        @segment[context.symbols.first] = { "type" => "string" }
+        @identifier[context.symbols.first] = { "type" => "string" }
 
       when :fields, :field
         context = with_context { visit(node.arguments) }
@@ -71,9 +78,11 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
         if context.keywords["name"]
           @segment[context.keywords["name"]] = { "type" => "string" }
         elsif node.block
-          @segment[context.symbols.first] = { "type" => "string" }
+          @segment[context.symbols.first] = { "type" => "string" } if context.symbols.first
+          @segment[context.strings.first] = { "type" => "string" } if context.strings.first
         else
           context.symbols.each { |symbol| @segment[symbol] = { "type" => "string" } }
+          context.strings.each { |string| @segment[string] = { "type" => "string" } }
         end
       end
     end
@@ -84,6 +93,10 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
 
     def visit_symbol_node(node)
       @context.symbols << node.value
+    end
+
+    def visit_string_node(node)
+      @context.strings << node.unescaped
     end
 
     private

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -32,7 +32,7 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
   end
 
   class VisitorContext
-    attr_accessor :symbols, :hashes, :keywords
+    attr_accessor :symbols, :keywords
 
     def initialize
       @symbols = []

--- a/spec/openapi/parsers/ext/blueprinter_spec.rb
+++ b/spec/openapi/parsers/ext/blueprinter_spec.rb
@@ -47,6 +47,27 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
       end
     end
 
+    context "when fields are declared with strings" do
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            fields "id", "name", "email"
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
     context "with identifier" do
       let_class("UserBlueprint") do
         <<~'RUBY'
@@ -104,11 +125,49 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
       end
     end
 
+    context "when field alias is declared with string values" do
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            field "email", name: "login"
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "login" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
     context "with a block field" do
       let_class("UserBlueprint") do
         <<~'RUBY'
           class UserBlueprint < Blueprinter::Base
             field(:full_name) { |u| "#{u.first_name} #{u.last_name}" }
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "full_name" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "with a block field declared with string values" do
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            field("full_name") { |u| "#{u.first_name} #{u.last_name}" }
           end
         RUBY
       end
@@ -132,6 +191,66 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
             field :email, name: :login
             fields :first_name, :last_name
             field(:full_name) { |u| "#{u.first_name} #{u.last_name}" }
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "uuid" => { "type" => "string" },
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "age" => { "type" => "string" },
+            "login" => { "type" => "string" },
+            "first_name" => { "type" => "string" },
+            "last_name" => { "type" => "string" },
+            "full_name" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "with all declaration types combined with string values" do
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            identifier :uuid
+            fields "id", "name", "age"
+            field "email", name: "login"
+            fields "first_name", "last_name"
+            field("full_name") { |u| "#{u.first_name} #{u.last_name}" }
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "uuid" => { "type" => "string" },
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "age" => { "type" => "string" },
+            "login" => { "type" => "string" },
+            "first_name" => { "type" => "string" },
+            "last_name" => { "type" => "string" },
+            "full_name" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "with all declaration types combined with string and symbol vales" do
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            identifier :uuid
+            fields :id, "name", :age
+            field :email, name: "login"
+            fields "first_name", :last_name
+            field("full_name") { |u| "#{u.first_name} #{u.last_name}" }
           end
         RUBY
       end

--- a/spec/openapi/parsers/ext/blueprinter_spec.rb
+++ b/spec/openapi/parsers/ext/blueprinter_spec.rb
@@ -271,6 +271,20 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         })
       end
     end
+
+    context "ensures identifier appears first in properties regardless of definition order" do
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            fields :name, :email
+            identifier :uuid
+          end
+        RUBY
+      end
+      it do
+        expect(subject["properties"].keys.first).to eq("uuid")
+      end
+    end
   end
 
   describe "collection" do

--- a/spec/openapi/parsers/ext/blueprinter_spec.rb
+++ b/spec/openapi/parsers/ext/blueprinter_spec.rb
@@ -8,19 +8,203 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
   subject { described_class.new(**options).parse(resource) }
 
   let(:options) { {} }
-  let(:resource) { "UserBlueprint" }
 
-  context "with an empty blueprint" do
-    let_class("UserBlueprint") do
-      <<~'RUBY'
-        class UserBlueprint < Blueprinter::Base
-          fields :id, :name, :email, :age
-        end
-      RUBY
+  describe "single object" do
+    let(:resource) { "UserBlueprint" }
+
+    context "with an empty blueprint" do
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({ "type" => "object" })
+      end
     end
 
-    it do
-      is_expected.to eq({ "type" => "object" })
+    context "with basic fields" do
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            fields :id, :name, :email, :age
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" },
+            "age" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "with identifier" do
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            identifier :uuid
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "uuid" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "with a single field" do
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            field :email
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "with field name alias" do
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            field :email, name: :login
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "login" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "with a block field" do
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            field(:full_name) { |u| "#{u.first_name} #{u.last_name}" }
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "full_name" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "with all declaration types combined" do
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            identifier :uuid
+            fields :id, :name, :age
+            field :email, name: :login
+            fields :first_name, :last_name
+            field(:full_name) { |u| "#{u.first_name} #{u.last_name}" }
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "uuid" => { "type" => "string" },
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "age" => { "type" => "string" },
+            "login" => { "type" => "string" },
+            "first_name" => { "type" => "string" },
+            "last_name" => { "type" => "string" },
+            "full_name" => { "type" => "string" }
+          }
+        })
+      end
+    end
+  end
+
+  describe "collection" do
+    let(:resource) { "Array<UserBlueprint>" }
+
+    context "with basic fields" do
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            fields :id, :name, :email
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "id" => { "type" => "string" },
+              "name" => { "type" => "string" },
+              "email" => { "type" => "string" }
+            }
+          }
+        })
+      end
+    end
+
+    context "with identifier" do
+      let(:resource) { "[UserBlueprint]" }
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            identifier :uuid
+            fields :name, :email
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "uuid" => { "type" => "string" },
+              "name" => { "type" => "string" },
+              "email" => { "type" => "string" }
+            }
+          }
+        })
+      end
     end
   end
 end


### PR DESCRIPTION
closes #289

### What this PR does?
Adds support for parsing basic Blueprinter fields:
- `identifier`
- `field`
- `fields`

Also supports:
- **Field renaming** via the `name:` option (e.g. `field :email, name: :login`)
- **Block fields** (e.g. `field(:full_name) { |u| ... }`) , defaults to `string` type since the block can't be statically evaluated
- **Collections** via `Array<UserBlueprint>` or `[UserBlueprint]` syntax

### Sample Code

- `routes.rb` 

```ruby
Rage.routes.draw do
  root to: ->(env) { [200, {}, ["It works!"]] }

  get "/users/:id/blue", to: "users#show_blue"
end

```

- `products_controller.rb`

```ruby


class UsersController < RageController::API
  
  # @response UserBlueprint
  def show_blue
    user = [{ uuid: 1, id: 101, name: "Alice", email: "alice@example.com", age: 25, first_name: "Alice", last_name: "loom", abishek: 'abi' }]
    render json: UserBlueprint.render(user)
  end
end


```

- `user_blueprint.rb`

```ruby

class UserBlueprint < Blueprinter::Base
  identifier :uuid
  
  fields :id, :name, :email, :age
  
  field :email, name: :login   # -> "login": string

  field :abishek, name: :ad   # -> "login": string
  
  fields :first_name, :last_name

  field(:full_name) { |u| "#{u[:first_name]} #{u[:last_name]}" }
end


```

### Screenrecording

- Before

<img width="1345" height="602" alt="image" src="https://github.com/user-attachments/assets/cf78f358-ece6-4bdd-8902-581f240b7de8" />




https://github.com/user-attachments/assets/ac780229-2ce7-44b6-bf9c-7093dd303e89



- After

<img width="1355" height="720" alt="image" src="https://github.com/user-attachments/assets/f506b4a9-f7c3-4ec6-88e2-f56255161881" />




https://github.com/user-attachments/assets/83ee85a7-841f-4bf7-839c-501261ea32b7




`collection`


<img width="1340" height="602" alt="image" src="https://github.com/user-attachments/assets/d1c35864-3c1f-4193-909b-6aa1a2a59cdc" />




https://github.com/user-attachments/assets/9f3591bb-ff70-4719-920d-f7543d9960aa






