### PR TITLE
Wrap resume fiber closures in blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+## [1.25.1] - 2026-06-08
+
+### Fixed
+
+- Wrap resume fiber closures in blocks (#322).
+
 ## [1.25.0] - 2026-06-03
 
 ### Added

--- a/lib/rage/fiber_scheduler.rb
+++ b/lib/rage/fiber_scheduler.rb
@@ -115,10 +115,8 @@ class Rage::FiberScheduler
       end
     end
 
-    ::Iodine.subscribe(channel, &resume_fiber_block)
-    if timeout
-      ::Iodine.run_after((timeout * 1000).to_i, &resume_fiber_block)
-    end
+    ::Iodine.subscribe(channel) { resume_fiber_block.call }
+    ::Iodine.run_after((timeout * 1000).to_i) { resume_fiber_block.call } if timeout
 
     Fiber.yield
   end

--- a/lib/rage/version.rb
+++ b/lib/rage/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rage
-  VERSION = "1.25.0"
+  VERSION = "1.25.1"
 end


### PR DESCRIPTION
When passing a proc via `&proc` to Iodine, Ruby's proc-to-block-to-proc conversion seems to retain references to the original proc's binding even after the callback is removed from `IodineStore`. Wrapping with `{ proc.call }` creates a minimal closure that only captures a reference to the proc variable, allowing the GC to properly collect the associated objects when the subscription is removed.