### PR TITLE
[API] Reject malformed or empty HTTP token authorization headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - [OpenAPI] Add Blueprinter parser scaffold and class detection (#287)
 - [OpenAPI] Extend @response / @request tag syntax to accept serializer options (#299)
 
+### Fixed
+
+- [API] Reject malformed or empty HTTP token authorization headers.
+
 ## [1.24.0] - 2026-05-12
 
 ### Added

--- a/lib/rage/controller/api.rb
+++ b/lib/rage/controller/api.rb
@@ -558,13 +558,13 @@ class RageController::API
   def authenticate_with_http_token
     auth_header = @__env["HTTP_AUTHORIZATION"]
 
-    payload = if auth_header&.start_with?("Bearer")
+    payload = if auth_header&.start_with?("Bearer ")
       auth_header[7..]
-    elsif auth_header&.start_with?("Token")
+    elsif auth_header&.start_with?("Token ")
       auth_header[6..]
     end
 
-    return unless payload
+    return if payload.nil? || payload.empty?
 
     token = if payload.start_with?("token=")
       payload[6..]
@@ -574,6 +574,8 @@ class RageController::API
 
     token.delete_prefix!('"')
     token.delete_suffix!('"')
+
+    return if token.empty?
 
     yield token
   end

--- a/spec/controller/api/authenticate_spec.rb
+++ b/spec/controller/api/authenticate_spec.rb
@@ -74,6 +74,80 @@ RSpec.describe RageController::API do
       end
     end
 
+    context "with a malformed Bearer token" do
+      let(:env) { { "HTTP_AUTHORIZATION" => auth_header } }
+
+      context "without a separator" do
+        let(:auth_header) { "Bearermy_token" }
+
+        it "returns nil" do
+          value = subject.authenticate_with_http_token { :request_authenticated }
+          expect(value).to be_nil
+        end
+
+        it "doesn't call the login procedure" do
+          expect {
+            subject.authenticate_with_http_token { raise }
+          }.not_to raise_error
+        end
+      end
+
+      context "with an empty token" do
+        let(:auth_header) { "Bearer " }
+
+        it "returns nil" do
+          value = subject.authenticate_with_http_token { :request_authenticated }
+          expect(value).to be_nil
+        end
+      end
+
+      context "with an empty token payload" do
+        let(:auth_header) { "Bearer token=" }
+
+        it "returns nil" do
+          value = subject.authenticate_with_http_token { :request_authenticated }
+          expect(value).to be_nil
+        end
+      end
+    end
+
+    context "with a malformed Token token" do
+      let(:env) { { "HTTP_AUTHORIZATION" => auth_header } }
+
+      context "without a separator" do
+        let(:auth_header) { "Tokenmy_token" }
+
+        it "returns nil" do
+          value = subject.authenticate_with_http_token { :request_authenticated }
+          expect(value).to be_nil
+        end
+
+        it "doesn't call the login procedure" do
+          expect {
+            subject.authenticate_with_http_token { raise }
+          }.not_to raise_error
+        end
+      end
+
+      context "with an empty token" do
+        let(:auth_header) { "Token " }
+
+        it "returns nil" do
+          value = subject.authenticate_with_http_token { :request_authenticated }
+          expect(value).to be_nil
+        end
+      end
+
+      context "with an empty token payload" do
+        let(:auth_header) { 'Token token=""' }
+
+        it "returns nil" do
+          value = subject.authenticate_with_http_token { :request_authenticated }
+          expect(value).to be_nil
+        end
+      end
+    end
+
     context "with a Digest token" do
       let(:env) { { "HTTP_AUTHORIZATION" => "Digest my_token" } }
 


### PR DESCRIPTION
## Description:

Issue #304 reported that malformed or empty HTTP token `Authorization` headers could still be accepted by `RageController::API#authenticate_with_http_token` because the helper only checked the `Bearer` / `Token` prefix and then sliced the header at fixed offsets.

This PR updates the token authentication helper to require the expected scheme separator (`Bearer ` / `Token `) and to return `nil` when the extracted token is empty.

It also adds regression tests covering malformed headers without a separator and headers with empty token payloads, while preserving the existing valid Bearer and Token formats.

Closes #304.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting checks in WSL using `rubocop --except Layout/EndOfLine lib/rage/controller/api.rb spec/controller/api/authenticate_spec.rb`.
- [x] I have run focused tests in WSL using `rspec spec/controller/api/authenticate_spec.rb`.
- [x] I have run broader API regression tests in WSL using `rspec spec/controller/api spec/rage/response_spec.rb`.

### Before the fix:
<img width="1440" height="1100" alt="image" src="https://github.com/user-attachments/assets/14d0d6c4-1191-41a6-ab3b-c6a4fcec4110" />

### After the fix:
<img width="1440" height="1100" alt="image" src="https://github.com/user-attachments/assets/0a1980b5-789f-40e7-ac5b-6aabe51730b9" />
