### PR TITLE
[OpenAPI]: Add support for Blueprinter view parsing - `blocks`, `include_view`, `exclude`  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [OpenAPI] Refactor `Rage::OpenAPI::Parsers::Ext::Blueprinter` using live reflection instead of Prism AST traversal to simplify schema extraction
 - Connection pool improvements (#301).
 - [OpenAPI] Add Blueprinter association parsing with cycle detection (#291)
+- [OpenAPI] Add support for the `view:` option in Blueprinter parser.
 
 ### Fixed
 

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Rage::OpenAPI::Parsers::Ext::Blueprinter
+  class InvalidViewError < StandardError; end
+
   def initialize(namespace: Object, root: Rage::OpenAPI::Nodes::Root.new, **)
     @namespace = namespace
     @root = root
@@ -24,6 +26,8 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
     end
 
     schema
+  rescue InvalidViewError => e
+    Rage::OpenAPI.__log_warn e.message
   end
 
   private
@@ -33,10 +37,12 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
 
     view_name = serializer_options&.key?(:view) ? serializer_options[:view] : :default
     reflections = klass.reflections
+    view = reflections[view_name]
+    raise InvalidViewError, "invalid view #{view_name}" unless view
 
-    identifier_fields = extract_fields(reflections, :identifier)
-    default_fields = extract_fields(reflections, view_name)
-    association_fields = extract_associations(reflections, view_name)
+    identifier_fields = extract_fields(reflections[:identifier])
+    default_fields = extract_fields(view)
+    association_fields = extract_associations(view)
 
     @parsing_stack.delete(klass.name)
 
@@ -48,17 +54,13 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
     result
   end
 
-  def extract_fields(reflections, view_name)
-    return {} unless (view = reflections[view_name])
-
-    view.fields.each_with_object({}) do |(_, field), hash|
-      hash[field.display_name.to_s] = { "type" => "string" }
+  def extract_fields(view)
+    view.fields.each_with_object({}) do |(_, field), properties|
+      properties[field.display_name.to_s] = { "type" => "string" }
     end
   end
 
-  def extract_associations(reflections, view_name)
-    return {} unless (view = reflections[view_name])
-
+  def extract_associations(view)
     view.associations.each_with_object({}) do |(_, association), properties|
       blueprint = association.blueprint
       name, display_name = association.name.to_s, association.display_name.to_s
@@ -76,8 +78,6 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
       properties[display_name] = is_collection ? { "type" => "array", "items" => item_schema } : item_schema
     end
   end
-
-  private
 
   def collection_association?(name)
     return true unless name.respond_to?(:singularize)

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -15,9 +15,9 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
   end
 
   def parse(klass_str)
-    is_collection, raw_klass_str, _ = Rage::OpenAPI.__parse_serializer_args(klass_str)
+    is_collection, raw_klass_str, serializer_options = Rage::OpenAPI.__parse_serializer_args(klass_str)
     klass = @namespace.const_get(raw_klass_str)
-    schema = build_schema(klass, is_collection)
+    schema = build_schema(klass, is_collection, serializer_options)
 
     if @root.schema_registry.key?(raw_klass_str)
       @root.schema_registry[raw_klass_str] = is_collection ? schema["items"] : schema
@@ -28,13 +28,15 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
 
   private
 
-  def build_schema(klass, is_collection)
+  def build_schema(klass, is_collection, serializer_options = nil)
     @parsing_stack.add(klass.name)
 
+    view_name = serializer_options&.key?(:view) ? serializer_options[:view] : :default
     reflections = klass.reflections
+
     identifier_fields = extract_fields(reflections, :identifier)
-    default_fields = extract_fields(reflections, :default)
-    association_fields = extract_associations(reflections, :default)
+    default_fields = extract_fields(reflections, view_name)
+    association_fields = extract_associations(reflections, view_name)
 
     @parsing_stack.delete(klass.name)
 

--- a/spec/openapi/parsers/ext/blueprinter_spec.rb
+++ b/spec/openapi/parsers/ext/blueprinter_spec.rb
@@ -1046,6 +1046,444 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         })
       end
     end
+
+    context "with a named view" do
+      let(:resource) { "UserBlueprint(view: :normal)" }
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+          view :normal do
+            fields :email, :age
+          end
+        RUBY
+      end
+
+      it "renders only fields declared in the specified view" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" },
+            "age" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "with no view option falls back to :default" do
+      let(:resource) { "UserBlueprint" }
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+          view :normal do
+            fields :email, :age
+          end
+        RUBY
+      end
+
+      it "renders only the default view fields" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "with a named view that includes an association" do
+      let(:resource) { "UserBlueprint(view: :normal)" }
+
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          view :normal do
+            fields :age
+            association :projects, blueprint: ProjectBlueprint
+          end
+        RUBY
+      end
+
+      it "renders the view's fields and associations" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "age" => { "type" => "string" },
+            "email" => { "type" => "string" },
+            "projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with a named view that has a singular association" do
+      let(:resource) { "UserBlueprint(view: :normal)" }
+
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :email
+          view :normal do
+            association :project, blueprint: ProjectBlueprint
+          end
+        RUBY
+      end
+
+      it "correctly detects singular association cardinality within the view" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "project" => {
+              "type" => "object",
+              "properties" => {
+                "id" => { "type" => "string" },
+                "name" => { "type" => "string" }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with a view that does not exist" do
+      let(:resource) { "UserBlueprint(view: :nonexistent)" }
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+          view :normal do
+            fields :email
+          end
+        RUBY
+      end
+
+      it "returns an empty object schema since the view has no fields" do
+        is_expected.to eq({ "type" => "object" })
+      end
+    end
+
+    context "with identifier in a named view" do
+      let(:resource) { "UserBlueprint(view: :normal)" }
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          identifier :uuid
+          fields :name
+          view :normal do
+            fields :email
+          end
+        RUBY
+      end
+
+      it "includes the identifier alongside view fields" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "uuid" => { "type" => "string" },
+            "email" => { "type" => "string" },
+            "name" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "with include_view in a named view" do
+      let(:resource) { "UserBlueprint(view: :normal)" }
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+          view :extended do
+            fields :email, :age
+          end
+          view :normal do
+            include_view :extended
+            fields :address
+          end
+        RUBY
+      end
+
+      it "includes fields from the included view alongside the named view's own fields" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" },
+            "age" => { "type" => "string" },
+            "address" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "with exclude in a named view" do
+      let(:resource) { "UserBlueprint(view: :normal)" }
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name, :email
+          view :normal do
+            fields :age
+            exclude :email
+          end
+        RUBY
+      end
+
+      it "excludes the specified field from the view" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "age" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "with exclude on a base-level field in a named view" do
+      let(:resource) { "UserBlueprint(view: :normal)" }
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name, :email, :age
+          view :normal do
+            exclude :id
+            exclude :age
+          end
+        RUBY
+      end
+
+      it "excludes multiple base-level fields from the view" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "with include_view and exclude combined" do
+      let(:resource) { "UserBlueprint(view: :normal)" }
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+          view :extended do
+            fields :email, :age, :address
+          end
+          view :normal do
+            include_view :extended
+            exclude :age
+          end
+        RUBY
+      end
+
+      it "includes the view's fields but excludes the specified one" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" },
+            "address" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "with include_view, exclude, and associations combined" do
+      let(:resource) { "UserBlueprint(view: :normal)" }
+
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("TeamBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name, :email
+          association :teams, blueprint: TeamBlueprint
+          view :extended do
+            fields :age, :address
+            association :projects, blueprint: ProjectBlueprint
+          end
+          view :normal do
+            include_view :extended
+            exclude :email
+            exclude :address
+          end
+        RUBY
+      end
+
+      it "merges included view, excludes specified fields, and includes all associations" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "age" => { "type" => "string" },
+            "teams" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            },
+            "projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with exclude on an association in a named view" do
+      let(:resource) { "UserBlueprint(view: :normal)" }
+
+      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id, :name
+          association :projects, blueprint: ProjectBlueprint
+          view :normal do
+            fields :email
+            exclude :projects
+          end
+        RUBY
+      end
+
+      it "excludes the association from the view" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "with multiple include_view chained" do
+      let(:resource) { "UserBlueprint(view: :admin)" }
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id
+          view :basic do
+            fields :name, :email
+          end
+          view :extended do
+            fields :age, :address
+          end
+          view :admin do
+            include_view :basic
+            include_view :extended
+            fields :role
+          end
+        RUBY
+      end
+
+      it "includes fields from all included views plus the view's own fields" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" },
+            "age" => { "type" => "string" },
+            "address" => { "type" => "string" },
+            "role" => { "type" => "string" }
+          }
+        })
+      end
+    end
+
+    context "with include_view chained and exclude applied to an included field" do
+      let(:resource) { "UserBlueprint(view: :admin)" }
+
+      let_class("UserBlueprint", parent: Blueprinter::Base) do
+        <<~'RUBY'
+          fields :id
+          view :basic do
+            fields :name, :email
+          end
+          view :extended do
+            fields :age, :address
+          end
+          view :admin do
+            include_view :basic
+            include_view :extended
+            fields :role
+            exclude :email
+            exclude :address
+          end
+        RUBY
+      end
+
+      it "includes fields from all included views, excluding the specified ones" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "age" => { "type" => "string" },
+            "role" => { "type" => "string" }
+          }
+        })
+      end
+    end
   end
 
   describe "collection" do
@@ -1934,6 +2372,486 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
           }
         })
       end
+    end
+  end
+
+  context "with a named view" do
+    let(:resource) { "Array<UserBlueprint(view: :normal)>" }
+
+    let_class("UserBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        fields :id, :name
+        view :normal do
+          fields :email, :age
+        end
+      RUBY
+    end
+
+    it "renders only fields declared in the specified view" do
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" },
+            "age" => { "type" => "string" }
+          }
+        }
+      })
+    end
+  end
+
+  context "with no view option falls back to :default" do
+    let(:resource) { "Array<UserBlueprint>" }
+
+    let_class("UserBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        fields :id, :name
+        view :normal do
+          fields :email, :age
+        end
+      RUBY
+    end
+
+    it "renders only the default view fields" do
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" }
+          }
+        }
+      })
+    end
+  end
+
+  context "with a named view that includes an association" do
+    let(:resource) { "Array<UserBlueprint(view: :normal)>" }
+
+    let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        fields :id, :name
+      RUBY
+    end
+
+    let_class("UserBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        fields :email
+        view :normal do
+          fields :age
+          association :projects, blueprint: ProjectBlueprint
+        end
+      RUBY
+    end
+
+    it "renders the view's fields and associations" do
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "age" => { "type" => "string" },
+            "email" => { "type" => "string" },
+            "projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        }
+      })
+    end
+  end
+
+  context "with a named view that has a singular association" do
+    let(:resource) { "Array<UserBlueprint(view: :normal)>" }
+
+    let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        fields :id, :name
+      RUBY
+    end
+
+    let_class("UserBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        fields :email
+        view :normal do
+          association :project, blueprint: ProjectBlueprint
+        end
+      RUBY
+    end
+
+    it "correctly detects singular association cardinality within the view" do
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "email" => { "type" => "string" },
+            "project" => {
+              "type" => "object",
+              "properties" => {
+                "id" => { "type" => "string" },
+                "name" => { "type" => "string" }
+              }
+            }
+          }
+        }
+      })
+    end
+  end
+
+  context "with a view that does not exist" do
+    let(:resource) { "Array<UserBlueprint(view: :nonexistent)>" }
+
+    let_class("UserBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        fields :id, :name
+        view :normal do
+          fields :email
+        end
+      RUBY
+    end
+
+    it "returns an empty items schema since the view has no fields" do
+      is_expected.to eq({
+        "type" => "array",
+        "items" => { "type" => "object" }
+      })
+    end
+  end
+
+  context "with identifier in a named view" do
+    let(:resource) { "Array<UserBlueprint(view: :normal)>" }
+
+    let_class("UserBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        identifier :uuid
+        fields :name
+        view :normal do
+          fields :email
+        end
+      RUBY
+    end
+
+    it "includes the identifier alongside view fields" do
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "uuid" => { "type" => "string" },
+            "email" => { "type" => "string" },
+            "name" => { "type" => "string" }
+          }
+        }
+      })
+    end
+  end
+
+  context "with include_view in a named view" do
+    let(:resource) { "Array<UserBlueprint(view: :normal)>" }
+
+    let_class("UserBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        fields :id, :name
+        view :extended do
+          fields :email, :age
+        end
+        view :normal do
+          include_view :extended
+          fields :address
+        end
+      RUBY
+    end
+
+    it "includes fields from the included view alongside the named view's own fields" do
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" },
+            "age" => { "type" => "string" },
+            "address" => { "type" => "string" }
+          }
+        }
+      })
+    end
+  end
+
+  context "with exclude in a named view" do
+    let(:resource) { "Array<UserBlueprint(view: :normal)>" }
+
+    let_class("UserBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        fields :id, :name, :email
+        view :normal do
+          fields :age
+          exclude :email
+        end
+      RUBY
+    end
+
+    it "excludes the specified field from the view" do
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "age" => { "type" => "string" }
+          }
+        }
+      })
+    end
+  end
+
+  context "with exclude on a base-level field in a named view" do
+    let(:resource) { "Array<UserBlueprint(view: :normal)>" }
+
+    let_class("UserBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        fields :id, :name, :email, :age
+        view :normal do
+          exclude :id
+          exclude :age
+        end
+      RUBY
+    end
+
+    it "excludes multiple base-level fields from the view" do
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" }
+          }
+        }
+      })
+    end
+  end
+
+  context "with include_view and exclude combined" do
+    let(:resource) { "Array<UserBlueprint(view: :normal)>" }
+
+    let_class("UserBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        fields :id, :name
+        view :extended do
+          fields :email, :age, :address
+        end
+        view :normal do
+          include_view :extended
+          exclude :age
+        end
+      RUBY
+    end
+
+    it "includes the view's fields but excludes the specified one" do
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" },
+            "address" => { "type" => "string" }
+          }
+        }
+      })
+    end
+  end
+
+  context "with include_view, exclude, and associations combined" do
+    let(:resource) { "Array<UserBlueprint(view: :normal)>" }
+
+    let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        fields :id, :name
+      RUBY
+    end
+
+    let_class("TeamBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        fields :id, :name
+      RUBY
+    end
+
+    let_class("UserBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        fields :id, :name, :email
+        association :teams, blueprint: TeamBlueprint
+        view :extended do
+          fields :age, :address
+          association :projects, blueprint: ProjectBlueprint
+        end
+        view :normal do
+          include_view :extended
+          exclude :email
+          exclude :address
+        end
+      RUBY
+    end
+
+    it "merges included view, excludes specified fields, and includes all associations" do
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "age" => { "type" => "string" },
+            "teams" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            },
+            "projects" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "properties" => {
+                  "id" => { "type" => "string" },
+                  "name" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        }
+      })
+    end
+  end
+
+  context "with exclude on an association in a named view" do
+    let(:resource) { "Array<UserBlueprint(view: :normal)>" }
+
+    let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        fields :id, :name
+      RUBY
+    end
+
+    let_class("UserBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        fields :id, :name
+        association :projects, blueprint: ProjectBlueprint
+        view :normal do
+          fields :email
+          exclude :projects
+        end
+      RUBY
+    end
+
+    it "excludes the association from the view" do
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" }
+          }
+        }
+      })
+    end
+  end
+
+  context "with multiple include_view chained" do
+    let(:resource) { "Array<UserBlueprint(view: :admin)>" }
+
+    let_class("UserBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        fields :id
+        view :basic do
+          fields :name, :email
+        end
+        view :extended do
+          fields :age, :address
+        end
+        view :admin do
+          include_view :basic
+          include_view :extended
+          fields :role
+        end
+      RUBY
+    end
+
+    it "includes fields from all included views plus the view's own fields" do
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "email" => { "type" => "string" },
+            "age" => { "type" => "string" },
+            "address" => { "type" => "string" },
+            "role" => { "type" => "string" }
+          }
+        }
+      })
+    end
+  end
+
+  context "with include_view chained and exclude applied to an included field" do
+    let(:resource) { "Array<UserBlueprint(view: :admin)>" }
+
+    let_class("UserBlueprint", parent: Blueprinter::Base) do
+      <<~'RUBY'
+        fields :id
+        view :basic do
+          fields :name, :email
+        end
+        view :extended do
+          fields :age, :address
+        end
+        view :admin do
+          include_view :basic
+          include_view :extended
+          fields :role
+          exclude :email
+          exclude :address
+        end
+      RUBY
+    end
+
+    it "includes fields from all included views, excluding the specified ones" do
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "id" => { "type" => "string" },
+            "name" => { "type" => "string" },
+            "age" => { "type" => "string" },
+            "role" => { "type" => "string" }
+          }
+        }
+      })
     end
   end
 end

--- a/spec/openapi/parsers/ext/blueprinter_spec.rb
+++ b/spec/openapi/parsers/ext/blueprinter_spec.rb
@@ -1182,8 +1182,8 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         RUBY
       end
 
-      it "returns an empty object schema since the view has no fields" do
-        is_expected.to eq({ "type" => "object" })
+      it "returns nil so the upstream parser logs an unrecognized tag warning" do
+        is_expected.to be_nil
       end
     end
 
@@ -2522,11 +2522,8 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
       RUBY
     end
 
-    it "returns an empty items schema since the view has no fields" do
-      is_expected.to eq({
-        "type" => "array",
-        "items" => { "type" => "object" }
-      })
+    it "returns nil so the upstream parser logs an unrecognized tag warning" do
+      is_expected.to be_nil
     end
   end
 

--- a/spec/openapi/parsers/ext/blueprinter_spec.rb
+++ b/spec/openapi/parsers/ext/blueprinter_spec.rb
@@ -1050,7 +1050,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with a named view" do
       let(:resource) { "UserBlueprint(view: :normal)" }
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :id, :name
           view :normal do
@@ -1075,7 +1075,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with no view option falls back to :default" do
       let(:resource) { "UserBlueprint" }
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :id, :name
           view :normal do
@@ -1098,13 +1098,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with a named view that includes an association" do
       let(:resource) { "UserBlueprint(view: :normal)" }
 
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :email
           view :normal do
@@ -1138,13 +1138,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with a named view that has a singular association" do
       let(:resource) { "UserBlueprint(view: :normal)" }
 
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :email
           view :normal do
@@ -1173,7 +1173,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with a view that does not exist" do
       let(:resource) { "UserBlueprint(view: :nonexistent)" }
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :id, :name
           view :normal do
@@ -1190,7 +1190,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with identifier in a named view" do
       let(:resource) { "UserBlueprint(view: :normal)" }
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           identifier :uuid
           fields :name
@@ -1215,7 +1215,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with include_view in a named view" do
       let(:resource) { "UserBlueprint(view: :normal)" }
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :id, :name
           view :extended do
@@ -1245,7 +1245,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with exclude in a named view" do
       let(:resource) { "UserBlueprint(view: :normal)" }
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :id, :name, :email
           view :normal do
@@ -1270,7 +1270,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with exclude on a base-level field in a named view" do
       let(:resource) { "UserBlueprint(view: :normal)" }
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :id, :name, :email, :age
           view :normal do
@@ -1294,7 +1294,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with include_view and exclude combined" do
       let(:resource) { "UserBlueprint(view: :normal)" }
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :id, :name
           view :extended do
@@ -1323,19 +1323,19 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with include_view, exclude, and associations combined" do
       let(:resource) { "UserBlueprint(view: :normal)" }
 
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("TeamBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("TeamBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :id, :name, :email
           association :teams, blueprint: TeamBlueprint
@@ -1386,13 +1386,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with exclude on an association in a named view" do
       let(:resource) { "UserBlueprint(view: :normal)" }
 
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :id, :name
           association :projects, blueprint: ProjectBlueprint
@@ -1418,7 +1418,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with multiple include_view chained" do
       let(:resource) { "UserBlueprint(view: :admin)" }
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :id
           view :basic do
@@ -1453,7 +1453,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with include_view chained and exclude applied to an included field" do
       let(:resource) { "UserBlueprint(view: :admin)" }
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :id
           view :basic do
@@ -2378,7 +2378,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
   context "with a named view" do
     let(:resource) { "Array<UserBlueprint(view: :normal)>" }
 
-    let_class("UserBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("UserBlueprint") do
       <<~'RUBY'
         fields :id, :name
         view :normal do
@@ -2406,7 +2406,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
   context "with no view option falls back to :default" do
     let(:resource) { "Array<UserBlueprint>" }
 
-    let_class("UserBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("UserBlueprint") do
       <<~'RUBY'
         fields :id, :name
         view :normal do
@@ -2432,13 +2432,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
   context "with a named view that includes an association" do
     let(:resource) { "Array<UserBlueprint(view: :normal)>" }
 
-    let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("ProjectBlueprint") do
       <<~'RUBY'
         fields :id, :name
       RUBY
     end
 
-    let_class("UserBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("UserBlueprint") do
       <<~'RUBY'
         fields :email
         view :normal do
@@ -2475,13 +2475,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
   context "with a named view that has a singular association" do
     let(:resource) { "Array<UserBlueprint(view: :normal)>" }
 
-    let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("ProjectBlueprint") do
       <<~'RUBY'
         fields :id, :name
       RUBY
     end
 
-    let_class("UserBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("UserBlueprint") do
       <<~'RUBY'
         fields :email
         view :normal do
@@ -2513,7 +2513,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
   context "with a view that does not exist" do
     let(:resource) { "Array<UserBlueprint(view: :nonexistent)>" }
 
-    let_class("UserBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("UserBlueprint") do
       <<~'RUBY'
         fields :id, :name
         view :normal do
@@ -2533,7 +2533,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
   context "with identifier in a named view" do
     let(:resource) { "Array<UserBlueprint(view: :normal)>" }
 
-    let_class("UserBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("UserBlueprint") do
       <<~'RUBY'
         identifier :uuid
         fields :name
@@ -2561,7 +2561,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
   context "with include_view in a named view" do
     let(:resource) { "Array<UserBlueprint(view: :normal)>" }
 
-    let_class("UserBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("UserBlueprint") do
       <<~'RUBY'
         fields :id, :name
         view :extended do
@@ -2594,7 +2594,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
   context "with exclude in a named view" do
     let(:resource) { "Array<UserBlueprint(view: :normal)>" }
 
-    let_class("UserBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("UserBlueprint") do
       <<~'RUBY'
         fields :id, :name, :email
         view :normal do
@@ -2622,7 +2622,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
   context "with exclude on a base-level field in a named view" do
     let(:resource) { "Array<UserBlueprint(view: :normal)>" }
 
-    let_class("UserBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("UserBlueprint") do
       <<~'RUBY'
         fields :id, :name, :email, :age
         view :normal do
@@ -2649,7 +2649,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
   context "with include_view and exclude combined" do
     let(:resource) { "Array<UserBlueprint(view: :normal)>" }
 
-    let_class("UserBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("UserBlueprint") do
       <<~'RUBY'
         fields :id, :name
         view :extended do
@@ -2681,19 +2681,19 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
   context "with include_view, exclude, and associations combined" do
     let(:resource) { "Array<UserBlueprint(view: :normal)>" }
 
-    let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("ProjectBlueprint") do
       <<~'RUBY'
         fields :id, :name
       RUBY
     end
 
-    let_class("TeamBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("TeamBlueprint") do
       <<~'RUBY'
         fields :id, :name
       RUBY
     end
 
-    let_class("UserBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("UserBlueprint") do
       <<~'RUBY'
         fields :id, :name, :email
         association :teams, blueprint: TeamBlueprint
@@ -2747,13 +2747,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
   context "with exclude on an association in a named view" do
     let(:resource) { "Array<UserBlueprint(view: :normal)>" }
 
-    let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("ProjectBlueprint") do
       <<~'RUBY'
         fields :id, :name
       RUBY
     end
 
-    let_class("UserBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("UserBlueprint") do
       <<~'RUBY'
         fields :id, :name
         association :projects, blueprint: ProjectBlueprint
@@ -2782,7 +2782,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
   context "with multiple include_view chained" do
     let(:resource) { "Array<UserBlueprint(view: :admin)>" }
 
-    let_class("UserBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("UserBlueprint") do
       <<~'RUBY'
         fields :id
         view :basic do
@@ -2820,7 +2820,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
   context "with include_view chained and exclude applied to an included field" do
     let(:resource) { "Array<UserBlueprint(view: :admin)>" }
 
-    let_class("UserBlueprint", parent: Blueprinter::Base) do
+    let_blueprinter_class("UserBlueprint") do
       <<~'RUBY'
         fields :id
         view :basic do


### PR DESCRIPTION
closes #292 

## What this PR does?

Extends the Rage OpenAPI Blueprinter parser to respect the `view:` option from `@response` annotations. Previously, the third return value from `__parse_serializer_args` was discarded and the parser always used the `:default` view, producing incorrect schemas for endpoints that render a non-default Blueprinter view.

## Changes

- Pass `serializer_options` from `__parse_serializer_args` into `build_schema`
- Resolve view name from `serializer_options[:view]`, falling back to `:default`
- Pass resolved view name to `extract_fields` and `extract_associations`

## Tests Added

**Single object:**
- with a named view renders base + view fields
- with no view option falls back to :default
- with a named view that includes an association
- with a named view that has a singular association
- with a view that does not exist returns empty schema
- with identifier in a named view
- with include_view in a named view
- with exclude in a named view
- with exclude on a base-level field in a named view
- with include_view and exclude combined
- with include_view, exclude, and associations combined
- with exclude on an association in a named view
- with multiple include_view chained
- with include_view chained and exclude applied to an included field

**Collection:**
- Same 14 cases as above for `Array<Blueprint(view: :name)>` resource shape

## Screnshoot

<img width="1355" height="678" alt="image" src="https://github.com/user-attachments/assets/6e27728b-2094-4dd6-a1c8-567e56e89632" />
