### PR TITLE
[API] Ignore If-Modified-Since when If-None-Match is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 
+- [API] Ignore `If-Modified-Since` when `If-None-Match` is present.
 - [Request] Treat IPv6 literals as non-domain hosts.
 - [Router] Fall back to `SERVER_NAME` when deriving exact host constraints.
 - [Cookies] Use request host fallback when resolving cookie domains.

--- a/lib/rage/request.rb
+++ b/lib/rage/request.rb
@@ -169,16 +169,18 @@ class Rage::Request
   #  request.fresh?(last_modified: Time.utc(2023, 12, 15))
   #  request.fresh?(etag: "123")
   def fresh?(etag:, last_modified:)
+    request_if_none_match = if_none_match
+    request_not_modified_since = if_not_modified_since
+
     # Always render response when no freshness information
     # is provided in the request.
-    return false unless if_none_match || if_not_modified_since
+    return false unless request_if_none_match || request_not_modified_since
 
-    etag_matches?(
-      requested_etags: if_none_match, response_etag: etag
-    ) && not_modified?(
-      request_not_modified_since: if_not_modified_since,
-      response_last_modified: last_modified
-    )
+    if request_if_none_match
+      etag_matches?(requested_etags: request_if_none_match, response_etag: etag)
+    else
+      not_modified?(request_not_modified_since: request_not_modified_since, response_last_modified: last_modified)
+    end
   end
 
   # Get the domain part of the request.

--- a/spec/controller/api/conditional_get_spec.rb
+++ b/spec/controller/api/conditional_get_spec.rb
@@ -248,6 +248,21 @@ RSpec.describe RageController::API do
       end
     end
 
+    context "and If-None-Match matches but If-Modified-Since is stale" do
+      let(:env) do
+        {
+          "HTTP_IF_MODIFIED_SINCE" => Time.utc(2023, 11, 15).httpdate,
+          "HTTP_IF_NONE_MATCH" => %(W/"#{Digest::SHA1.hexdigest("123")}")
+        }
+      end
+
+      it "returns NOT MODIFIED" do
+        expect(run_action(klass, :stale_last_modified_and_etag_test, env:)).to match(
+          [304, a_hash_including(Rage::Response::ETAG_HEADER => expected_etag, Rage::Response::LAST_MODIFIED_HEADER => expected_last_modified), []]
+        )
+      end
+    end
+
     context "and request is stale" do
       let(:env) do
         {
@@ -299,17 +314,17 @@ RSpec.describe RageController::API do
     context "and last_modified is not set in the action" do
       let(:env) do
         {
-          "HTTP_IF_MODIFIED_SINCE" => Time.utc(2023, 12, 15).httpdate,
-          "HTTP_IF_NONE_MATCH" => "123"
+          "HTTP_IF_MODIFIED_SINCE" => Time.utc(2023, 11, 15).httpdate,
+          "HTTP_IF_NONE_MATCH" => %(W/"#{Digest::SHA1.hexdigest("123")}")
         }
       end
 
-      it "renders the requested resource" do
+      it "returns NOT MODIFIED" do
         expect(run_action(klass, :stale_etag_test, env:)).to match(
-          [200, a_hash_including(
+          [304, a_hash_including(
             Rage::Response::ETAG_HEADER => expected_etag,
             Rage::Response::LAST_MODIFIED_HEADER => nil
-          ), ["test_etag"]]
+          ), []]
         )
       end
     end


### PR DESCRIPTION
## Description:

Issue #329 reported that Rage still evaluated `If-Modified-Since` when `If-None-Match` was present, so an older `If-Modified-Since` could force a `200 OK` even when `If-None-Match` already matched.

This PR updates `Rage::Request#fresh?` to give `If-None-Match` precedence when it is present and only fall back to `If-Modified-Since` when no `If-None-Match` header is sent.

It also adds regression tests for the matching `If-None-Match` + stale `If-Modified-Since` case and for the path where the response only sets an ETag.

Closes #329.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting checks in WSL using `bundle exec rubocop --except Layout/EndOfLine lib/rage/request.rb spec/controller/api/conditional_get_spec.rb`.
- [x] I have run focused tests in WSL using `bundle exec rspec spec/controller/api/conditional_get_spec.rb`.
- [x] I have run broader regression checks in WSL using `bundle exec rspec spec/controller/api`.

### Before the fix:

<img width="1007" height="548" alt="image" src="https://github.com/user-attachments/assets/122fb58d-8dda-469d-ba48-b71caaf020ca" />

### After the fix:

<img width="1007" height="538" alt="image" src="https://github.com/user-attachments/assets/1fb3c764-9ddc-4c47-9195-9d086c5fbbcb" />
