### PR TITLE
[Deferred] Ignore missing temp files during async cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - [API] Ignore `If-Modified-Since` when `If-None-Match` is present.
 - [API] Use weak comparison for `If-None-Match` validation.
+- [Deferred] Ignore missing temp files during async disk storage cleanup.
 - [Request] Treat IPv6 literals as non-domain hosts.
 - [Router] Fall back to `SERVER_NAME` when deriving exact host constraints.
 - [Cookies] Use request host fallback when resolving cookie domains.

--- a/lib/rage/deferred/backends/disk.rb
+++ b/lib/rage/deferred/backends/disk.rb
@@ -241,8 +241,7 @@ class Rage::Deferred::Backends::Disk
 
     # delete the old storage ensuring the copied data has already been written to disk
     Iodine.run_after(@fsync_frequency) do
-      old_storage.close
-      File.unlink(old_storage.path)
+      cleanup_storage(old_storage)
     end
   end
 
@@ -267,8 +266,14 @@ class Rage::Deferred::Backends::Disk
     end
 
     Iodine.run_after(@fsync_frequency) do
-      storage.close
-      File.unlink(storage.path)
+      cleanup_storage(storage)
     end
+  end
+
+  def cleanup_storage(storage)
+    storage.close
+    File.unlink(storage.path)
+  rescue Errno::ENOENT
+    nil
   end
 end

--- a/lib/rage/deferred/backends/disk.rb
+++ b/lib/rage/deferred/backends/disk.rb
@@ -271,9 +271,8 @@ class Rage::Deferred::Backends::Disk
   end
 
   def cleanup_storage(storage)
+    path = storage.path
     storage.close
-    File.unlink(storage.path)
-  rescue Errno::ENOENT
-    nil
+    File.unlink(path) if File.exist?(path)
   end
 end

--- a/spec/deferred/backends/disk_spec.rb
+++ b/spec/deferred/backends/disk_spec.rb
@@ -72,16 +72,30 @@ RSpec.describe Rage::Deferred::Backends::Disk do
 
   describe "#rotate_storage" do
     let(:task) { double("Rage::Deferred::Task") }
+    let(:task_id) { backend.add(task) }
 
     before do
       allow(backend).to receive(:rotate_storage).and_call_original
-      backend.add(task)
+      task_id
       backend.instance_variable_set(:@should_rotate, true)
     end
 
     it "rotates the storage when conditions are met" do
-      backend.remove(task)
+      backend.remove(task_id)
       expect(storage_path.glob("#{prefix}*").size).to eq(2)
+    end
+
+    it "ignores missing old storage files during async cleanup" do
+      scheduled_cleanups = []
+      allow(Iodine).to receive(:run_after) { |_, &block| scheduled_cleanups << block }
+
+      old_storage = backend.instance_variable_get(:@storage)
+
+      backend.remove(task_id)
+      File.unlink(old_storage.path)
+
+      expect(scheduled_cleanups.size).to eq(1)
+      expect { scheduled_cleanups.first.call }.not_to raise_error
     end
   end
 
@@ -128,6 +142,37 @@ RSpec.describe Rage::Deferred::Backends::Disk do
       task_id = backend.add(task)
 
       expect(task_id.split("-").first.to_i).to be > future_timestamps.max
+    end
+
+    it "With a recovered storage file already removed before async cleanup." do
+      main_file = storage_path.join("#{prefix}0-#{Time.now.strftime("%Y%m%d")}-#{Process.pid}-aaa")
+      recovered_file = storage_path.join("#{prefix}0-#{Time.now.strftime("%Y%m%d")}-#{Process.pid}-bbb")
+      main_storage = main_file.open("a+b")
+      recovered_storage = recovered_file.open("a+b")
+
+      {
+        main_storage => "main-task-id",
+        recovered_storage => "recovered-task-id"
+      }.each do |storage, task_id|
+        serialized = Marshal.dump("Rage::Deferred::Task").dump
+        entry = "add:#{task_id}:0:#{serialized}"
+        crc = Zlib.crc32(entry).to_s(16).rjust(8, "0")
+        storage.write("#{crc}:#{entry}\n")
+        storage.close
+      end
+
+      scheduled_cleanups = []
+      allow(Iodine).to receive(:run_after) { |_, &block| scheduled_cleanups << block }
+
+      backend = described_class.new(path: storage_path, prefix: prefix, fsync_frequency: fsync_frequency)
+      recovered_storage = backend.instance_variable_get(:@recovered_storages).first
+
+      expect(backend.pending_tasks.map(&:first)).to include("main-task-id", "recovered-task-id")
+
+      File.unlink(recovered_storage.path)
+
+      expect(scheduled_cleanups.size).to eq(1)
+      expect { scheduled_cleanups.first.call }.not_to raise_error
     end
 
     it "With empty storage file." do

--- a/spec/deferred/backends/disk_spec.rb
+++ b/spec/deferred/backends/disk_spec.rb
@@ -145,31 +145,15 @@ RSpec.describe Rage::Deferred::Backends::Disk do
     end
 
     it "With a recovered storage file already removed before async cleanup." do
-      main_file = storage_path.join("#{prefix}0-#{Time.now.strftime("%Y%m%d")}-#{Process.pid}-aaa")
-      recovered_file = storage_path.join("#{prefix}0-#{Time.now.strftime("%Y%m%d")}-#{Process.pid}-bbb")
-      main_storage = main_file.open("a+b")
-      recovered_storage = recovered_file.open("a+b")
-
-      {
-        main_storage => "main-task-id",
-        recovered_storage => "recovered-task-id"
-      }.each do |storage, task_id|
-        serialized = Marshal.dump("Rage::Deferred::Task").dump
-        entry = "add:#{task_id}:0:#{serialized}"
-        crc = Zlib.crc32(entry).to_s(16).rjust(8, "0")
-        storage.write("#{crc}:#{entry}\n")
-        storage.close
-      end
-
       scheduled_cleanups = []
+      recovered_storage = instance_double(File, path: storage_path.join("missing-recovered-storage"), close: nil)
+
       allow(Iodine).to receive(:run_after) { |_, &block| scheduled_cleanups << block }
+      allow(recovered_storage).to receive(:rewind)
+      allow(recovered_storage).to receive(:read).with(262_144).and_return(nil)
 
-      backend = described_class.new(path: storage_path, prefix: prefix, fsync_frequency: fsync_frequency)
-      recovered_storage = backend.instance_variable_get(:@recovered_storages).first
-
-      expect(backend.pending_tasks.map(&:first)).to include("main-task-id", "recovered-task-id")
-
-      File.unlink(recovered_storage.path)
+      backend.instance_variable_set(:@recovered_storages, [recovered_storage])
+      backend.pending_tasks
 
       expect(scheduled_cleanups.size).to eq(1)
       expect { scheduled_cleanups.first.call }.not_to raise_error


### PR DESCRIPTION
## Description:

Issue #333 reported that deferred disk backend temp-file cleanup could run asynchronously after the file had already been removed, raising `Errno::ENOENT` in later reactor-based specs.

This PR updates the deferred disk backend to route async storage cleanup through a shared helper that still closes the file handle and ignores only missing-file unlink errors.

It also adds regression tests for both rotated storage cleanup and recovered storage cleanup, and updates `CHANGELOG.md`.

Fixes #333.

### Before the fix:

- Running `bundle exec rspec spec/deferred/backends/disk_spec.rb spec/logger_spec.rb` could finish the examples and then still report an unprotected Iodine exception.
- The delayed cleanup callback could try to unlink a temp file that had already been removed.

#### Example output:

```text
Finished in 2.61 seconds (files took 1.62 seconds to load)
79 examples, 0 failures

ERROR: Iodine caught an unprotected exception - Errno::ENOENT: No such file or directory @ apply2files - /tmp/.../test_prefix...
.../lib/rage/deferred/backends/disk.rb:245:in `unlink'
.../lib/rage/deferred/backends/disk.rb:245:in `block in rotate_storage'
```

### After the fix:

- The same repro command finishes cleanly.
- Async cleanup still closes the file handle, and missing temp-file unlinks no longer raise.
- Regression coverage now exercises both rotated storage cleanup and recovered storage cleanup.

#### Example output:

```text
Finished in 2.46 seconds (files took 1.43 seconds to load)
79 examples, 0 failures
```

## Checklist:

- [x] I have run linting checks using `bundle exec rubocop lib/rage/deferred/backends/disk.rb spec/deferred/backends/disk_spec.rb`.
- [x] I have run focused tests using `bundle exec rspec spec/deferred/backends/disk_spec.rb spec/logger_spec.rb`.