### PR TITLE
[API] Use weak comparison for If-None-Match validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- [API] Use weak comparison for `If-None-Match` validation.
 - [Request] Treat IPv6 literals as non-domain hosts.
 - [Router] Fall back to `SERVER_NAME` when deriving exact host constraints.
 - [Cookies] Use request host fallback when resolving cookie domains.

--- a/lib/rage/request.rb
+++ b/lib/rage/request.rb
@@ -271,8 +271,10 @@ class Rage::Request
 
     return true if requested_etags.empty?
     return false if response_etag.nil?
+    return true if requested_etags.include?("*")
 
-    requested_etags.include?(response_etag) || requested_etags.include?("*")
+    response_etag = weak_etag(response_etag)
+    requested_etags.any? { |requested_etag| weak_etag(requested_etag) == response_etag }
   end
 
   def not_modified?(request_not_modified_since:, response_last_modified:)
@@ -280,6 +282,10 @@ class Rage::Request
     return false if response_last_modified.nil?
 
     request_not_modified_since >= response_last_modified
+  end
+
+  def weak_etag(etag)
+    etag.delete_prefix("W/")
   end
 
   # @private

--- a/lib/rage/request.rb
+++ b/lib/rage/request.rb
@@ -284,7 +284,7 @@ class Rage::Request
     request_not_modified_since >= response_last_modified
   end
 
-  def weak_etag(etag)
+  private def weak_etag(etag)
     etag.delete_prefix("W/")
   end
 

--- a/spec/controller/api/conditional_get_spec.rb
+++ b/spec/controller/api/conditional_get_spec.rb
@@ -180,12 +180,12 @@ RSpec.describe RageController::API do
       let(:env) { { "HTTP_IF_NONE_MATCH" => "\"#{Digest::SHA1.hexdigest("123")}\"" } }
       let(:expected_etag) { %(W/"#{Digest::SHA1.hexdigest("123")}") }
 
-      it "renders the requested resource" do
+      it "returns NOT MODIFIED" do
         expect(run_action(klass, :stale_etag_test, env:)).to match(
-          [200, a_hash_including(
+          [304, a_hash_including(
             Rage::Response::ETAG_HEADER => expected_etag,
             Rage::Response::LAST_MODIFIED_HEADER => nil
-          ), ["test_etag"]]
+          ), []]
         )
       end
     end


### PR DESCRIPTION
## Description:

Issue #324 reported that `If-None-Match` validation used exact string comparison, so a strong request ETag like `"..."` did not match Rage's weak response ETag `W/"..."`.

This PR updates `Rage::Request#etag_matches?` to use weak comparison for `If-None-Match` validation, while keeping wildcard handling unchanged.

It also updates the conditional GET regression spec to cover the strong-request / weak-response match and adds a changelog entry.

Closes #324.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting checks in WSL using `bundle exec rubocop --except Layout/EndOfLine lib/rage/request.rb spec/controller/api/conditional_get_spec.rb`.
- [x] I have run focused tests in WSL using `bundle exec rspec spec/controller/api/conditional_get_spec.rb`.
- [x] I have run a broader controller API regression pass in WSL using `bundle exec rspec spec/controller/api`.


### Before the fix:

<img width="838" height="242" alt="image" src="https://github.com/user-attachments/assets/939a6b03-fb2e-4533-95fb-f5ba08beeb93" />

### After the fix:

<img width="833" height="253" alt="image" src="https://github.com/user-attachments/assets/ea562d90-9162-4952-b5ef-7f39cb621db8" />
