### PR TITLE
[Request] Normalize malformed SERVER_NAME fallback hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - [API] Ignore `If-Modified-Since` when `If-None-Match` is present.
 - [API] Use weak comparison for `If-None-Match` validation.
+- [Request] Normalize malformed `SERVER_NAME` fallback hosts that already include a port.
 - [Request] Treat IPv6 literals as non-domain hosts.
 - [Router] Fall back to `SERVER_NAME` when deriving exact host constraints.
 - [Cookies] Use request host fallback when resolving cookie domains.

--- a/lib/rage/cookies.rb
+++ b/lib/rage/cookies.rb
@@ -201,8 +201,7 @@ class Rage::Cookies
     end
 
     if (domain = value[:domain])
-      host = Rack::Request.new(@env).host
-      host ||= Rage::Internal.extract_host(@env["SERVER_NAME"]) unless @env["HTTP_HOST"]
+      host = Rage::Request.new(@env).host
 
       processed_domain = if domain.is_a?(String)
         domain

--- a/lib/rage/cookies.rb
+++ b/lib/rage/cookies.rb
@@ -202,6 +202,7 @@ class Rage::Cookies
 
     if (domain = value[:domain])
       host = Rack::Request.new(@env).host
+      host ||= Rage::Internal.extract_host(@env["SERVER_NAME"]) unless @env["HTTP_HOST"]
 
       processed_domain = if domain.is_a?(String)
         domain

--- a/lib/rage/internal.rb
+++ b/lib/rage/internal.rb
@@ -44,6 +44,19 @@ class Rage::Internal
       }.join(", ")
     end
 
+    # Extract the host from a host:port authority while leaving bare IPv6 literals unchanged.
+    # @param authority [String, nil]
+    # @return [String, nil]
+    def extract_host(authority)
+      if authority&.start_with?("[")
+        authority.sub(/\]:\d+\z/, "]")
+      elsif authority&.count(":") == 1
+        authority.sub(/:\d+\z/, "")
+      else
+        authority
+      end
+    end
+
     # Generate a stream name based on the provided object.
     # @param streamables [#id, String, Symbol, Numeric, Array] an object that will be used to generate the stream name
     # @return [String] the generated stream name

--- a/lib/rage/internal.rb
+++ b/lib/rage/internal.rb
@@ -44,19 +44,6 @@ class Rage::Internal
       }.join(", ")
     end
 
-    # Extract the host from a host:port authority while leaving bare IPv6 literals unchanged.
-    # @param authority [String, nil]
-    # @return [String, nil]
-    def extract_host(authority)
-      if authority&.start_with?("[")
-        authority.sub(/\]:\d+\z/, "]")
-      elsif authority&.count(":") == 1
-        authority.sub(/:\d+\z/, "")
-      else
-        authority
-      end
-    end
-
     # Generate a stream name based on the provided object.
     # @param streamables [#id, String, Symbol, Numeric, Array] an object that will be used to generate the stream name
     # @return [String] the generated stream name

--- a/lib/rage/request.rb
+++ b/lib/rage/request.rb
@@ -226,7 +226,15 @@ class Rage::Request
   private
 
   def rack_request
-    @rack_request ||= Rack::Request.new(@env)
+    @rack_request ||= begin
+      request_env = @env
+
+      if !request_env["HTTP_HOST"] && (server_name = Rage::Internal.extract_host(request_env["SERVER_NAME"])) != request_env["SERVER_NAME"]
+        request_env = request_env.merge("SERVER_NAME" => server_name)
+      end
+
+      Rack::Request.new(request_env)
+    end
   end
 
   def check_method(name)

--- a/lib/rage/request.rb
+++ b/lib/rage/request.rb
@@ -36,6 +36,19 @@ class Rage::Request
   # Set data structure of all RFC defined HTTP headers
   KNOWN_HTTP_METHODS = (RFC2616 + RFC2518 + RFC3253 + RFC3648 + RFC3744 + RFC5323 + RFC4791 + RFC5789).to_set
 
+  # Extract the host from a host:port authority while leaving bare IPv6 literals unchanged.
+  # @param authority [String, nil]
+  # @return [String, nil]
+  def self.extract_host(authority)
+    if authority&.start_with?("[")
+      authority.sub(/\]:\d+\z/, "]")
+    elsif authority&.count(":") == 1
+      authority.sub(/:\d+\z/, "")
+    else
+      authority
+    end
+  end
+
   # @private
   # @param env [Hash] Rack env
   # @param controller [RageController::API]
@@ -229,7 +242,7 @@ class Rage::Request
     @rack_request ||= begin
       request_env = @env
 
-      if !request_env["HTTP_HOST"] && (server_name = Rage::Internal.extract_host(request_env["SERVER_NAME"])) != request_env["SERVER_NAME"]
+      if !request_env["HTTP_HOST"] && (server_name = self.class.extract_host(request_env["SERVER_NAME"])) != request_env["SERVER_NAME"]
         request_env = request_env.merge("SERVER_NAME" => server_name)
       end
 

--- a/lib/rage/router/constrainer.rb
+++ b/lib/rage/router/constrainer.rb
@@ -69,7 +69,7 @@ class Rage::Router::Constrainer
       # Optimization: inline the derivation for the common built in constraints
       if !strategy.custom?
         if key == :host
-          lines << "   host: env['HTTP_HOST'.freeze]&.sub(/:\\d+\\z/, ''.freeze) || Rage::Internal.extract_host(env['SERVER_NAME'.freeze]),"
+          lines << "   host: env['HTTP_HOST'.freeze]&.sub(/:\\d+\\z/, ''.freeze) || Rage::Request.extract_host(env['SERVER_NAME'.freeze]),"
         else
           raise ArgumentError, "unknown non-custom strategy for compiling constraint derivation function"
         end

--- a/lib/rage/router/constrainer.rb
+++ b/lib/rage/router/constrainer.rb
@@ -69,7 +69,7 @@ class Rage::Router::Constrainer
       # Optimization: inline the derivation for the common built in constraints
       if !strategy.custom?
         if key == :host
-          lines << "   host: env['HTTP_HOST'.freeze]&.sub(/:\\d+\\z/, ''.freeze) || env['SERVER_NAME'.freeze],"
+          lines << "   host: env['HTTP_HOST'.freeze]&.sub(/:\\d+\\z/, ''.freeze) || Rage::Internal.extract_host(env['SERVER_NAME'.freeze]),"
         else
           raise ArgumentError, "unknown non-custom strategy for compiling constraint derivation function"
         end

--- a/spec/controller/api/cookies_spec.rb
+++ b/spec/controller/api/cookies_spec.rb
@@ -353,6 +353,24 @@ RSpec.describe RageController::API do
           expect(response_cookies[:user_id]).to eq("120; domain=cookie.test.com")
         end
       end
+
+      context "when request uses malformed SERVER_NAME fallback" do
+        let(:request_env) do
+          {
+            "SERVER_NAME" => "cookie.test.com:3000",
+            "SERVER_PORT" => "3000"
+          }
+        end
+
+        it "correctly sets domain value" do
+          subject.cookies[:user_id] = {
+            domain: %w(api.test.com cookie.test.com),
+            value: 120
+          }
+
+          expect(response_cookies[:user_id]).to eq("120; domain=cookie.test.com")
+        end
+      end
     end
 
     context "with :all domain" do
@@ -369,6 +387,24 @@ RSpec.describe RageController::API do
         let(:request_env) do
           {
             "SERVER_NAME" => "cookie.test.com",
+            "SERVER_PORT" => "3000"
+          }
+        end
+
+        it "correctly sets domain value" do
+          subject.cookies[:user_id] = {
+            domain: :all,
+            value: 120
+          }
+
+          expect(response_cookies[:user_id]).to eq("120; domain=test.com")
+        end
+      end
+
+      context "when request uses malformed SERVER_NAME fallback" do
+        let(:request_env) do
+          {
+            "SERVER_NAME" => "cookie.test.com:3000",
             "SERVER_PORT" => "3000"
           }
         end

--- a/spec/rage/request_spec.rb
+++ b/spec/rage/request_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe Rage::Request do
     expect(request.url).to eq("http://localhost:3000/users?show_archived=true")
   end
 
+  context "when HTTP_HOST is missing and SERVER_NAME contains a port" do
+    before do
+      env.delete("HTTP_HOST")
+      env["SERVER_NAME"] = "api.foo.bar.com:3000"
+      env["SERVER_PORT"] = "3000"
+    end
+
+    it "normalizes the URL" do
+      expect(request.url).to eq("http://api.foo.bar.com:3000/users?show_archived=true")
+    end
+  end
+
   it "returns the path" do
     expect(request.path).to eq("/users")
   end
@@ -137,6 +149,14 @@ RSpec.describe Rage::Request do
       it "falls back to SERVER_NAME" do
         expect(subject).to eq("fallback.example")
       end
+
+      context "when SERVER_NAME contains a port" do
+        before { env["SERVER_NAME"] = "api.foo.bar.com:3000" }
+
+        it "falls back to the normalized SERVER_NAME" do
+          expect(subject).to eq("api.foo.bar.com")
+        end
+      end
     end
   end
 
@@ -177,6 +197,18 @@ RSpec.describe Rage::Request do
 
       it "returns nil" do
         expect(request.domain).to be_nil
+      end
+    end
+
+    context "without HTTP_HOST and with SERVER_NAME containing a port" do
+      before do
+        env.delete("HTTP_HOST")
+        env["SERVER_NAME"] = "api.foo.bar.com:3000"
+        env["SERVER_PORT"] = "3000"
+      end
+
+      it "returns the correct domain" do
+        expect(request.domain).to eq("bar.com")
       end
     end
   end

--- a/spec/router/constraints_spec.rb
+++ b/spec/router/constraints_spec.rb
@@ -38,6 +38,23 @@ RSpec.describe Rage::Router::Backend do
     expect(handler[:handler].call(env, handler[:params])).to eq("get photos")
   end
 
+  it "correctly processes a constrained url when malformed SERVER_NAME contains a port" do
+    router.on("GET", "/photos", ->(_) { "get photos" }, constraints: { host: "google.com" })
+
+    env = {
+      "REQUEST_METHOD" => "GET",
+      "PATH_INFO" => "/photos",
+      "SERVER_NAME" => "google.com:3000",
+      "SERVER_PORT" => "3000",
+      "rack.input" => StringIO.new
+    }
+
+    handler = router.lookup(env)
+
+    expect(handler).not_to be_nil
+    expect(handler[:handler].call(env, handler[:params])).to eq("get photos")
+  end
+
   it "correctly processes urls with multiple constraints" do
     router.on("GET", "/photos", ->(_) { "US photos" }, constraints: { host: "google.com" })
     router.on("GET", "/photos", ->(_) { "CA photos" }, constraints: { host: "google.ca" })


### PR DESCRIPTION
## Description:

Issue #331 reported that host fallback paths could break when `HTTP_HOST` was missing and `SERVER_NAME` already included a port, because Rage used the malformed fallback value as-is.

This PR normalizes malformed `SERVER_NAME` fallback hosts before they are used in request host handling, exact host constraints, and cookie domain resolution.

It also adds regression tests for request URL/host/domain handling, router exact host constraints, and cookie domain resolution when `SERVER_NAME` contains an embedded port, and updates `CHANGELOG.md`.

Closes #331.

## Checklist:

- [x] I have run linting checks using `bundle exec rubocop --except Layout/EndOfLine lib/rage/internal.rb lib/rage/request.rb lib/rage/cookies.rb lib/rage/router/constrainer.rb spec/rage/request_spec.rb spec/router/constraints_spec.rb spec/controller/api/cookies_spec.rb`.
- [x] I have run focused tests using `bundle exec rspec spec/rage/request_spec.rb spec/router/constraints_spec.rb spec/controller/api/cookies_spec.rb`.
- [x] I have run broader regression checks in WSL using `bundle exec rspec spec/controller/api spec/rage/request_spec.rb spec/router/constraints_spec.rb`.

### Before the fix:

<img width="1279" height="720" alt="image" src="https://github.com/user-attachments/assets/bbe8758a-b27e-4f87-b8eb-f175f74a9ec4" />

### After the fix:

<img width="1279" height="720" alt="image" src="https://github.com/user-attachments/assets/a6081620-803c-4d39-8139-32d2b5635f6d" />
