### PR TITLE
[OpenAPI]: Parse association declarations in Blueprinter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - [OpenAPI] Add support for blueprint inheritance. Child blueprints now inherit fields from parent blueprints.
+- [OpenAPI] Add support for `association` declarations in Blueprinter serializers, including nested schemas, `name:` aliasing, and circular reference detection.
 
 ### Fixed
 

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -4,6 +4,7 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
   def initialize(namespace: Object, root: Rage::OpenAPI::Nodes::Root.new, **)
     @namespace = namespace
     @root = root
+    @parsing_stack = Set.new
   end
 
   def known_definition?(str)
@@ -14,21 +15,45 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
   end
 
   def parse(klass_str)
+    _, raw_klass_str, _ = Rage::OpenAPI.__parse_serializer_args(klass_str)
     visitor = __parse(klass_str)
+
+    if @root.schema_registry.key?(raw_klass_str)
+      clean = { "type" => "object" }
+      clean["properties"] = visitor.identifier.merge(visitor.schema.sort.to_h) if visitor.schema.any?
+      @root.schema_registry[raw_klass_str] = clean
+    end
+
     visitor.build_schema
   end
 
   def __parse(klass_str)
     is_collection, klass_str, _ = Rage::OpenAPI.__parse_serializer_args(klass_str)
 
+    @parsing_stack.add(klass_str)
+
     klass = @namespace.const_get(klass_str)
     source_path, _ = Object.const_source_location(klass.name)
+
     ast = Prism.parse_file(source_path)
 
     visitor = Visitor.new(self, is_collection)
     ast.value.accept(visitor)
 
+    @parsing_stack.delete(klass_str)
+
     visitor
+  end
+
+  def __parse_nested(klass_str)
+    _, raw_klass_str = Rage::OpenAPI.__try_parse_collection(klass_str)
+
+    if @parsing_stack.include?(raw_klass_str)
+      @root.schema_registry[raw_klass_str] ||= nil
+      return { "$ref" => "#/components/schemas/#{raw_klass_str}" }
+    end
+
+    __parse(raw_klass_str).build_schema
   end
 
   class VisitorContext
@@ -94,11 +119,25 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
           context.symbols.each { |symbol| @segment[symbol] = { "type" => "string" } }
           context.strings.each { |string| @segment[string] = { "type" => "string" } }
         end
+
+      when :association
+        context = with_context { visit(node.arguments) }
+
+        if context.keywords["blueprint"]
+          has_name = context.keywords["name"]
+          key = has_name || context.symbols.first
+          nested = @parser.__parse_nested(context.keywords["blueprint"]) rescue { "type" => "object" }
+          @segment[key] = { "type" => "array", "items" => nested }
+        end
       end
     end
 
     def visit_assoc_node(node)
-      @context.keywords[node.key.value] = node.value.unescaped
+      @context.keywords[node.key.value] = if node.value.respond_to?(:unescaped)
+        node.value.unescaped
+      else
+        node.value.slice
+      end
     end
 
     def visit_symbol_node(node)

--- a/spec/openapi/parsers/ext/blueprinter_spec.rb
+++ b/spec/openapi/parsers/ext/blueprinter_spec.rb
@@ -436,6 +436,260 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         expect(subject["properties"].keys[1]).to eq("id")
       end
     end
+
+    context "with a basic association" do
+      let_class("ProjectBlueprint") do
+        <<~'RUBY'
+          class ProjectBlueprint < Blueprinter::Base
+            fields :id, :name
+          end
+        RUBY
+      end
+
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            fields :email
+            association :projects, blueprint: ProjectBlueprint
+          end
+        RUBY
+      end
+
+      it "defaults to array type with nested blueprint schema" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with association name alias" do
+      let_class("ProjectBlueprint") do
+        <<~'RUBY'
+          class ProjectBlueprint < Blueprinter::Base
+            fields :id, :name
+          end
+        RUBY
+      end
+
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            fields :email
+            association :projects, blueprint: ProjectBlueprint, name: :work_projects
+          end
+        RUBY
+      end
+
+      it "uses the name alias as the association key" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "work_projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        })
+      end
+
+      context "when referenced blueprint cannot be resolved" do
+        let_class("UserBlueprint") do
+          <<~'RUBY'
+            class UserBlueprint < Blueprinter::Base
+              fields :email
+              association :projects, blueprint: UnknownBlueprint
+            end
+          RUBY
+        end
+
+        it "falls back to empty object schema" do
+          is_expected.to eq({
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "projects" => {
+                "type" => "array",
+                "items" => { "type" => "object" }
+              }
+            }
+          })
+        end
+      end
+
+      context "with circular association" do
+        let_class("ProjectBlueprint") do
+          <<~'RUBY'
+            class ProjectBlueprint < Blueprinter::Base
+              fields :name
+              association :user, blueprint: UserBlueprint
+            end
+          RUBY
+        end
+
+        let_class("UserBlueprint") do
+          <<~'RUBY'
+            class UserBlueprint < Blueprinter::Base
+              fields :email
+              association :projects, blueprint: ProjectBlueprint
+            end
+          RUBY
+        end
+
+        it "does not loop infinitely and falls back to $ref for circular reference" do
+          expect { subject }.not_to raise_error
+          is_expected.to eq({
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "projects" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "name" => { "type" => "string" },
+                    "user" => {
+                      "type" => "array",
+                      "items" => { "$ref" => "#/components/schemas/UserBlueprint" }
+                    }
+                  }
+                }
+              }
+            }
+          })
+        end
+      end
+    end
+
+    context "with association across multiple levels of inheritance" do
+      let_class("TagBlueprint") do
+        <<~'RUBY'
+          class TagBlueprint < Blueprinter::Base
+            fields :id, :label
+          end
+        RUBY
+      end
+
+      let_class("ProjectBlueprint") do
+        <<~'RUBY'
+          class ProjectBlueprint < Blueprinter::Base
+            fields :name
+            association :tags, blueprint: TagBlueprint
+          end
+        RUBY
+      end
+
+      let_class("BaseUserBlueprint") do
+        <<~'RUBY'
+          class BaseUserBlueprint < Blueprinter::Base
+            fields :email
+            association :projects, blueprint: ProjectBlueprint
+          end
+        RUBY
+      end
+
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < BaseUserBlueprint
+            fields :first_name
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "first_name" => { "type" => "string" },
+            "projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "name" => { "type" => "string" },
+                  "tags" => {
+                    "type" => "array",
+                    "items" => {
+                      "type" => "object",
+                      "properties" => {
+                        "id" => { "type" => "string" },
+                        "label" => { "type" => "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with identifier in associated blueprint" do
+      let_class("ProjectBlueprint") do
+        <<~'RUBY'
+          class ProjectBlueprint < Blueprinter::Base
+            identifier :uuid
+            fields :name
+          end
+        RUBY
+      end
+
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            identifier :id
+            fields :email
+            association :projects, blueprint: ProjectBlueprint
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "email" => { "type" => "string" },
+            "projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "uuid" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        })
+      end
+
+      it "ensures identifier appears first in properties" do
+        expect(subject["properties"].keys.first).to eq("id")
+        expect(subject.dig("properties", "projects", "items", "properties").keys.first).to eq("uuid")
+      end
+    end
   end
 
   describe "collection" do
@@ -593,6 +847,278 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         })
         expect(subject["items"]["properties"].keys.first).to eq("uuid")
         expect(subject["items"]["properties"].keys[1]).to eq("id")
+      end
+    end
+
+    context "with a basic association" do
+      let_class("ProjectBlueprint") do
+        <<~'RUBY'
+          class ProjectBlueprint < Blueprinter::Base
+            fields :id, :name
+          end
+        RUBY
+      end
+
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            fields :email
+            association :projects, blueprint: ProjectBlueprint
+          end
+        RUBY
+      end
+
+      it "defaults to array type with nested blueprint schema" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "projects" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "id" => { "type" => "string" },
+                    "name" => { "type" => "string" }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with association name alias" do
+      let_class("ProjectBlueprint") do
+        <<~'RUBY'
+          class ProjectBlueprint < Blueprinter::Base
+            fields :id, :name
+          end
+        RUBY
+      end
+
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            fields :email
+            association :projects, blueprint: ProjectBlueprint, name: :work_projects
+          end
+        RUBY
+      end
+
+      it "uses the name alias as the association key" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "work_projects" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "id" => { "type" => "string" },
+                    "name" => { "type" => "string" }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "when referenced blueprint cannot be resolved" do
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            fields :email
+            association :projects, blueprint: UnknownBlueprint
+          end
+        RUBY
+      end
+
+      it "falls back to empty object schema" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "projects" => {
+                "type" => "array",
+                "items" => { "type" => "object" }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with circular association" do
+      let_class("ProjectBlueprint") do
+        <<~'RUBY'
+          class ProjectBlueprint < Blueprinter::Base
+            fields :name
+            association :user, blueprint: UserBlueprint
+          end
+        RUBY
+      end
+
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            fields :email
+            association :projects, blueprint: ProjectBlueprint
+          end
+        RUBY
+      end
+
+      it "does not loop infinitely and falls back to $ref for circular reference" do
+        expect { subject }.not_to raise_error
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "projects" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "name" => { "type" => "string" },
+                    "user" => {
+                      "type" => "array",
+                      "items" => { "$ref" => "#/components/schemas/UserBlueprint" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with association across multiple levels of inheritance" do
+      let_class("TagBlueprint") do
+        <<~'RUBY'
+          class TagBlueprint < Blueprinter::Base
+            fields :id, :label
+          end
+        RUBY
+      end
+
+      let_class("ProjectBlueprint") do
+        <<~'RUBY'
+          class ProjectBlueprint < Blueprinter::Base
+            fields :name
+            association :tags, blueprint: TagBlueprint
+          end
+        RUBY
+      end
+
+      let_class("BaseUserBlueprint") do
+        <<~'RUBY'
+          class BaseUserBlueprint < Blueprinter::Base
+            fields :email
+            association :projects, blueprint: ProjectBlueprint
+          end
+        RUBY
+      end
+
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < BaseUserBlueprint
+            fields :first_name
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "first_name" => { "type" => "string" },
+              "projects" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "name" => { "type" => "string" },
+                    "tags" => {
+                      "type" => "array",
+                      "items" => {
+                        "type" => "object",
+                        "properties" => {
+                          "id" => { "type" => "string" },
+                          "label" => { "type" => "string" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with identifier in associated blueprint" do
+      let_class("ProjectBlueprint") do
+        <<~'RUBY'
+          class ProjectBlueprint < Blueprinter::Base
+            identifier :uuid
+            fields :name
+          end
+        RUBY
+      end
+
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            identifier :id
+            fields :email
+            association :projects, blueprint: ProjectBlueprint
+          end
+        RUBY
+      end
+
+      it do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "id" => { "type" => "string" },
+              "email" => { "type" => "string" },
+              "projects" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "uuid" => { "type" => "string" },
+                    "name" => { "type" => "string" }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+
+      it "ensures identifier appears first in properties" do
+        expect(subject["items"]["properties"].keys.first).to eq("id")
+        expect(subject.dig("items", "properties", "projects", "items", "properties").keys.first).to eq("uuid")
       end
     end
   end

--- a/spec/openapi/parsers/ext/blueprinter_spec.rb
+++ b/spec/openapi/parsers/ext/blueprinter_spec.rb
@@ -615,7 +615,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it do
+      it "includes identifier in collection items" do
         is_expected.to eq({
           "type" => "object",
           "properties" => {
@@ -665,7 +665,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it do
+      it "includes identifier in nested blueprint schema" do
         is_expected.to eq({
           "type" => "object",
           "properties" => {
@@ -688,6 +688,58 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
       it "ensures identifier appears first in properties" do
         expect(subject["properties"].keys.first).to eq("id")
         expect(subject.dig("properties", "projects", "items", "properties").keys.first).to eq("uuid")
+      end
+    end
+
+    context "with circular association through inheritance" do
+      let_class("BaseProjectBlueprint") do
+        <<~'RUBY'
+          class BaseProjectBlueprint < Blueprinter::Base
+            fields :name
+          end
+        RUBY
+      end
+
+      let_class("ProjectBlueprint") do
+        <<~'RUBY'
+          class ProjectBlueprint < BaseProjectBlueprint
+            fields :description
+            association :user, blueprint: UserBlueprint
+          end
+        RUBY
+      end
+
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            fields :email
+            association :projects, blueprint: ProjectBlueprint
+          end
+        RUBY
+      end
+
+      it "does not loop infinitely and falls back to $ref for circular reference" do
+        expect { subject }.not_to raise_error
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "description" => { "type" => "string" },
+                  "name" => { "type" => "string" },
+                  "user" => {
+                    "type" => "array",
+                    "items" => { "$ref" => "#/components/schemas/UserBlueprint" }
+                  }
+                }
+              }
+            }
+          }
+        })
       end
     end
   end
@@ -1040,7 +1092,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it do
+      it "inherits and resolves nested associations across multiple blueprint levels" do
         is_expected.to eq({
           "type" => "array",
           "items" => {
@@ -1093,7 +1145,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it do
+      it "includes identifier in nested blueprint schema" do
         is_expected.to eq({
           "type" => "array",
           "items" => {
@@ -1119,6 +1171,61 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
       it "ensures identifier appears first in properties" do
         expect(subject["items"]["properties"].keys.first).to eq("id")
         expect(subject.dig("items", "properties", "projects", "items", "properties").keys.first).to eq("uuid")
+      end
+    end
+
+    context "with circular association through inheritance" do
+      let_class("BaseProjectBlueprint") do
+        <<~'RUBY'
+          class BaseProjectBlueprint < Blueprinter::Base
+            fields :name
+          end
+        RUBY
+      end
+
+      let_class("ProjectBlueprint") do
+        <<~'RUBY'
+          class ProjectBlueprint < BaseProjectBlueprint
+            fields :description
+            association :user, blueprint: UserBlueprint
+          end
+        RUBY
+      end
+
+      let_class("UserBlueprint") do
+        <<~'RUBY'
+          class UserBlueprint < Blueprinter::Base
+            fields :email
+            association :projects, blueprint: ProjectBlueprint
+          end
+        RUBY
+      end
+
+      it "does not loop infinitely and falls back to $ref for circular reference" do
+        expect { subject }.not_to raise_error
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "projects" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "description" => { "type" => "string" },
+                    "name" => { "type" => "string" },
+                    "user" => {
+                      "type" => "array",
+                      "items" => { "$ref" => "#/components/schemas/UserBlueprint" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        })
       end
     end
   end


### PR DESCRIPTION
Closes #291

### What this PR does?

- Extract blueprint: class reference and recursively build nested schema
- Support name: rename option for associations
- Default to array type in the output
- Fall back to empty object schema when referenced blueprint cannot be resolved

### Example Code

- `routes.rb`

```ruby
Rage.routes.draw do
  root to: ->(env) { [200, {}, ["It works!"]] }
  get "/data_mining", to: "data_mining#show_data_mining"
end
```

- `data_mining_controller.rb`

```ruby

class DataMiningController < RageController::API

  # @response DataMining
  def show_data_mining
    data_mining_details = { 
      test_id: 'Fourth Edition',
      uuid: 'Third Edition', 
      email: 'MorganKaufmann@publishers.com', 
      first_name: 'Morgan', 
      hello_world: 'Earth', 
      projects: [
        { 
          hello_world: 'Project 1', 
          email: 'test@email.com',
          uuid: 'Third Edition',
          data_mining: [{
            uuid: 'Third Edition',
            test_id: 'Fourth Edition',
            email: 'test@publishers.com',
            first_name: 'John',
            hello_world: 'Mars'
          }]
        },
      ]
    }
    render json: DataMining.render(data_mining_details)
  end
end


```

- `data_mining_base.rb`

```ruby
class DataMiningBase < Blueprinter::Base
  identifier :uuid
  field :hello_world
  field :email, name: :something
  association :data_mining, blueprint: DataMining
end
```

- `data_mining.rb`

```ruby
class DataMining < Blueprinter::Base
  identifier :test_id
  field "email", name: :login
  fields "first_name", :hello_world
  association :projects, blueprint: DataMiningBase, name: :classmate
end
```

- `Blueprinter Response for route /data_mining`

```
{
  "test_id": "Fourth Edition",
  "classmate": [
    {
      "uuid": "Third Edition",
      "data_mining": [
        {
          "test_id": "Fourth Edition",
          "classmate": null,
          "first_name": "John",
          "hello_world": "Mars",
          "login": "test@publishers.com"
        }
      ],
      "hello_world": "Project 1",
      "something": "test@email.com"
    }
  ],
  "first_name": "Morgan",
  "hello_world": "Earth",
  "login": "MorganKaufmann@publishers.com"
}
```


- `OpenAPI response output for # @response DataMining`

```
{
  "test_id": "string",
  "classmate": [
    {
      "uuid": "string",
      "data_mining": [
        {
          "test_id": "string",
          "classmate": [
            {
              "uuid": "string",
              "data_mining": [
                "string"
              ],
              "hello_world": "string",
              "something": "string"
            }
          ],
          "first_name": "string",
          "hello_world": "string",
          "login": "string"
        }
      ],
      "hello_world": "string",
      "something": "string"
    }
  ],
  "first_name": "string",
  "hello_world": "string",
  "login": "string"
}
```

### ScreenRecording & ScreenShot

- Before

<img width="1358" height="726" alt="Before" src="https://github.com/user-attachments/assets/10ceed1e-54d8-4bfe-8892-4becb79b820e" />


https://github.com/user-attachments/assets/fde7d354-a273-4913-9a45-414b905d157b





- After

<img width="1348" height="736" alt="After" src="https://github.com/user-attachments/assets/646676d2-b48b-4586-8fc9-4721274b1018" />


https://github.com/user-attachments/assets/18654cac-a86f-402d-84c1-c6fa83bc05b4

