### PR TITLE
[API] Reject invalid status symbols in head and render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [API] Reject malformed or empty HTTP token authorization headers.
 - [Cookies] Strip the port from `HTTP_HOST` before matching configured cookie domains.
 - [Router] Strip the port from `HTTP_HOST` before matching exact host constraints.
+- [API] Reject invalid status symbols in `head` and `render`.
 
 ## [1.24.0] - 2026-05-12
 

--- a/lib/rage/controller/api.rb
+++ b/lib/rage/controller/api.rb
@@ -485,7 +485,7 @@ class RageController::API
   # @note `render` doesn't terminate execution of the action, so if you want to exit an action after rendering, you need to do something like `render(...) and return`.
   def render(json: nil, plain: nil, sse: nil, status: nil)
     raise "Render was called multiple times in this action." if @__rendered
-    status = normalize_status(status) if status
+    status = ::Rack::Utils.status_code(status) if status
     @__rendered = true
 
     if json || plain
@@ -527,7 +527,7 @@ class RageController::API
   # @example
   #   head 429
   def head(status)
-    status = normalize_status(status)
+    status = ::Rack::Utils.status_code(status)
     @__rendered = true
     @__status = status
   end
@@ -540,11 +540,6 @@ class RageController::API
   def headers
     @__headers
   end
-
-  def normalize_status(status)
-    status.is_a?(Symbol) ? ::Rack::Utils.status_code(status) : status
-  end
-  private :normalize_status
 
   # Authenticate using an HTTP Bearer token. Returns the value of the block if a token is found. Returns `nil` if no token is found.
   #

--- a/lib/rage/controller/api.rb
+++ b/lib/rage/controller/api.rb
@@ -485,7 +485,7 @@ class RageController::API
   # @note `render` doesn't terminate execution of the action, so if you want to exit an action after rendering, you need to do something like `render(...) and return`.
   def render(json: nil, plain: nil, sse: nil, status: nil)
     raise "Render was called multiple times in this action." if @__rendered
-    status = ::Rack::Utils.status_code(status) if status
+    normalized_status = status.nil? ? nil : ::Rack::Utils.status_code(status)
     @__rendered = true
 
     if json || plain
@@ -500,14 +500,14 @@ class RageController::API
       @__status = 200
     end
 
-    if status
-      @__status = status
+    if normalized_status
+      @__status = normalized_status
     end
 
     if sse
       raise ArgumentError, "Cannot render both a standard body and an SSE stream." unless @__body.empty?
 
-      if status
+      if normalized_status
         return if @__status == 204
         raise ArgumentError, "SSE responses only support 200 and 204 statuses." if @__status != 200
       end
@@ -527,9 +527,8 @@ class RageController::API
   # @example
   #   head 429
   def head(status)
-    status = ::Rack::Utils.status_code(status)
     @__rendered = true
-    @__status = status
+    @__status = ::Rack::Utils.status_code(status)
   end
 
   # Set response headers.

--- a/lib/rage/controller/api.rb
+++ b/lib/rage/controller/api.rb
@@ -485,6 +485,7 @@ class RageController::API
   # @note `render` doesn't terminate execution of the action, so if you want to exit an action after rendering, you need to do something like `render(...) and return`.
   def render(json: nil, plain: nil, sse: nil, status: nil)
     raise "Render was called multiple times in this action." if @__rendered
+    status = normalize_status(status) if status
     @__rendered = true
 
     if json || plain
@@ -500,11 +501,7 @@ class RageController::API
     end
 
     if status
-      @__status = if status.is_a?(Symbol)
-        ::Rack::Utils::SYMBOL_TO_STATUS_CODE[status]
-      else
-        status
-      end
+      @__status = status
     end
 
     if sse
@@ -530,13 +527,9 @@ class RageController::API
   # @example
   #   head 429
   def head(status)
+    status = normalize_status(status)
     @__rendered = true
-
-    @__status = if status.is_a?(Symbol)
-      ::Rack::Utils::SYMBOL_TO_STATUS_CODE[status]
-    else
-      status
-    end
+    @__status = status
   end
 
   # Set response headers.
@@ -547,6 +540,11 @@ class RageController::API
   def headers
     @__headers
   end
+
+  def normalize_status(status)
+    status.is_a?(Symbol) ? ::Rack::Utils.status_code(status) : status
+  end
+  private :normalize_status
 
   # Authenticate using an HTTP Bearer token. Returns the value of the block if a token is found. Returns `nil` if no token is found.
   #

--- a/spec/controller/api/render_spec.rb
+++ b/spec/controller/api/render_spec.rb
@@ -14,6 +14,10 @@ module ControllerApiRenderSpec
       head 402
     end
 
+    def head_invalid_symbol
+      head :not_a_status
+    end
+
     def render_json_with_status
       render json: { message: "hello world" }, status: :created
     end
@@ -28,6 +32,10 @@ module ControllerApiRenderSpec
 
     def render_status
       render status: 202
+    end
+
+    def render_invalid_status_symbol
+      render plain: "ok", status: :not_a_status
     end
   end
 end
@@ -62,5 +70,13 @@ RSpec.describe RageController::API do
 
   it "correctly renders status" do
     expect(run_action(klass, :render_status)).to eq([202, json_header, []])
+  end
+
+  it "raises on invalid symbol status in head" do
+    expect { run_action(klass, :head_invalid_symbol) }.to raise_error(ArgumentError, "Unrecognized status code :not_a_status")
+  end
+
+  it "raises on invalid symbol status in render" do
+    expect { run_action(klass, :render_invalid_status_symbol) }.to raise_error(ArgumentError, "Unrecognized status code :not_a_status")
   end
 end

--- a/spec/rage/response_spec.rb
+++ b/spec/rage/response_spec.rb
@@ -152,5 +152,15 @@ RSpec.describe Rage::Response do
       controller.head 403
       expect(subject.status).to eq(403)
     end
+
+    it "does not update status via invalid symbol in head" do
+      expect { controller.head :not_a_status }.to raise_error(ArgumentError, "Unrecognized status code :not_a_status")
+      expect(subject.status).to eq(204)
+    end
+
+    it "does not update status via invalid symbol in render" do
+      expect { controller.render plain: "test_body", status: :not_a_status }.to raise_error(ArgumentError, "Unrecognized status code :not_a_status")
+      expect(subject.status).to eq(204)
+    end
   end
 end


### PR DESCRIPTION
## Description:

Issue #313 reported that `head` and `render` could accept invalid status symbols and silently set the response status to `nil`.

This PR updates `RageController::API` to validate symbol statuses through `Rack::Utils.status_code` before mutating controller state.

It also adds regression tests that cover invalid status symbols in both `head` and `render`, and verifies that the response status remains unchanged when validation fails.

Closes #313.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting checks in WSL using `rubocop --except Layout/EndOfLine lib/rage/controller/api.rb spec/controller/api/render_spec.rb spec/rage/response_spec.rb`.
- [x] I have run focused tests in WSL using `rspec spec/controller/api/render_spec.rb spec/rage/response_spec.rb`.
- [x] I have run broader related tests in WSL using `rspec spec/controller/api spec/rage/response_spec.rb`.

### Before the fix:

<img width="1380" height="793" alt="image" src="https://github.com/user-attachments/assets/4e4f81b3-710c-4afe-9be3-18eadeb2a80a" />

### After the fix:

<img width="1382" height="793" alt="image" src="https://github.com/user-attachments/assets/f8f7b8c5-d7b3-458f-91b7-b0f158f7c4d6" />