### PR TITLE
[Router] Fall back to SERVER_NAME for exact host constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - [Request] Treat IPv6 literals as non-domain hosts.
+- [Router] Fall back to `SERVER_NAME` when deriving exact host constraints.
 
 ## [1.25.0] - 2026-06-03
 

--- a/lib/rage/router/constrainer.rb
+++ b/lib/rage/router/constrainer.rb
@@ -69,7 +69,7 @@ class Rage::Router::Constrainer
       # Optimization: inline the derivation for the common built in constraints
       if !strategy.custom?
         if key == :host
-          lines << "   host: env['HTTP_HOST'.freeze]&.sub(/:\\d+\\z/, ''.freeze),"
+          lines << "   host: (host = env['HTTP_HOST'.freeze]) ? host.sub(/:\\d+\\z/, ''.freeze) : env['SERVER_NAME'.freeze],"
         else
           raise ArgumentError, "unknown non-custom strategy for compiling constraint derivation function"
         end

--- a/lib/rage/router/constrainer.rb
+++ b/lib/rage/router/constrainer.rb
@@ -69,7 +69,7 @@ class Rage::Router::Constrainer
       # Optimization: inline the derivation for the common built in constraints
       if !strategy.custom?
         if key == :host
-          lines << "   host: (host = env['HTTP_HOST'.freeze]) ? host.sub(/:\\d+\\z/, ''.freeze) : env['SERVER_NAME'.freeze],"
+          lines << "   host: env['HTTP_HOST'.freeze]&.sub(/:\\d+\\z/, ''.freeze) || env['SERVER_NAME'.freeze],"
         else
           raise ArgumentError, "unknown non-custom strategy for compiling constraint derivation function"
         end

--- a/spec/router/constraints_spec.rb
+++ b/spec/router/constraints_spec.rb
@@ -21,6 +21,23 @@ RSpec.describe Rage::Router::Backend do
     expect(result).to eq("get photos")
   end
 
+  it "correctly processes a constrained url when request host falls back to SERVER_NAME" do
+    router.on("GET", "/photos", ->(_) { "get photos" }, constraints: { host: "google.com" })
+
+    env = {
+      "REQUEST_METHOD" => "GET",
+      "PATH_INFO" => "/photos",
+      "SERVER_NAME" => "google.com",
+      "SERVER_PORT" => "3000",
+      "rack.input" => StringIO.new
+    }
+
+    handler = router.lookup(env)
+
+    expect(handler).not_to be_nil
+    expect(handler[:handler].call(env, handler[:params])).to eq("get photos")
+  end
+
   it "correctly processes urls with multiple constraints" do
     router.on("GET", "/photos", ->(_) { "US photos" }, constraints: { host: "google.com" })
     router.on("GET", "/photos", ->(_) { "CA photos" }, constraints: { host: "google.ca" })


### PR DESCRIPTION
## Description:

Issue #320 reported that exact router host constraints only derived the request host from `HTTP_HOST`.

This PR updates the router constrainer to fall back to `SERVER_NAME` when `HTTP_HOST` is missing, while still stripping the port from `HTTP_HOST` when it is present.

It also adds a regression spec that covers exact host-constrained route lookup when the request host comes from `SERVER_NAME`.

Closes #320.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using `bundle exec rubocop --except Layout/EndOfLine lib/rage/router/constrainer.rb spec/router/constraints_spec.rb`.
- [x] I have run focused tests in WSL using `bundle exec rspec spec/router/constraints_spec.rb`.
- [x] I have run the broader router suite in WSL using `bundle exec rspec spec/router`.

### Before the fix:

<img width="889" height="324" alt="image" src="https://github.com/user-attachments/assets/e57ee789-62a6-49c8-bee9-224a81e1b1b2" />

### After the fix:

<img width="889" height="322" alt="image" src="https://github.com/user-attachments/assets/78c4bbad-c465-4ccb-bc8a-3ae08a44ea7c" />
