### PR TITLE
[OpenAPI]: Parse association declarations in Blueprinter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [OpenAPI] Add support for blueprint inheritance. Child blueprints now inherit fields from parent blueprints.
 - [OpenAPI] Refactor `Rage::OpenAPI::Parsers::Ext::Blueprinter` using live reflection instead of Prism AST traversal to simplify schema extraction
 - Connection pool improvements (#301).
+- [OpenAPI] Add Blueprinter association parsing with cycle detection (#291)
 
 ### Fixed
 

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -57,35 +57,25 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
   def extract_associations(reflections, view_name)
     return {} unless (view = reflections[view_name])
 
-    view.associations.each_with_object({}) do |(_, association), hash|
-      blueprint = resolve_blueprint(association.blueprint)
-      name = association.display_name.to_s
+    view.associations.each_with_object({}) do |(_, association), properties|
+      blueprint = association.blueprint
+      name = association.name.to_s
       is_collection = collection_association?(name)
 
-      if blueprint.nil?
-        item_schema = { "type" => "string" }
+      item_schema = if blueprint.is_a?(Proc)
+        { "type" => "object" }
       elsif @parsing_stack.include?(blueprint.name)
         @root.schema_registry[blueprint.name] ||= nil
-        item_schema = { "$ref" => "#/components/schemas/#{blueprint.name}" }
+        { "$ref" => "#/components/schemas/#{blueprint.name}" }
       else
-        item_schema = build_schema(blueprint, false)
+        build_schema(blueprint, false)
       end
 
-      hash[name] = is_collection ? { "type" => "array", "items" => item_schema } : item_schema
+      properties[name] = is_collection ? { "type" => "array", "items" => item_schema } : item_schema
     end
   end
 
   private
-
-  def resolve_blueprint(blueprint)
-    return blueprint unless blueprint.respond_to?(:call)
-
-    begin
-      blueprint.call(nil)
-    rescue
-      nil
-    end
-  end
 
   def collection_association?(name)
     return true unless name.respond_to?(:singularize)

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -4,6 +4,7 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
   def initialize(namespace: Object, root: Rage::OpenAPI::Nodes::Root.new, **)
     @namespace = namespace
     @root = root
+    @parsing_stack = Set.new
   end
 
   def known_definition?(str)
@@ -16,17 +17,28 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
   def parse(klass_str)
     is_collection, raw_klass_str, _ = Rage::OpenAPI.__parse_serializer_args(klass_str)
     klass = @namespace.const_get(raw_klass_str)
-    build_schema(klass, is_collection)
+    schema = build_schema(klass, is_collection)
+
+    if @root.schema_registry.key?(raw_klass_str)
+      @root.schema_registry[raw_klass_str] = is_collection ? schema["items"] : schema
+    end
+
+    schema
   end
 
   private
 
   def build_schema(klass, is_collection)
+    @parsing_stack.add(klass.name)
+
     reflections = klass.reflections
     identifier_fields = extract_fields(reflections, :identifier)
     default_fields = extract_fields(reflections, :default)
+    association_fields = extract_associations(reflections, :default)
 
-    schema = identifier_fields.merge(default_fields.sort.to_h)
+    @parsing_stack.delete(klass.name)
+
+    schema = identifier_fields.merge(default_fields.merge(association_fields).sort.to_h)
 
     result = { "type" => "object" }
     result["properties"] = schema if schema.any?
@@ -39,6 +51,27 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
 
     view.fields.each_with_object({}) do |(_, field), hash|
       hash[field.display_name.to_s] = { "type" => "string" }
+    end
+  end
+
+  def extract_associations(reflections, view_name)
+    return {} unless (view = reflections[view_name])
+
+    view.associations.each_with_object({}) do |(_, assoc), hash|
+      blueprint = assoc.blueprint
+
+      if @parsing_stack.include?(blueprint&.name)
+        @root.schema_registry[blueprint&.name] ||= nil
+        hash[assoc.display_name.to_s] = {
+          "type" => "array",
+          "items" => { "$ref" => "#/components/schemas/#{blueprint&.name}" }
+        }
+      else
+        hash[assoc.display_name.to_s] = {
+          "type" => "array",
+          "items" => build_schema(blueprint, false)
+        }
+      end
     end
   end
 end

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -59,7 +59,7 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
 
     view.associations.each_with_object({}) do |(_, association), properties|
       blueprint = association.blueprint
-      name = association.name.to_s
+      name, display_name = association.name.to_s, association.display_name.to_s
       is_collection = collection_association?(name)
 
       item_schema = if blueprint.is_a?(Proc)
@@ -71,7 +71,7 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
         build_schema(blueprint, false)
       end
 
-      properties[name] = is_collection ? { "type" => "array", "items" => item_schema } : item_schema
+      properties[display_name] = is_collection ? { "type" => "array", "items" => item_schema } : item_schema
     end
   end
 

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -57,21 +57,39 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
   def extract_associations(reflections, view_name)
     return {} unless (view = reflections[view_name])
 
-    view.associations.each_with_object({}) do |(_, assoc), hash|
-      blueprint = assoc.blueprint
+    view.associations.each_with_object({}) do |(_, association), hash|
+      blueprint = resolve_blueprint(association.blueprint)
+      name = association.display_name.to_s
+      is_collection = collection_association?(name)
 
-      if @parsing_stack.include?(blueprint&.name)
-        @root.schema_registry[blueprint&.name] ||= nil
-        hash[assoc.display_name.to_s] = {
-          "type" => "array",
-          "items" => { "$ref" => "#/components/schemas/#{blueprint&.name}" }
-        }
+      if blueprint.nil?
+        item_schema = { "type" => "string" }
+      elsif @parsing_stack.include?(blueprint.name)
+        @root.schema_registry[blueprint.name] ||= nil
+        item_schema = { "$ref" => "#/components/schemas/#{blueprint.name}" }
       else
-        hash[assoc.display_name.to_s] = {
-          "type" => "array",
-          "items" => build_schema(blueprint, false)
-        }
+        item_schema = build_schema(blueprint, false)
       end
+
+      hash[name] = is_collection ? { "type" => "array", "items" => item_schema } : item_schema
     end
+  end
+
+  private
+
+  def resolve_blueprint(blueprint)
+    return blueprint unless blueprint.respond_to?(:call)
+
+    begin
+      blueprint.call(nil)
+    rescue
+      nil
+    end
+  end
+
+  def collection_association?(name)
+    return true unless name.respond_to?(:singularize)
+
+    name.singularize != name
   end
 end

--- a/spec/openapi/parsers/ext/blueprinter_spec.rb
+++ b/spec/openapi/parsers/ext/blueprinter_spec.rb
@@ -408,12 +408,12 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it "uses the original association name as the key, ignoring the name: alias" do
+      it "uses the name alias as the association key" do
         is_expected.to eq({
           "type" => "object",
           "properties" => {
             "email" => { "type" => "string" },
-            "projects" => {
+            "work_projects" => {
               "type" => "array",
               "items" => {
                 "type" => "object",
@@ -720,7 +720,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
           "type" => "object",
           "properties" => {
             "email" => { "type" => "string" },
-            "projects" => {
+            "classmates" => {
               "type" => "array",
               "items" => { "type" => "object" }
             }
@@ -927,12 +927,12 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it "cardinality follows the original association name, not the alias" do
+      it "follows the alias, not the original association key" do
         is_expected.to eq({
           "type" => "object",
           "properties" => {
             "email" => { "type" => "string" },
-            "projects" => {
+            "classmate" => {
               "type" => "array",
               "items" => {
                 "type" => "object",
@@ -1243,14 +1243,14 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it "uses the original association name as the key, ignoring the name: alias" do
+      it "uses the name alias as the association key" do
         is_expected.to eq({
           "type" => "array",
           "items" => {
             "type" => "object",
             "properties" => {
               "email" => { "type" => "string" },
-              "projects" => {
+              "work_projects" => {
                 "type" => "array",
                 "items" => {
                   "type" => "object",
@@ -1582,7 +1582,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
             "type" => "object",
             "properties" => {
               "email" => { "type" => "string" },
-              "projects" => {
+              "classmates" => {
                 "type" => "array",
                 "items" => { "type" => "object" }
               }
@@ -1806,14 +1806,14 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it "cardinality follows the original association name, not the alias" do
+      it "follows the alias, not the original association key" do
         is_expected.to eq({
           "type" => "array",
           "items" => {
             "type" => "object",
             "properties" => {
               "email" => { "type" => "string" },
-              "projects" => {
+              "classmate" => {
                 "type" => "array",
                 "items" => {
                   "type" => "object",

--- a/spec/openapi/parsers/ext/blueprinter_spec.rb
+++ b/spec/openapi/parsers/ext/blueprinter_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "blueprinter"
+require "active_support/inflector"
 
 RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
   include_context "mocked_classes"
@@ -431,7 +432,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
       let_class("ProjectBlueprint", parent: Blueprinter::Base) do
         <<~'RUBY'
           fields :name
-          association :user, blueprint: UserBlueprint
+          association :users, blueprint: UserBlueprint
         RUBY
       end
 
@@ -454,7 +455,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
                 "type" => "object",
                 "properties" => {
                   "name" => { "type" => "string" },
-                  "user" => {
+                  "users" => {
                     "type" => "array",
                     "items" => { "$ref" => "#/components/schemas/UserBlueprint" }
                   }
@@ -575,7 +576,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
       let_class("ProjectBlueprint", parent: mocked_classes["BaseProjectBlueprint"]) do
         <<~'RUBY'
           fields :description
-          association :user, blueprint: UserBlueprint
+          association :users, blueprint: UserBlueprint
         RUBY
       end
 
@@ -599,7 +600,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
                 "properties" => {
                   "description" => { "type" => "string" },
                   "name" => { "type" => "string" },
-                  "user" => {
+                  "users" => {
                     "type" => "array",
                     "items" => { "$ref" => "#/components/schemas/UserBlueprint" }
                   }
@@ -691,6 +692,361 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
                   "id" => { "type" => "string" },
                   "name" => { "type" => "string" }
                 }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with a blueprint: Proc that ignores its argument" do
+      let(:resource) { "ConstLambdaParent" }
+
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("ConstLambdaParent", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          field :email
+          association :projects, name: :classmates, blueprint: ->(_) { ProjectBlueprint }
+        RUBY
+      end
+
+      it "resolves the Proc by calling it and renders the same schema as a static reference" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "classmates" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        })
+      end
+
+      it "does not raise" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "with a proc that branches on the parent object (not statically resolvable)" do
+      let(:resource) { "BranchingUserBlueprint" }
+
+      let_class("DataMiningBase", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("DataMiningExtended", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name, :uuid
+        RUBY
+      end
+
+      let_class("BranchingUserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email, :subject
+          association :projects,
+                      blueprint: ->(parent) {
+                        parent[:subject] == "Graph Theroy" ? DataMiningExtended : DataMiningBase
+                      }
+        RUBY
+      end
+
+      it "does not raise NoMethodError for undefined method 'reflections' on Proc" do
+        expect { subject }.not_to raise_error
+      end
+
+      it "falls back to a generic untyped item schema instead of guessing a branch" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "subject" => { "type" => "string" },
+            "projects" => {
+              "type" => "array",
+              "items" => { "type" => "string" }
+            }
+          }
+        })
+      end
+    end
+
+    context "with a circular association expressed as a Proc" do
+      let(:resource) { "RecursiveNodeBlueprint" }
+
+      let_class("RecursiveNodeBlueprint", parent: Blueprinter::Base) do
+        <<~RUBY
+          field :id
+          association :children, blueprint: ->(_) { RecursiveNodeBlueprint }
+        RUBY
+      end
+
+      it "does not infinite-loop and falls back to $ref for the circular reference" do
+        expect { subject }.not_to raise_error
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "children" => {
+              "type" => "array",
+              "items" => { "$ref" => "#/components/schemas/RecursiveNodeBlueprint" }
+            }
+          }
+        })
+      end
+    end
+
+    context "with a pluralized association name" do
+      let(:resource) { "PluralizedBlueprint" }
+
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("PluralizedBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: ProjectBlueprint
+        RUBY
+      end
+
+      it "renders as an array" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with a singular association name" do
+      let(:resource) { "SingularBlueprint" }
+
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("SingularBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :project, blueprint: ProjectBlueprint
+        RUBY
+      end
+
+      it "renders as a single object, not array-wrapped" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "project" => {
+              "type" => "object",
+              "properties" => {
+                "id" => { "type" => "string" },
+                "name" => { "type" => "string" }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with a singular association name when ActiveSupport's singularize is unavailable" do
+      let(:resource) { "ActiveBlueprint" }
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("ActiveBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :project, blueprint: ProjectBlueprint
+        RUBY
+      end
+
+      before do
+        allow_any_instance_of(String).to receive(:respond_to?).and_call_original
+        allow_any_instance_of(String).to receive(:respond_to?).with(:singularize).and_return(false)
+      end
+
+      it "falls back to array, since cardinality cannot be determined without singularize" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "project" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with a pluralized association name and a singular name: alias" do
+      let(:resource) { "PluralizedBlueprint" }
+
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("PluralizedBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: ProjectBlueprint, name: :classmate
+        RUBY
+      end
+
+      it "cardinality follows the alias, not the original association key" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "classmate" => {
+              "type" => "object",
+              "properties" => {
+                "id" => { "type" => "string" },
+                "name" => { "type" => "string" }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with an unresolvable dynamic blueprint on a singular association name" do
+      let(:resource) { "DataBluePrint" }
+
+      let_class("DataMiningBase", parent: Blueprinter::Base) do
+        <<~RUBY
+          fields :id
+        RUBY
+      end
+
+      let_class("DataMiningExtended", parent: Blueprinter::Base) do
+        <<~RUBY
+          fields :id, :uuid
+        RUBY
+      end
+
+      let_class("DataBluePrint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email, :subject
+          association :project,
+                      blueprint: ->(parent) {
+                        parent[:subject] == "Graph Theroy" ? DataMiningExtended : DataMiningBase
+                      }
+        RUBY
+      end
+
+      it "falls back to a generic untyped schema directly (no array wrapper, since name is singular)" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "subject" => { "type" => "string" },
+            "project" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "known limitation: uncountable noun association name" do
+      let(:resource) { "LimitationBlueprint" }
+
+      let_class("DatumBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id
+        RUBY
+      end
+
+      let_class("LimitationBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :data, blueprint: DatumBlueprint
+        RUBY
+      end
+
+      it "correctly detects :data as a collection, since ActiveSupport singularizes it to :datum" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "data" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "known limitation: genuinely uncountable noun association name" do
+      let(:resource) { "InformerBlueprint" }
+
+      let_class("InfoBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id
+        RUBY
+      end
+
+      let_class("InformerBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :information, blueprint: InfoBlueprint
+        RUBY
+      end
+
+      it "is treated as a single object even if the real relationship is a collection" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "information" => {
+              "type" => "object",
+              "properties" => {
+                "id" => { "type" => "string" }
               }
             }
           }
@@ -917,7 +1273,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
       let_class("ProjectBlueprint", parent: Blueprinter::Base) do
         <<~'RUBY'
           fields :name
-          association :user, blueprint: UserBlueprint
+          association :users, blueprint: UserBlueprint
         RUBY
       end
 
@@ -942,7 +1298,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
                   "type" => "object",
                   "properties" => {
                     "name" => { "type" => "string" },
-                    "user" => {
+                    "users" => {
                       "type" => "array",
                       "items" => { "$ref" => "#/components/schemas/UserBlueprint" }
                     }
@@ -1070,7 +1426,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
       let_class("ProjectBlueprint", parent: mocked_classes["BaseProjectBlueprint"]) do
         <<~'RUBY'
           fields :description
-          association :user, blueprint: UserBlueprint
+          association :users, blueprint: UserBlueprint
         RUBY
       end
 
@@ -1096,7 +1452,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
                   "properties" => {
                     "description" => { "type" => "string" },
                     "name" => { "type" => "string" },
-                    "user" => {
+                    "users" => {
                       "type" => "array",
                       "items" => { "$ref" => "#/components/schemas/UserBlueprint" }
                     }
@@ -1198,6 +1554,392 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
                     "id" => { "type" => "string" },
                     "name" => { "type" => "string" }
                   }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with a blueprint: Proc that ignores its argument" do
+      let(:resource) { "Array<ConstLambdaParentCollection>" }
+
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("ConstLambdaParentCollection", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          field :email
+          association :projects, name: :classmates, blueprint: ->(_) { ProjectBlueprint }
+        RUBY
+      end
+
+      it "resolves the Proc by calling it and renders the same schema as a static reference" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "classmates" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "id" => { "type" => "string" },
+                    "name" => { "type" => "string" }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+
+      it "does not raise" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "with a proc that branches on the parent object (not statically resolvable)" do
+      let(:resource) { "Array<BranchingUserBlueprintCollection>" }
+
+      let_class("DataMiningBase", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("DataMiningExtended", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name, :uuid
+        RUBY
+      end
+
+      let_class("BranchingUserBlueprintCollection", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email, :subject
+          association :projects,
+                      blueprint: ->(parent) {
+                        parent[:subject] == "Graph Theroy" ? DataMiningExtended : DataMiningBase
+                      }
+        RUBY
+      end
+
+      it "does not raise NoMethodError for undefined method 'reflections' on Proc" do
+        expect { subject }.not_to raise_error
+      end
+
+      it "falls back to a generic untyped item schema instead of guessing a branch" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "subject" => { "type" => "string" },
+              "projects" => {
+                "type" => "array",
+                "items" => { "type" => "string" }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with a circular association expressed as a Proc" do
+      let(:resource) { "Array<RecursiveNodeBlueprintCollection>" }
+
+      let_class("RecursiveNodeBlueprintCollection", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          field :id
+          association :children, blueprint: ->(_) { RecursiveNodeBlueprintCollection }
+        RUBY
+      end
+
+      it "does not infinite-loop and falls back to $ref for the circular reference" do
+        expect { subject }.not_to raise_error
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "id" => { "type" => "string" },
+              "children" => {
+                "type" => "array",
+                "items" => { "$ref" => "#/components/schemas/RecursiveNodeBlueprintCollection" }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with a pluralized association name" do
+      let(:resource) { "Array<PluralizedBlueprintCollection>" }
+
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("PluralizedBlueprintCollection", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: ProjectBlueprint
+        RUBY
+      end
+
+      it "renders as an array" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "projects" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "id" => { "type" => "string" },
+                    "name" => { "type" => "string" }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with a singular association name" do
+      let(:resource) { "Array<SingularBlueprintCollection>" }
+
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("SingularBlueprintCollection", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :project, blueprint: ProjectBlueprint
+        RUBY
+      end
+
+      it "renders as a single object, not array-wrapped" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "project" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with a singular association name when ActiveSupport's singularize is unavailable" do
+      let(:resource) { "Array<ActiveBlueprintCollection>" }
+
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("ActiveBlueprintCollection", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :project, blueprint: ProjectBlueprint
+        RUBY
+      end
+
+      before do
+        allow_any_instance_of(String).to receive(:respond_to?).and_call_original
+        allow_any_instance_of(String).to receive(:respond_to?).with(:singularize).and_return(false)
+      end
+
+      it "falls back to array, since cardinality cannot be determined without singularize" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "project" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "id" => { "type" => "string" },
+                    "name" => { "type" => "string" }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with a pluralized association name and a singular name: alias" do
+      let(:resource) { "Array<PluralizedAliasBlueprintCollection>" }
+
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("PluralizedAliasBlueprintCollection", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: ProjectBlueprint, name: :classmate
+        RUBY
+      end
+
+      it "cardinality follows the alias, not the original association key" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "classmate" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with an unresolvable dynamic blueprint on a singular association name" do
+      let(:resource) { "Array<DataBluePrintCollection>" }
+
+      let_class("DataMiningBase", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id
+        RUBY
+      end
+
+      let_class("DataMiningExtended", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :uuid
+        RUBY
+      end
+
+      let_class("DataBluePrintCollection", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email, :subject
+          association :project,
+                      blueprint: ->(parent) {
+                        parent[:subject] == "Graph Theroy" ? DataMiningExtended : DataMiningBase
+                      }
+        RUBY
+      end
+
+      it "falls back to a generic untyped schema directly (no array wrapper, since name is singular)" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "subject" => { "type" => "string" },
+              "project" => { "type" => "string" }
+            }
+          }
+        })
+      end
+    end
+
+    context "known limitation: uncountable noun association name" do
+      let(:resource) { "Array<LimitationBlueprintCollection>" }
+
+      let_class("DatumBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id
+        RUBY
+      end
+
+      let_class("LimitationBlueprintCollection", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :data, blueprint: DatumBlueprint
+        RUBY
+      end
+
+      it "correctly detects :data as a collection, since ActiveSupport singularizes it to :datum" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "data" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "id" => { "type" => "string" }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "known limitation: genuinely uncountable noun association name" do
+      let(:resource) { "Array<InformerBlueprintCollection>" }
+
+      let_class("InfoBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id
+        RUBY
+      end
+
+      let_class("InformerBlueprintCollection", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :information, blueprint: InfoBlueprint
+        RUBY
+      end
+
+      it "is treated as a single object even if the real relationship is a collection" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "information" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" }
                 }
               }
             }

--- a/spec/openapi/parsers/ext/blueprinter_spec.rb
+++ b/spec/openapi/parsers/ext/blueprinter_spec.rb
@@ -408,12 +408,12 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it "uses the name alias as the association key" do
+      it "uses the original association name as the key, ignoring the name: alias" do
         is_expected.to eq({
           "type" => "object",
           "properties" => {
             "email" => { "type" => "string" },
-            "work_projects" => {
+            "projects" => {
               "type" => "array",
               "items" => {
                 "type" => "object",
@@ -715,20 +715,14 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it "resolves the Proc by calling it and renders the same schema as a static reference" do
+      it "returns generic object schema for a Proc blueprint without resolving it" do
         is_expected.to eq({
           "type" => "object",
           "properties" => {
             "email" => { "type" => "string" },
-            "classmates" => {
+            "projects" => {
               "type" => "array",
-              "items" => {
-                "type" => "object",
-                "properties" => {
-                  "id" => { "type" => "string" },
-                  "name" => { "type" => "string" }
-                }
-              }
+              "items" => { "type" => "object" }
             }
           }
         })
@@ -768,7 +762,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         expect { subject }.not_to raise_error
       end
 
-      it "falls back to a generic untyped item schema instead of guessing a branch" do
+      it "returns generic object schema for unresolvable Proc blueprint" do
         is_expected.to eq({
           "type" => "object",
           "properties" => {
@@ -776,7 +770,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
             "subject" => { "type" => "string" },
             "projects" => {
               "type" => "array",
-              "items" => { "type" => "string" }
+              "items" => { "type" => "object" }
             }
           }
         })
@@ -793,7 +787,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it "does not infinite-loop and falls back to $ref for the circular reference" do
+      it "does not infinite-loop and returns generic object schema for Proc blueprint" do
         expect { subject }.not_to raise_error
         is_expected.to eq({
           "type" => "object",
@@ -801,7 +795,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
             "id" => { "type" => "string" },
             "children" => {
               "type" => "array",
-              "items" => { "$ref" => "#/components/schemas/RecursiveNodeBlueprint" }
+              "items" => { "type" => "object" }
             }
           }
         })
@@ -933,16 +927,19 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it "cardinality follows the alias, not the original association key" do
+      it "cardinality follows the original association name, not the alias" do
         is_expected.to eq({
           "type" => "object",
           "properties" => {
             "email" => { "type" => "string" },
-            "classmate" => {
-              "type" => "object",
-              "properties" => {
-                "id" => { "type" => "string" },
-                "name" => { "type" => "string" }
+            "projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
               }
             }
           }
@@ -975,13 +972,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it "falls back to a generic untyped schema directly (no array wrapper, since name is singular)" do
+      it "returns generic object schema for unresolvable Proc blueprint (no array wrapper, since name is singular)" do
         is_expected.to eq({
           "type" => "object",
           "properties" => {
             "email" => { "type" => "string" },
             "subject" => { "type" => "string" },
-            "project" => { "type" => "string" }
+            "project" => { "type" => "object" }
           }
         })
       end
@@ -1246,14 +1243,14 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it "uses the name alias as the association key" do
+      it "uses the original association name as the key, ignoring the name: alias" do
         is_expected.to eq({
           "type" => "array",
           "items" => {
             "type" => "object",
             "properties" => {
               "email" => { "type" => "string" },
-              "work_projects" => {
+              "projects" => {
                 "type" => "array",
                 "items" => {
                   "type" => "object",
@@ -1578,22 +1575,16 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it "resolves the Proc by calling it and renders the same schema as a static reference" do
+      it "returns generic object schema for a Proc blueprint without resolving it" do
         is_expected.to eq({
           "type" => "array",
           "items" => {
             "type" => "object",
             "properties" => {
               "email" => { "type" => "string" },
-              "classmates" => {
+              "projects" => {
                 "type" => "array",
-                "items" => {
-                  "type" => "object",
-                  "properties" => {
-                    "id" => { "type" => "string" },
-                    "name" => { "type" => "string" }
-                  }
-                }
+                "items" => { "type" => "object" }
               }
             }
           }
@@ -1634,7 +1625,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         expect { subject }.not_to raise_error
       end
 
-      it "falls back to a generic untyped item schema instead of guessing a branch" do
+      it "returns generic object schema for unresolvable Proc blueprint" do
         is_expected.to eq({
           "type" => "array",
           "items" => {
@@ -1644,7 +1635,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
               "subject" => { "type" => "string" },
               "projects" => {
                 "type" => "array",
-                "items" => { "type" => "string" }
+                "items" => { "type" => "object" }
               }
             }
           }
@@ -1662,7 +1653,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it "does not infinite-loop and falls back to $ref for the circular reference" do
+      it "does not infinite-loop and returns generic object schema for Proc blueprint" do
         expect { subject }.not_to raise_error
         is_expected.to eq({
           "type" => "array",
@@ -1672,7 +1663,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
               "id" => { "type" => "string" },
               "children" => {
                 "type" => "array",
-                "items" => { "$ref" => "#/components/schemas/RecursiveNodeBlueprintCollection" }
+                "items" => { "type" => "object" }
               }
             }
           }
@@ -1815,18 +1806,21 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it "cardinality follows the alias, not the original association key" do
+      it "cardinality follows the original association name, not the alias" do
         is_expected.to eq({
           "type" => "array",
           "items" => {
             "type" => "object",
             "properties" => {
               "email" => { "type" => "string" },
-              "classmate" => {
-                "type" => "object",
-                "properties" => {
-                  "id" => { "type" => "string" },
-                  "name" => { "type" => "string" }
+              "projects" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "id" => { "type" => "string" },
+                    "name" => { "type" => "string" }
+                  }
                 }
               }
             }
@@ -1860,7 +1854,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it "falls back to a generic untyped schema directly (no array wrapper, since name is singular)" do
+      it "returns generic object schema for unresolvable Proc blueprint (no array wrapper, since name is singular)" do
         is_expected.to eq({
           "type" => "array",
           "items" => {
@@ -1868,7 +1862,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
             "properties" => {
               "email" => { "type" => "string" },
               "subject" => { "type" => "string" },
-              "project" => { "type" => "string" }
+              "project" => { "type" => "object" }
             }
           }
         })

--- a/spec/openapi/parsers/ext/blueprinter_spec.rb
+++ b/spec/openapi/parsers/ext/blueprinter_spec.rb
@@ -356,6 +356,347 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         expect(subject["properties"].keys[1]).to eq("id")
       end
     end
+
+    context "with a basic association" do
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: ProjectBlueprint
+        RUBY
+      end
+
+      before { ProjectBlueprint }
+
+      it "defaults to array type with nested blueprint schema" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with association name alias" do
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: ProjectBlueprint, name: :work_projects
+        RUBY
+      end
+
+      it "uses the name alias as the association key" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "work_projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with circular association" do
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :name
+          association :user, blueprint: UserBlueprint
+        RUBY
+      end
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: ProjectBlueprint
+        RUBY
+      end
+
+      it "does not loop infinitely and falls back to $ref for circular reference" do
+        expect { subject }.not_to raise_error
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "name" => { "type" => "string" },
+                  "user" => {
+                    "type" => "array",
+                    "items" => { "$ref" => "#/components/schemas/UserBlueprint" }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with association across multiple levels of inheritance" do
+      let_class("TagBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :label
+        RUBY
+      end
+
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :name
+          association :tags, blueprint: TagBlueprint
+        RUBY
+      end
+
+      let_class("BaseUserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: ProjectBlueprint
+        RUBY
+      end
+
+      let_class("UserBlueprint", parent: mocked_classes["BaseUserBlueprint"]) do
+        <<~'RUBY'
+          fields :first_name
+        RUBY
+      end
+
+      it "includes identifier in collection items" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "first_name" => { "type" => "string" },
+            "projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "name" => { "type" => "string" },
+                  "tags" => {
+                    "type" => "array",
+                    "items" => {
+                      "type" => "object",
+                      "properties" => {
+                        "id" => { "type" => "string" },
+                        "label" => { "type" => "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with identifier in associated blueprint" do
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          identifier :uuid
+          fields :name
+        RUBY
+      end
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          identifier :id
+          fields :email
+          association :projects, blueprint: ProjectBlueprint
+        RUBY
+      end
+
+      it "includes identifier in nested blueprint schema" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "email" => { "type" => "string" },
+            "projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "uuid" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        })
+      end
+
+      it "ensures identifier appears first in properties" do
+        expect(subject["properties"].keys.first).to eq("id")
+        expect(subject.dig("properties", "projects", "items", "properties").keys.first).to eq("uuid")
+      end
+    end
+
+    context "with circular association through inheritance" do
+      let_class("BaseProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :name
+        RUBY
+      end
+
+      let_class("ProjectBlueprint", parent: mocked_classes["BaseProjectBlueprint"]) do
+        <<~'RUBY'
+          fields :description
+          association :user, blueprint: UserBlueprint
+        RUBY
+      end
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: ProjectBlueprint
+        RUBY
+      end
+
+      it "does not loop infinitely and falls back to $ref for circular reference" do
+        expect { subject }.not_to raise_error
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "description" => { "type" => "string" },
+                  "name" => { "type" => "string" },
+                  "user" => {
+                    "type" => "array",
+                    "items" => { "$ref" => "#/components/schemas/UserBlueprint" }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with multiple associations" do
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("TeamBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: ProjectBlueprint
+          association :teams, blueprint: TeamBlueprint
+        RUBY
+      end
+
+      it "includes schemas for all associations" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            },
+            "teams" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with namespaced association" do
+      unless Object.const_defined?(:V1)
+        Object.const_set(:V1, Module.new)
+      end
+      V1::ProjectBlueprint = Class.new(Blueprinter::Base)
+      V1::ProjectBlueprint.class_eval do
+        fields :id, :name
+      end
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: V1::ProjectBlueprint
+        RUBY
+      end
+
+      it "resolves namespaced blueprint" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
   end
 
   describe "collection" do
@@ -495,6 +836,373 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         })
         expect(subject["items"]["properties"].keys.first).to eq("uuid")
         expect(subject["items"]["properties"].keys[1]).to eq("id")
+      end
+    end
+
+    context "with a basic association" do
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: ProjectBlueprint
+        RUBY
+      end
+
+      it "defaults to array type with nested blueprint schema" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "projects" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "id" => { "type" => "string" },
+                    "name" => { "type" => "string" }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with association name alias" do
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: ProjectBlueprint, name: :work_projects
+        RUBY
+      end
+
+      it "uses the name alias as the association key" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "work_projects" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "id" => { "type" => "string" },
+                    "name" => { "type" => "string" }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with circular association" do
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :name
+          association :user, blueprint: UserBlueprint
+        RUBY
+      end
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: ProjectBlueprint
+        RUBY
+      end
+
+      it "does not loop infinitely and falls back to $ref for circular reference" do
+        expect { subject }.not_to raise_error
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "projects" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "name" => { "type" => "string" },
+                    "user" => {
+                      "type" => "array",
+                      "items" => { "$ref" => "#/components/schemas/UserBlueprint" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with association across multiple levels of inheritance" do
+      let_class("TagBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :label
+        RUBY
+      end
+
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :name
+          association :tags, blueprint: TagBlueprint
+        RUBY
+      end
+
+      let_class("BaseUserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: ProjectBlueprint
+        RUBY
+      end
+
+      let_class("UserBlueprint", parent: mocked_classes["BaseUserBlueprint"]) do
+        <<~'RUBY'
+          fields :first_name
+        RUBY
+      end
+
+      it "inherits and resolves nested associations across multiple blueprint levels" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "first_name" => { "type" => "string" },
+              "projects" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "name" => { "type" => "string" },
+                    "tags" => {
+                      "type" => "array",
+                      "items" => {
+                        "type" => "object",
+                        "properties" => {
+                          "id" => { "type" => "string" },
+                          "label" => { "type" => "string" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with identifier in associated blueprint" do
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          identifier :uuid
+          fields :name
+        RUBY
+      end
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          identifier :id
+          fields :email
+          association :projects, blueprint: ProjectBlueprint
+        RUBY
+      end
+
+      it "includes identifier in nested blueprint schema" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "id" => { "type" => "string" },
+              "email" => { "type" => "string" },
+              "projects" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "uuid" => { "type" => "string" },
+                    "name" => { "type" => "string" }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+
+      it "ensures identifier appears first in properties" do
+        expect(subject["items"]["properties"].keys.first).to eq("id")
+        expect(subject.dig("items", "properties", "projects", "items", "properties").keys.first).to eq("uuid")
+      end
+    end
+
+    context "with circular association through inheritance" do
+      let_class("BaseProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :name
+        RUBY
+      end
+
+      let_class("ProjectBlueprint", parent: mocked_classes["BaseProjectBlueprint"]) do
+        <<~'RUBY'
+          fields :description
+          association :user, blueprint: UserBlueprint
+        RUBY
+      end
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: ProjectBlueprint
+        RUBY
+      end
+
+      it "does not loop infinitely and falls back to $ref for circular reference" do
+        expect { subject }.not_to raise_error
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "projects" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "description" => { "type" => "string" },
+                    "name" => { "type" => "string" },
+                    "user" => {
+                      "type" => "array",
+                      "items" => { "$ref" => "#/components/schemas/UserBlueprint" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with multiple associations" do
+      let(:resource) { "Array<UserBlueprint>" }
+
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("TeamBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: ProjectBlueprint
+          association :teams, blueprint: TeamBlueprint
+        RUBY
+      end
+
+      it "includes schemas for all associations" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "projects" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "id" => { "type" => "string" },
+                    "name" => { "type" => "string" }
+                  }
+                }
+              },
+              "teams" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "id" => { "type" => "string" },
+                    "name" => { "type" => "string" }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with namespaced association" do
+      let(:resource) { "Array<UserBlueprint>" }
+
+      unless Object.const_defined?(:V1)
+        Object.const_set(:V1, Module.new)
+      end
+      V1::ProjectBlueprint = Class.new(Blueprinter::Base) unless V1.const_defined?(:ProjectBlueprint)
+      V1::ProjectBlueprint.class_eval do
+        fields :id, :name
+      end
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: V1::ProjectBlueprint
+        RUBY
+      end
+
+      it "resolves namespaced blueprint" do
+        is_expected.to eq({
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "email" => { "type" => "string" },
+              "projects" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "properties" => {
+                    "id" => { "type" => "string" },
+                    "name" => { "type" => "string" }
+                  }
+                }
+              }
+            }
+          }
+        })
       end
     end
   end

--- a/spec/support/contexts/mocked_classes.rb
+++ b/spec/support/contexts/mocked_classes.rb
@@ -29,8 +29,8 @@ RSpec.shared_context "mocked_classes" do
     if block
       if defined?(Blueprinter::Base) && parent.ancestors.include?(Blueprinter::Base)
         klass.class_eval(block.call)
-      else
-        klass.class_eval(&block)
+        Object.send(:remove_const, class_name) if Object.const_defined?(class_name, false)
+        Object.const_set(class_name, klass)
       end
     end
 


### PR DESCRIPTION
closes #291

### What this PR does?

- Extract blueprint: class reference and recursively build nested schema
- Support name: rename option for associations
- Default to array type in the output
- Fall back to empty object schema when referenced blueprint cannot be resolved


### Example Code

- `routes.rb`

```ruby
Rage.routes.draw do
  root to: ->(env) { [200, {}, ["It works!"]] }
  get "/data_mining", to: "data_mining#show_data_mining"
end
```

- `data_mining_controller.rb`

```ruby

class DataMiningController < RageController::API

  # @response DataMining
  def show_data_mining
    data_mining_details = { 
      test_id: 'Fourth Edition',
      uuid: 'Third Edition', 
      email: 'MorganKaufmann@publishers.com', 
      first_name: 'Morgan', 
      hello_world: 'Earth', 
      projects: [
        { 
          hello_world: 'Project 1', 
          email: 'test@email.com',
          uuid: 'Third Edition',
          data_mining: [{
            uuid: 'Third Edition',
            test_id: 'Fourth Edition',
            email: 'test@publishers.com',
            first_name: 'John',
            hello_world: 'Mars'
          }]
        },
      ]
    }
    render json: DataMining.render(data_mining_details)
  end
end


```

- `data_mining_base.rb`

```ruby
class DataMiningBase < Blueprinter::Base
  identifier :uuid
  field :hello_world
  field :email, name: :something
  association :data_mining, blueprint: DataMining
end
```

- `data_mining.rb`

```ruby
class DataMining < Blueprinter::Base
  identifier :test_id
  field "email", name: :login
  fields "first_name", :hello_world
  association :projects, blueprint: DataMiningBase, name: :classmate
end
```

- `Blueprinter Response for route /data_mining`

```
{
  "test_id": "Fourth Edition",
  "classmate": [
    {
      "uuid": "Third Edition",
      "data_mining": [
        {
          "test_id": "Fourth Edition",
          "classmate": null,
          "first_name": "John",
          "hello_world": "Mars",
          "login": "test@publishers.com"
        }
      ],
      "hello_world": "Project 1",
      "something": "test@email.com"
    }
  ],
  "first_name": "Morgan",
  "hello_world": "Earth",
  "login": "MorganKaufmann@publishers.com"
}
```


- `OpenAPI response output for # @response DataMining`

```
{
  "test_id": "string",
  "classmate": [
    {
      "uuid": "string",
      "data_mining": [
        {
          "test_id": "string",
          "classmate": [
            {
              "uuid": "string",
              "data_mining": [
                "string"
              ],
              "hello_world": "string",
              "something": "string"
            }
          ],
          "first_name": "string",
          "hello_world": "string",
          "login": "string"
        }
      ],
      "hello_world": "string",
      "something": "string"
    }
  ],
  "first_name": "string",
  "hello_world": "string",
  "login": "string"
}
```

### Screenshot

- Before 

<img width="1349" height="717" alt="image" src="https://github.com/user-attachments/assets/dc99e080-be2f-48b2-a5f5-b0c4a53b023a" />


- After

<img width="1352" height="719" alt="First" src="https://github.com/user-attachments/assets/c82ffd68-a526-4bb4-a352-946cb9b475a8" />


https://github.com/user-attachments/assets/a1d2e806-b857-409e-8dae-15b1157b3814


