### PR TITLE
[Request] Treat IPv6 literals as non-domain hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [API] Reject malformed or empty HTTP token authorization headers.
 - [Cookies] Strip the port from `HTTP_HOST` before matching configured cookie domains.
 - [Router] Strip the port from `HTTP_HOST` before matching exact host constraints.
+- [Request] Treat IPv6 literals as non-domain hosts.
 
 ## [1.24.0] - 2026-05-12
 

--- a/lib/rage/request.rb
+++ b/lib/rage/request.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "ipaddr"
 require "time"
 
 class Rage::Request
@@ -245,7 +246,14 @@ class Rage::Request
   end
 
   def named_host?(host)
-    !IP_HOST_REGEXP.match?(host)
+    host && !ip_host?(host)
+  end
+
+  def ip_host?(host)
+    IP_HOST_REGEXP.match?(host) || IPAddr.new(host.delete_prefix("[").delete_suffix("]"))
+    true
+  rescue IPAddr::InvalidAddressError
+    false
   end
 
   def if_none_match

--- a/spec/rage/request_spec.rb
+++ b/spec/rage/request_spec.rb
@@ -120,6 +120,11 @@ RSpec.describe Rage::Request do
         before { env["HTTP_HOST"] = "api.foo.bar.com:443" }
         it { is_expected.to eq("api.foo.bar.com") }
       end
+
+      context "when using an IPv6 address with port" do
+        before { env["HTTP_HOST"] = "[::1]:3000" }
+        it { is_expected.to eq("[::1]") }
+      end
     end
 
     context "without HTTP_HOST header" do
@@ -152,6 +157,26 @@ RSpec.describe Rage::Request do
         expect(request.domain(1)).to eq("tld1.tld2")
         expect(request.domain(2)).to eq("tld0.tld1.tld2")
         expect(request.domain(3)).to eq("tld0.tld1.tld2")
+      end
+    end
+
+    context "with HTTP_HOST set to an IPv6 address" do
+      before { env["HTTP_HOST"] = "[::1]:3000" }
+
+      it "returns nil" do
+        expect(request.domain).to be_nil
+        expect(request.domain(0)).to be_nil
+      end
+    end
+
+    context "without HTTP_HOST and with bare IPv6 SERVER_NAME" do
+      before do
+        env.delete("HTTP_HOST")
+        env["SERVER_NAME"] = "::1"
+      end
+
+      it "returns nil" do
+        expect(request.domain).to be_nil
       end
     end
   end


### PR DESCRIPTION
## Description:

Issue #311 reported that `Rage::Request#domain` could treat IPv6 literals as domain names and could raise when the request fell back to a bare IPv6 `SERVER_NAME`.

This PR updates `Rage::Request` to detect IP literals using `IPAddr`, so IPv6 hosts are treated the same way as IPv4 hosts during domain extraction.

It also adds regression tests that cover IPv6 `HTTP_HOST` handling and the fallback path where `HTTP_HOST` is missing.

Closes #311.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting checks in WSL using `rubocop --except Layout/EndOfLine lib/rage/request.rb spec/rage/request_spec.rb`.
- [x] I have run focused tests in WSL using `rspec spec/rage/request_spec.rb`.
- [x] I have run broader related tests in WSL using `rspec spec/rage`.

### Before the fix:

<img width="1354" height="764" alt="image" src="https://github.com/user-attachments/assets/a6792d93-64a4-443a-bf18-977beec821b7" />

### After the fix:

<img width="1358" height="768" alt="image" src="https://github.com/user-attachments/assets/57463fbe-bb84-41e7-be92-2dd90c919372" />

