### PR TITLE
[Router] Normalize exact host constraints when host includes a port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - [API] Reject malformed or empty HTTP token authorization headers.
+- [Router] Strip the port from `HTTP_HOST` before matching exact host constraints.
 
 ## [1.24.0] - 2026-05-12
 

--- a/lib/rage/router/constrainer.rb
+++ b/lib/rage/router/constrainer.rb
@@ -69,7 +69,7 @@ class Rage::Router::Constrainer
       # Optimization: inline the derivation for the common built in constraints
       if !strategy.custom?
         if key == :host
-          lines << "   host: env['HTTP_HOST'.freeze],"
+          lines << "   host: env['HTTP_HOST'.freeze]&.sub(/:\\d+\\z/, ''.freeze),"
         else
           raise ArgumentError, "unknown non-custom strategy for compiling constraint derivation function"
         end

--- a/spec/router/constraints_spec.rb
+++ b/spec/router/constraints_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe Rage::Router::Backend do
     expect(result).to be_nil
   end
 
+  it "correctly processes a constrained url when host includes a port" do
+    router.on("GET", "/photos", ->(_) { "get photos" }, constraints: { host: "google.com" })
+
+    result, _ = perform_get_request("/photos", host: "google.com:3000")
+    expect(result).to eq("get photos")
+  end
+
   it "correctly processes urls with multiple constraints" do
     router.on("GET", "/photos", ->(_) { "US photos" }, constraints: { host: "google.com" })
     router.on("GET", "/photos", ->(_) { "CA photos" }, constraints: { host: "google.ca" })


### PR DESCRIPTION
## Description:

This fixes exact host constraint matching when the request host includes a port.

The router currently derives the `host` constraint directly from `HTTP_HOST`, so a route constrained with `host: "google.com"` does not match requests like `Host: google.com:3000`.

This PR strips the port from `HTTP_HOST` before host constraint matching, so exact host constraints compare against the normalized host value.

It also adds a regression spec covering requests where the host includes a port.

Closes #306.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting checks in WSL using `rubocop --except Layout/EndOfLine lib/rage/router/constrainer.rb spec/router/constraints_spec.rb`.
- [x] I have run focused tests in WSL using `rspec spec/router/constraints_spec.rb`.
- [x] I have run broader related tests in WSL using `rspec spec/router`.

### Before the fix:

<img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/603a958c-fd00-49c4-bf6b-4ee1accc95a6" />

### After the fix:

<img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/576a076e-adfd-4c5a-9f12-a84e4a4e70b2" />
