### PR TITLE
[Cookies] Preserve array domain matching when request host includes a port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - [API] Reject malformed or empty HTTP token authorization headers.
+- [Cookies] Strip the port from `HTTP_HOST` before matching configured cookie domains.
 - [Router] Strip the port from `HTTP_HOST` before matching exact host constraints.
 
 ## [1.24.0] - 2026-05-12

--- a/lib/rage/cookies.rb
+++ b/lib/rage/cookies.rb
@@ -201,7 +201,7 @@ class Rage::Cookies
     end
 
     if (domain = value[:domain])
-      host = @env["HTTP_HOST"]
+      host = @env["HTTP_HOST"]&.sub(/:\d+\z/, "")
 
       processed_domain = if domain.is_a?(String)
         domain

--- a/spec/controller/api/cookies_spec.rb
+++ b/spec/controller/api/cookies_spec.rb
@@ -6,8 +6,10 @@ require "domain_name"
 RSpec.describe RageController::API do
   subject do
     cookie_header = cookies.map { |k, v| "#{k}=#{v}" }.join("; ")
-    described_class.new({ "HTTP_COOKIE" => cookie_header, "HTTP_HOST" => "cookie.test.com" }, nil)
+    described_class.new({ "HTTP_COOKIE" => cookie_header, "HTTP_HOST" => request_host }, nil)
   end
+
+  let(:request_host) { "cookie.test.com" }
 
   context "with no cookies" do
     let(:cookies) { {} }
@@ -292,6 +294,19 @@ RSpec.describe RageController::API do
         }
 
         expect(response_cookies[:user_id]).to eq("120; domain=cookie.test.com")
+      end
+
+      context "when request host includes a port" do
+        let(:request_host) { "cookie.test.com:3000" }
+
+        it "correctly sets domain value" do
+          subject.cookies[:user_id] = {
+            domain: %w(api.test.com cookie.test.com),
+            value: 120
+          }
+
+          expect(response_cookies[:user_id]).to eq("120; domain=cookie.test.com")
+        end
       end
     end
 


### PR DESCRIPTION
## Description:

Issue #308 reported that array-based cookie domain matching could fail when the request host included a port.

This PR updates `Rage::Cookies` to strip the port from `HTTP_HOST` before resolving configured cookie domains.

It also adds a regression test that covers array-based cookie domain matching when the request host includes a port.

Closes #308.

##Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting checks in WSL using `rubocop --except Layout/EndOfLine lib/rage/cookies.rb spec/controller/api/cookies_spec.rb`.
- [x] I have run focused tests in WSL using `rspec spec/controller/api/cookies_spec.rb`.
- [x] I have run broader related tests in WSL using `rspec spec/controller/api`.

### Before the fix:

<img width="1191" height="540" alt="image" src="https://github.com/user-attachments/assets/927ad8fc-c7a8-48cb-9fc9-4823c3346713" />

### After the fix:

<img width="1190" height="560" alt="image" src="https://github.com/user-attachments/assets/f816f915-2f9d-47c9-8a83-efdad540a2ec" />
