### PR TITLE
[OpenAPI]: Blueprint inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [OpenAPI] Extend @response / @request tag syntax to accept serializer options (#299)
 - Add `FiberScheduler#blocking_operation_wait` (#303).
 - [OpenAPI] Added static parsing of basic Blueprinter fields (`identifier`, `field`, `fields`) for OpenAPI schema generation. (#289)
+- [OpenAPI] Add support for blueprint inheritance. Child blueprints now inherit fields from parent blueprints.
 
 ### Fixed
 

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -67,8 +67,6 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
     end
 
     def visit_class_node(node)
-      @self_name ||= node.name.to_s
-
       if node.superclass && node.superclass.name != :Base
         visitor = @parser.__parse(node.superclass.name.to_s)
         @schema.merge!(visitor.schema)

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -42,7 +42,7 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
   end
 
   class Visitor < Prism::Visitor
-    attr_accessor :schema
+    attr_accessor :schema, :identifier
 
     def initialize(parser, is_collection)
       @parser = parser
@@ -67,8 +67,9 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
     end
 
     def visit_class_node(node)
-      if node.superclass && node.superclass.name != :Base
+      if node.superclass && node.superclass.full_name != "Blueprinter::Base"
         visitor = @parser.__parse(node.superclass.name.to_s)
+        @identifier.merge!(visitor.identifier)
         @schema.merge!(visitor.schema)
       end
 

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -66,6 +66,17 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
       result
     end
 
+    def visit_class_node(node)
+      @self_name ||= node.name.to_s
+
+      if node.superclass && node.superclass.name != :Base
+        visitor = @parser.__parse(node.superclass.name.to_s)
+        @schema.merge!(visitor.schema)
+      end
+
+      super
+    end
+
     def visit_call_node(node)
       case node.name
       when :identifier

--- a/spec/openapi/parsers/ext/blueprinter_spec.rb
+++ b/spec/openapi/parsers/ext/blueprinter_spec.rb
@@ -364,6 +364,78 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         })
       end
     end
+
+    context "with multiple levels of inheritance" do
+      let_class("GrandparentBlueprint") do
+        <<~'RUBY'
+          class GrandparentBlueprint < Blueprinter::Base
+            fields :id, :name
+          end
+        RUBY
+      end
+
+      let_class("ParentBlueprint") do
+        <<~'RUBY'
+          class ParentBlueprint < GrandparentBlueprint
+            fields :email
+          end
+        RUBY
+      end
+
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < ParentBlueprint
+            fields :age
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" },
+            "age" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "with identifier in parent blueprint" do
+      let_class("BaseUserBlueprint") do
+        <<~'RUBY'
+          class BaseUserBlueprint < Blueprinter::Base
+            identifier :uuid
+            fields :name
+          end
+        RUBY
+      end
+
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < BaseUserBlueprint
+            identifier :id
+            fields :email
+          end
+        RUBY
+      end
+
+      it "inherits identifier from parent" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "uuid" => { "type" => "string" },
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" }
+          }
+        })
+        expect(subject["properties"].keys.first).to eq("uuid")
+        expect(subject["properties"].keys[1]).to eq("id")
+      end
+    end
   end
 
   describe "collection" do
@@ -448,6 +520,79 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
             }
           }
         })
+      end
+    end
+
+    context "with multiple levels of inheritance" do
+      let_class("GrandparentBlueprint") do
+        <<~'RUBY'
+          class GrandparentBlueprint < Blueprinter::Base
+            fields :id, :name
+          end
+        RUBY
+      end
+      let_class("ParentBlueprint") do
+        <<~'RUBY'
+          class ParentBlueprint < GrandparentBlueprint
+            fields :email
+          end
+        RUBY
+      end
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < ParentBlueprint
+            fields :age
+          end
+        RUBY
+      end
+      it do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "id" => { "type" => "string" },
+              "name" => { "type" => "string" },
+              "email" => { "type" => "string" },
+              "age" => { "type" => "string" }
+            }
+          }
+        })
+      end
+    end
+
+    context "with identifier in parent blueprint" do
+      let_class("BaseUserBlueprint") do
+        <<~'RUBY'
+          class BaseUserBlueprint < Blueprinter::Base
+            identifier :uuid
+            fields :name
+          end
+        RUBY
+      end
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < BaseUserBlueprint
+            identifier :id
+            fields :email
+          end
+        RUBY
+      end
+      it "inherits identifier from parent" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "uuid" => { "type" => "string" },
+              "id" => { "type" => "string" },
+              "name" => { "type" => "string" },
+              "email" => { "type" => "string" }
+            }
+          }
+        })
+        expect(subject["items"]["properties"].keys.first).to eq("uuid")
+        expect(subject["items"]["properties"].keys[1]).to eq("id")
       end
     end
   end

--- a/spec/openapi/parsers/ext/blueprinter_spec.rb
+++ b/spec/openapi/parsers/ext/blueprinter_spec.rb
@@ -285,6 +285,85 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         expect(subject["properties"].keys.first).to eq("uuid")
       end
     end
+
+    context "with inheritance from another blueprint" do
+      let_class("BaseUserBlueprint") do
+        <<~'RUBY'
+          class BaseUserBlueprint < Blueprinter::Base
+            fields :id, :name
+          end
+        RUBY
+      end
+
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < BaseUserBlueprint
+            fields :email, :age
+          end
+        RUBY
+      end
+
+      it "merges parent schema into child schema" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" },
+            "age" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "when superclass is Base (should not merge)" do
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            fields :id, :name
+          end
+        RUBY
+      end
+
+      it "does not attempt to parse superclass" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "when child blueprint overrides a parent field" do
+      let_class("BaseUserBlueprint") do
+        <<~'RUBY'
+          class BaseUserBlueprint < Blueprinter::Base
+            fields :id, :name
+          end
+        RUBY
+      end
+
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < BaseUserBlueprint
+            fields :name, :email
+          end
+        RUBY
+      end
+
+      it "child fields take precedence" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" }
+          }
+        })
+      end
+    end
   end
 
   describe "collection" do
@@ -332,6 +411,38 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
             "type" => "object",
             "properties" => {
               "uuid" => { "type" => "string" },
+              "name" => { "type" => "string" },
+              "email" => { "type" => "string" }
+            }
+          }
+        })
+      end
+    end
+
+    context "with inherited fields" do
+      let_class("BaseUserBlueprint") do
+        <<~'RUBY'
+          class BaseUserBlueprint < Blueprinter::Base
+            fields :id, :name
+          end
+        RUBY
+      end
+
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < BaseUserBlueprint
+            fields :email
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "id" => { "type" => "string" },
               "name" => { "type" => "string" },
               "email" => { "type" => "string" }
             }


### PR DESCRIPTION
closes #290

### What this PR does?

Add support for blueprint inheritance. Child blueprints now inherit fields from parent blueprints.

### Example Code

- `routes.rb`

```ruby
Rage.routes.draw do
  root to: ->(env) { [200, {}, ["It works!"]] }

  get "/data_mining", to: "data_mining#show_data_mining"
end
```

- `data_mining_controller.rb`

```ruby

class DataMiningController < RageController::API

  # @response DataMining
  def show_data_mining
    data_mining_details = { uuid: 'Third Edition', email: 'MorganKaufmann@publishers.com', name: 'Han Kamber Pei', first_name: 'Morgan', last_name: 'Kaufmann', hello_world: 'Earth', subject: "DataMining"  }
    render json: DataMining.render(data_mining_details)
  end
end


```

- `data_mining_base.rb`

```ruby
class DataMiningBase < Blueprinter::Base
  field :hello_world
  field :email, name: :something
  fields :subject
end

```

- `data_mining.rb`

```ruby
class DataMining < DataMiningBase
  identifier :uuid
  field "email", name: :login
  field "first_name"
  field :hello_world
end
```


- `Blueprinter Response for route /data_mining`

```
{
  "uuid": "Third Edition",
  "first_name": "Morgan",
  "hello_world": "Earth",
  "login": "MorganKaufmann@publishers.com",
  "something": "MorganKaufmann@publishers.com",
  "subject": "DataMining"
}
```


- `OpenAPI response output for # @response DataMining`

```ruby

{
  "uuid": "string",
  "first_name": "string",
  "hello_world": "string",
  "login": "string",
  "something": "string",
  "subject": "string"
}

```

### ScreenRecording

- Before

<img width="1354" height="734" alt="Before" src="https://github.com/user-attachments/assets/0bb8297a-832f-49e4-837e-268ab32dd048" />


https://github.com/user-attachments/assets/6a8b7d70-42b4-4197-8acb-8f60779a07e9



- After


<img width="1352" height="725" alt="After" src="https://github.com/user-attachments/assets/0a0679b4-d5a7-498d-b666-0285b781965d" />

https://github.com/user-attachments/assets/7f4ea991-96a9-4754-9136-4359c683e0cb