### PR TITLE
[Cookies] Match array-based cookie domains case-insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [Request] Treat IPv6 literals as non-domain hosts.
 - [Router] Fall back to `SERVER_NAME` when deriving exact host constraints.
 - [Cookies] Use request host fallback when resolving cookie domains.
+- [Cookies] Match array-based cookie domains case-insensitively.
 
 ## [1.25.1] - 2026-06-08
 

--- a/lib/rage/cookies.rb
+++ b/lib/rage/cookies.rb
@@ -208,7 +208,7 @@ class Rage::Cookies
       elsif domain == :all
         DomainName(host).domain
       elsif domain.is_a?(Array)
-        host if domain.include?(host)
+        domain.find { |candidate| candidate.casecmp?(host) } if host
       end
     end
 

--- a/spec/controller/api/cookies_spec.rb
+++ b/spec/controller/api/cookies_spec.rb
@@ -310,6 +310,32 @@ RSpec.describe RageController::API do
         end
       end
 
+      context "when request host uses different casing" do
+        let(:request_host) { "COOKIE.TEST.COM" }
+
+        it "correctly sets domain value" do
+          subject.cookies[:user_id] = {
+            domain: %w(api.test.com cookie.test.com),
+            value: 120
+          }
+
+          expect(response_cookies[:user_id]).to eq("120; domain=cookie.test.com")
+        end
+      end
+
+      context "when request host uses different casing and includes a port" do
+        let(:request_host) { "COOKIE.TEST.COM:3000" }
+
+        it "correctly sets domain value" do
+          subject.cookies[:user_id] = {
+            domain: %w(api.test.com cookie.test.com),
+            value: 120
+          }
+
+          expect(response_cookies[:user_id]).to eq("120; domain=cookie.test.com")
+        end
+      end
+
       context "when request uses SERVER_NAME fallback" do
         let(:request_env) do
           {


### PR DESCRIPTION
## Description:

Issue #327 reported that array-based cookie domains were matched with exact string equality, so uppercase request hosts did not match lowercase configured domains.

This PR updates `Rage::Cookies#[]=` to match array-based cookie domains case-insensitively while still using the configured domain value in the `Set-Cookie` header.

It also adds regression tests for uppercase hosts with and without a port, and updates `CHANGELOG.md`.

Closes #327.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting checks in WSL using `bundle exec rubocop --except Layout/EndOfLine lib/rage/cookies.rb spec/controller/api/cookies_spec.rb`.
- [x] I have run focused tests in WSL using `bundle exec rspec spec/controller/api/cookies_spec.rb`.
- [x] I have run broader regression checks in WSL using `bundle exec rspec spec/controller/api spec/router/constraints_spec.rb`.


### Before the fix:

<img width="623" height="287" alt="image" src="https://github.com/user-attachments/assets/c3eee025-3fc3-4530-b076-d34c04843fbe" />

### After the fix:

<img width="634" height="291" alt="image" src="https://github.com/user-attachments/assets/d9463db1-4672-4965-b8c5-d734d2abe1e9" />
