### PR TITLE
[Cookies] Use request host fallback when resolving cookie domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - [Request] Treat IPv6 literals as non-domain hosts.
+- [Cookies] Use request host fallback when resolving cookie domains.
 
 ## [1.25.0] - 2026-06-03
 

--- a/lib/rage/cookies.rb
+++ b/lib/rage/cookies.rb
@@ -201,7 +201,7 @@ class Rage::Cookies
     end
 
     if (domain = value[:domain])
-      host = @env["HTTP_HOST"]&.sub(/:\d+\z/, "")
+      host = Rack::Request.new(@env).host
 
       processed_domain = if domain.is_a?(String)
         domain

--- a/spec/controller/api/cookies_spec.rb
+++ b/spec/controller/api/cookies_spec.rb
@@ -6,10 +6,11 @@ require "domain_name"
 RSpec.describe RageController::API do
   subject do
     cookie_header = cookies.map { |k, v| "#{k}=#{v}" }.join("; ")
-    described_class.new({ "HTTP_COOKIE" => cookie_header, "HTTP_HOST" => request_host }, nil)
+    described_class.new({ "HTTP_COOKIE" => cookie_header, **request_env }, nil)
   end
 
   let(:request_host) { "cookie.test.com" }
+  let(:request_env) { { "HTTP_HOST" => request_host } }
 
   context "with no cookies" do
     let(:cookies) { {} }
@@ -308,6 +309,24 @@ RSpec.describe RageController::API do
           expect(response_cookies[:user_id]).to eq("120; domain=cookie.test.com")
         end
       end
+
+      context "when request uses SERVER_NAME fallback" do
+        let(:request_env) do
+          {
+            "SERVER_NAME" => "cookie.test.com",
+            "SERVER_PORT" => "3000"
+          }
+        end
+
+        it "correctly sets domain value" do
+          subject.cookies[:user_id] = {
+            domain: %w(api.test.com cookie.test.com),
+            value: 120
+          }
+
+          expect(response_cookies[:user_id]).to eq("120; domain=cookie.test.com")
+        end
+      end
     end
 
     context "with :all domain" do
@@ -318,6 +337,24 @@ RSpec.describe RageController::API do
         }
 
         expect(response_cookies[:user_id]).to eq("120; domain=test.com")
+      end
+
+      context "when request uses SERVER_NAME fallback" do
+        let(:request_env) do
+          {
+            "SERVER_NAME" => "cookie.test.com",
+            "SERVER_PORT" => "3000"
+          }
+        end
+
+        it "correctly sets domain value" do
+          subject.cookies[:user_id] = {
+            domain: :all,
+            value: 120
+          }
+
+          expect(response_cookies[:user_id]).to eq("120; domain=test.com")
+        end
       end
     end
 


### PR DESCRIPTION
## Description:

Issue #318 reported that cookie domain resolution could depend on `HTTP_HOST` only.

This PR updates `Rage::Cookies` to derive the request host through `Rack::Request`, so cookie domain resolution follows the same host fallback semantics as request host handling when `HTTP_HOST` is missing and `SERVER_NAME` is present.

It also adds regression tests that cover both array-based domains and `domain: :all` when the request uses `SERVER_NAME` fallback.

Closes #318.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting checks in WSL using `rubocop --except Layout/EndOfLine lib/rage/cookies.rb spec/controller/api/cookies_spec.rb`.
- [x] I have run focused tests in WSL using `rspec spec/controller/api/cookies_spec.rb`.
- [x] I have run broader related tests in WSL using `rspec spec/controller/api`.

### Before the fix:

<img width="893" height="417" alt="image" src="https://github.com/user-attachments/assets/0f97d76a-c66b-4250-989d-97298740c360" />

### After the fix:

<img width="890" height="416" alt="image" src="https://github.com/user-attachments/assets/622ffa0f-5550-4636-996f-542c6bdd2a9d" />
