### PR TITLE
Update Blueprinter specs to use `let_blueprinter_class`

### DIFF
--- a/spec/openapi/parsers/ext/blueprinter_spec.rb
+++ b/spec/openapi/parsers/ext/blueprinter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     let(:resource) { "UserBlueprint" }
 
     context "with an empty blueprint" do
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
         RUBY
       end
@@ -25,7 +25,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with basic fields" do
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :id, :name, :email, :age
         RUBY
@@ -44,7 +44,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "when fields are declared with strings" do
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields "id", "name", "email"
         RUBY
@@ -63,7 +63,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with identifier" do
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           identifier :uuid
         RUBY
@@ -80,7 +80,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with a single field" do
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           field :email
         RUBY
@@ -97,7 +97,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with field name alias" do
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           field :email, name: :login
         RUBY
@@ -114,7 +114,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "when field alias is declared with string values" do
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           field "email", name: "login"
         RUBY
@@ -131,7 +131,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with a block field" do
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           field(:full_name) { |u| "#{u.first_name} #{u.last_name}" }
         RUBY
@@ -148,7 +148,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with a block field declared with string values" do
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           field("full_name") { |u| "#{u.first_name} #{u.last_name}" }
         RUBY
@@ -165,7 +165,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with all declaration types combined" do
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           identifier :uuid
           fields :id, :name, :age
@@ -193,7 +193,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with all declaration types combined with string values" do
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           identifier :uuid
           fields "id", "name", "age"
@@ -216,7 +216,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "ensures identifier appears first in properties regardless of definition order" do
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :name, :email
           identifier :uuid
@@ -228,13 +228,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with inheritance from another blueprint" do
-      let_class("BaseUserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("BaseUserBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("UserBlueprint", parent: mocked_classes["BaseUserBlueprint"]) do
+      let_blueprinter_class("UserBlueprint", parent: mocked_classes["BaseUserBlueprint"]) do
         <<~'RUBY'
           fields :email, :age
         RUBY
@@ -254,7 +254,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "when superclass is Base (should not merge)" do
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
@@ -272,13 +272,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "when child blueprint overrides a parent field" do
-      let_class("BaseUserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("BaseUserBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("UserBlueprint", parent: mocked_classes["BaseUserBlueprint"]) do
+      let_blueprinter_class("UserBlueprint", parent: mocked_classes["BaseUserBlueprint"]) do
         <<~'RUBY'
           fields :name, :email
         RUBY
@@ -297,19 +297,19 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with multiple levels of inheritance" do
-      let_class("GrandparentBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("GrandparentBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("ParentBlueprint", parent: mocked_classes["GrandparentBlueprint"]) do
+      let_blueprinter_class("ParentBlueprint", parent: mocked_classes["GrandparentBlueprint"]) do
         <<~'RUBY'
           fields :email
         RUBY
       end
 
-      let_class("UserBlueprint", parent: mocked_classes["ParentBlueprint"]) do
+      let_blueprinter_class("UserBlueprint", parent: mocked_classes["ParentBlueprint"]) do
         <<~'RUBY'
           fields :age
         RUBY
@@ -329,14 +329,14 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with identifier in parent blueprint" do
-      let_class("BaseUserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("BaseUserBlueprint") do
         <<~'RUBY'
           identifier :uuid
           fields :name
         RUBY
       end
 
-      let_class("UserBlueprint", parent: mocked_classes["BaseUserBlueprint"]) do
+      let_blueprinter_class("UserBlueprint", parent: mocked_classes["BaseUserBlueprint"]) do
         <<~'RUBY'
           identifier :id
           fields :email
@@ -359,20 +359,18 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with a basic association" do
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :email
           association :projects, blueprint: ProjectBlueprint
         RUBY
       end
-
-      before { ProjectBlueprint }
 
       it "defaults to array type with nested blueprint schema" do
         is_expected.to eq({
@@ -395,13 +393,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with association name alias" do
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :email
           association :projects, blueprint: ProjectBlueprint, name: :work_projects
@@ -429,14 +427,14 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with circular association" do
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :name
           association :users, blueprint: UserBlueprint
         RUBY
       end
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :email
           association :projects, blueprint: ProjectBlueprint
@@ -468,27 +466,27 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with association across multiple levels of inheritance" do
-      let_class("TagBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("TagBlueprint") do
         <<~'RUBY'
           fields :id, :label
         RUBY
       end
 
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :name
           association :tags, blueprint: TagBlueprint
         RUBY
       end
 
-      let_class("BaseUserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("BaseUserBlueprint") do
         <<~'RUBY'
           fields :email
           association :projects, blueprint: ProjectBlueprint
         RUBY
       end
 
-      let_class("UserBlueprint", parent: mocked_classes["BaseUserBlueprint"]) do
+      let_blueprinter_class("UserBlueprint", parent: mocked_classes["BaseUserBlueprint"]) do
         <<~'RUBY'
           fields :first_name
         RUBY
@@ -525,14 +523,14 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with identifier in associated blueprint" do
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           identifier :uuid
           fields :name
         RUBY
       end
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           identifier :id
           fields :email
@@ -567,20 +565,20 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with circular association through inheritance" do
-      let_class("BaseProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("BaseProjectBlueprint") do
         <<~'RUBY'
           fields :name
         RUBY
       end
 
-      let_class("ProjectBlueprint", parent: mocked_classes["BaseProjectBlueprint"]) do
+      let_blueprinter_class("ProjectBlueprint", parent: mocked_classes["BaseProjectBlueprint"]) do
         <<~'RUBY'
           fields :description
           association :users, blueprint: UserBlueprint
         RUBY
       end
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :email
           association :projects, blueprint: ProjectBlueprint
@@ -613,19 +611,19 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with multiple associations" do
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("TeamBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("TeamBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :email
           association :projects, blueprint: ProjectBlueprint
@@ -664,15 +662,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with namespaced association" do
-      unless Object.const_defined?(:V1)
-        Object.const_set(:V1, Module.new)
-      end
-      V1::ProjectBlueprint = Class.new(Blueprinter::Base)
-      V1::ProjectBlueprint.class_eval do
-        fields :id, :name
+      let_blueprinter_class("V1::ProjectBlueprint") do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
       end
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :email
           association :projects, blueprint: V1::ProjectBlueprint
@@ -702,13 +698,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with a blueprint: Proc that ignores its argument" do
       let(:resource) { "ConstLambdaParent" }
 
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("ConstLambdaParent", parent: Blueprinter::Base) do
+      let_blueprinter_class("ConstLambdaParent") do
         <<~'RUBY'
           field :email
           association :projects, name: :classmates, blueprint: ->(_) { ProjectBlueprint }
@@ -736,19 +732,19 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with a proc that branches on the parent object (not statically resolvable)" do
       let(:resource) { "BranchingUserBlueprint" }
 
-      let_class("DataMiningBase", parent: Blueprinter::Base) do
+      let_blueprinter_class("DataMiningBase") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("DataMiningExtended", parent: Blueprinter::Base) do
+      let_blueprinter_class("DataMiningExtended") do
         <<~'RUBY'
           fields :id, :name, :uuid
         RUBY
       end
 
-      let_class("BranchingUserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("BranchingUserBlueprint") do
         <<~'RUBY'
           fields :email, :subject
           association :projects,
@@ -780,7 +776,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with a circular association expressed as a Proc" do
       let(:resource) { "RecursiveNodeBlueprint" }
 
-      let_class("RecursiveNodeBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("RecursiveNodeBlueprint") do
         <<~RUBY
           field :id
           association :children, blueprint: ->(_) { RecursiveNodeBlueprint }
@@ -805,13 +801,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with a pluralized association name" do
       let(:resource) { "PluralizedBlueprint" }
 
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("PluralizedBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("PluralizedBlueprint") do
         <<~'RUBY'
           fields :email
           association :projects, blueprint: ProjectBlueprint
@@ -841,13 +837,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with a singular association name" do
       let(:resource) { "SingularBlueprint" }
 
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("SingularBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("SingularBlueprint") do
         <<~'RUBY'
           fields :email
           association :project, blueprint: ProjectBlueprint
@@ -873,13 +869,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
 
     context "with a singular association name when ActiveSupport's singularize is unavailable" do
       let(:resource) { "ActiveBlueprint" }
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("ActiveBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ActiveBlueprint") do
         <<~'RUBY'
           fields :email
           association :project, blueprint: ProjectBlueprint
@@ -914,13 +910,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with a pluralized association name and a singular name: alias" do
       let(:resource) { "PluralizedBlueprint" }
 
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("PluralizedBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("PluralizedBlueprint") do
         <<~'RUBY'
           fields :email
           association :projects, blueprint: ProjectBlueprint, name: :classmate
@@ -950,19 +946,19 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with an unresolvable dynamic blueprint on a singular association name" do
       let(:resource) { "DataBluePrint" }
 
-      let_class("DataMiningBase", parent: Blueprinter::Base) do
+      let_blueprinter_class("DataMiningBase") do
         <<~RUBY
           fields :id
         RUBY
       end
 
-      let_class("DataMiningExtended", parent: Blueprinter::Base) do
+      let_blueprinter_class("DataMiningExtended") do
         <<~RUBY
           fields :id, :uuid
         RUBY
       end
 
-      let_class("DataBluePrint", parent: Blueprinter::Base) do
+      let_blueprinter_class("DataBluePrint") do
         <<~'RUBY'
           fields :email, :subject
           association :project,
@@ -987,13 +983,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "known limitation: uncountable noun association name" do
       let(:resource) { "LimitationBlueprint" }
 
-      let_class("DatumBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("DatumBlueprint") do
         <<~'RUBY'
           fields :id
         RUBY
       end
 
-      let_class("LimitationBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("LimitationBlueprint") do
         <<~'RUBY'
           fields :email
           association :data, blueprint: DatumBlueprint
@@ -1022,13 +1018,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "known limitation: genuinely uncountable noun association name" do
       let(:resource) { "InformerBlueprint" }
 
-      let_class("InfoBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("InfoBlueprint") do
         <<~'RUBY'
           fields :id
         RUBY
       end
 
-      let_class("InformerBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("InformerBlueprint") do
         <<~'RUBY'
           fields :email
           association :information, blueprint: InfoBlueprint
@@ -1056,7 +1052,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     let(:resource) { "Array<UserBlueprint>" }
 
     context "with basic fields" do
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :id, :name, :email
         RUBY
@@ -1079,7 +1075,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
 
     context "with identifier" do
       let(:resource) { "[UserBlueprint]" }
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           identifier :uuid
           fields :name, :email
@@ -1102,13 +1098,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with inherited fields" do
-      let_class("BaseUserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("BaseUserBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("UserBlueprint", parent: mocked_classes["BaseUserBlueprint"]) do
+      let_blueprinter_class("UserBlueprint", parent: mocked_classes["BaseUserBlueprint"]) do
         <<~'RUBY'
           fields :email
         RUBY
@@ -1130,17 +1126,17 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with multiple levels of inheritance" do
-      let_class("GrandparentBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("GrandparentBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
-      let_class("ParentBlueprint", parent: mocked_classes["GrandparentBlueprint"]) do
+      let_blueprinter_class("ParentBlueprint", parent: mocked_classes["GrandparentBlueprint"]) do
         <<~'RUBY'
           fields :email
         RUBY
       end
-      let_class("UserBlueprint", parent: mocked_classes["ParentBlueprint"]) do
+      let_blueprinter_class("UserBlueprint", parent: mocked_classes["ParentBlueprint"]) do
         <<~'RUBY'
           fields :age
         RUBY
@@ -1162,13 +1158,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with identifier in parent blueprint" do
-      let_class("BaseUserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("BaseUserBlueprint") do
         <<~'RUBY'
           identifier :uuid
           fields :name
         RUBY
       end
-      let_class("UserBlueprint", parent: mocked_classes["BaseUserBlueprint"]) do
+      let_blueprinter_class("UserBlueprint", parent: mocked_classes["BaseUserBlueprint"]) do
         <<~'RUBY'
           identifier :id
           fields :email
@@ -1193,13 +1189,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with a basic association" do
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :email
           association :projects, blueprint: ProjectBlueprint
@@ -1230,13 +1226,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with association name alias" do
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :email
           association :projects, blueprint: ProjectBlueprint, name: :work_projects
@@ -1267,14 +1263,14 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with circular association" do
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :name
           association :users, blueprint: UserBlueprint
         RUBY
       end
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :email
           association :projects, blueprint: ProjectBlueprint
@@ -1309,27 +1305,27 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with association across multiple levels of inheritance" do
-      let_class("TagBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("TagBlueprint") do
         <<~'RUBY'
           fields :id, :label
         RUBY
       end
 
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :name
           association :tags, blueprint: TagBlueprint
         RUBY
       end
 
-      let_class("BaseUserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("BaseUserBlueprint") do
         <<~'RUBY'
           fields :email
           association :projects, blueprint: ProjectBlueprint
         RUBY
       end
 
-      let_class("UserBlueprint", parent: mocked_classes["BaseUserBlueprint"]) do
+      let_blueprinter_class("UserBlueprint", parent: mocked_classes["BaseUserBlueprint"]) do
         <<~'RUBY'
           fields :first_name
         RUBY
@@ -1369,14 +1365,14 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with identifier in associated blueprint" do
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           identifier :uuid
           fields :name
         RUBY
       end
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           identifier :id
           fields :email
@@ -1414,20 +1410,20 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     end
 
     context "with circular association through inheritance" do
-      let_class("BaseProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("BaseProjectBlueprint") do
         <<~'RUBY'
           fields :name
         RUBY
       end
 
-      let_class("ProjectBlueprint", parent: mocked_classes["BaseProjectBlueprint"]) do
+      let_blueprinter_class("ProjectBlueprint", parent: mocked_classes["BaseProjectBlueprint"]) do
         <<~'RUBY'
           fields :description
           association :users, blueprint: UserBlueprint
         RUBY
       end
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :email
           association :projects, blueprint: ProjectBlueprint
@@ -1465,19 +1461,19 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with multiple associations" do
       let(:resource) { "Array<UserBlueprint>" }
 
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("TeamBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("TeamBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :email
           association :projects, blueprint: ProjectBlueprint
@@ -1521,15 +1517,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with namespaced association" do
       let(:resource) { "Array<UserBlueprint>" }
 
-      unless Object.const_defined?(:V1)
-        Object.const_set(:V1, Module.new)
-      end
-      V1::ProjectBlueprint = Class.new(Blueprinter::Base) unless V1.const_defined?(:ProjectBlueprint)
-      V1::ProjectBlueprint.class_eval do
-        fields :id, :name
+      let_blueprinter_class("V1::ProjectBlueprint") do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
       end
 
-      let_class("UserBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("UserBlueprint") do
         <<~'RUBY'
           fields :email
           association :projects, blueprint: V1::ProjectBlueprint
@@ -1562,13 +1556,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with a blueprint: Proc that ignores its argument" do
       let(:resource) { "Array<ConstLambdaParentCollection>" }
 
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("ConstLambdaParentCollection", parent: Blueprinter::Base) do
+      let_blueprinter_class("ConstLambdaParentCollection") do
         <<~'RUBY'
           field :email
           association :projects, name: :classmates, blueprint: ->(_) { ProjectBlueprint }
@@ -1599,19 +1593,19 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with a proc that branches on the parent object (not statically resolvable)" do
       let(:resource) { "Array<BranchingUserBlueprintCollection>" }
 
-      let_class("DataMiningBase", parent: Blueprinter::Base) do
+      let_blueprinter_class("DataMiningBase") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("DataMiningExtended", parent: Blueprinter::Base) do
+      let_blueprinter_class("DataMiningExtended") do
         <<~'RUBY'
           fields :id, :name, :uuid
         RUBY
       end
 
-      let_class("BranchingUserBlueprintCollection", parent: Blueprinter::Base) do
+      let_blueprinter_class("BranchingUserBlueprintCollection") do
         <<~'RUBY'
           fields :email, :subject
           association :projects,
@@ -1646,7 +1640,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with a circular association expressed as a Proc" do
       let(:resource) { "Array<RecursiveNodeBlueprintCollection>" }
 
-      let_class("RecursiveNodeBlueprintCollection", parent: Blueprinter::Base) do
+      let_blueprinter_class("RecursiveNodeBlueprintCollection") do
         <<~'RUBY'
           field :id
           association :children, blueprint: ->(_) { RecursiveNodeBlueprintCollection }
@@ -1674,13 +1668,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with a pluralized association name" do
       let(:resource) { "Array<PluralizedBlueprintCollection>" }
 
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("PluralizedBlueprintCollection", parent: Blueprinter::Base) do
+      let_blueprinter_class("PluralizedBlueprintCollection") do
         <<~'RUBY'
           fields :email
           association :projects, blueprint: ProjectBlueprint
@@ -1713,13 +1707,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with a singular association name" do
       let(:resource) { "Array<SingularBlueprintCollection>" }
 
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("SingularBlueprintCollection", parent: Blueprinter::Base) do
+      let_blueprinter_class("SingularBlueprintCollection") do
         <<~'RUBY'
           fields :email
           association :project, blueprint: ProjectBlueprint
@@ -1749,13 +1743,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with a singular association name when ActiveSupport's singularize is unavailable" do
       let(:resource) { "Array<ActiveBlueprintCollection>" }
 
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("ActiveBlueprintCollection", parent: Blueprinter::Base) do
+      let_blueprinter_class("ActiveBlueprintCollection") do
         <<~'RUBY'
           fields :email
           association :project, blueprint: ProjectBlueprint
@@ -1793,13 +1787,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with a pluralized association name and a singular name: alias" do
       let(:resource) { "Array<PluralizedAliasBlueprintCollection>" }
 
-      let_class("ProjectBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("ProjectBlueprint") do
         <<~'RUBY'
           fields :id, :name
         RUBY
       end
 
-      let_class("PluralizedAliasBlueprintCollection", parent: Blueprinter::Base) do
+      let_blueprinter_class("PluralizedAliasBlueprintCollection") do
         <<~'RUBY'
           fields :email
           association :projects, blueprint: ProjectBlueprint, name: :classmate
@@ -1832,19 +1826,19 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "with an unresolvable dynamic blueprint on a singular association name" do
       let(:resource) { "Array<DataBluePrintCollection>" }
 
-      let_class("DataMiningBase", parent: Blueprinter::Base) do
+      let_blueprinter_class("DataMiningBase") do
         <<~'RUBY'
           fields :id
         RUBY
       end
 
-      let_class("DataMiningExtended", parent: Blueprinter::Base) do
+      let_blueprinter_class("DataMiningExtended") do
         <<~'RUBY'
           fields :id, :uuid
         RUBY
       end
 
-      let_class("DataBluePrintCollection", parent: Blueprinter::Base) do
+      let_blueprinter_class("DataBluePrintCollection") do
         <<~'RUBY'
           fields :email, :subject
           association :project,
@@ -1872,13 +1866,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "known limitation: uncountable noun association name" do
       let(:resource) { "Array<LimitationBlueprintCollection>" }
 
-      let_class("DatumBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("DatumBlueprint") do
         <<~'RUBY'
           fields :id
         RUBY
       end
 
-      let_class("LimitationBlueprintCollection", parent: Blueprinter::Base) do
+      let_blueprinter_class("LimitationBlueprintCollection") do
         <<~'RUBY'
           fields :email
           association :data, blueprint: DatumBlueprint
@@ -1910,13 +1904,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
     context "known limitation: genuinely uncountable noun association name" do
       let(:resource) { "Array<InformerBlueprintCollection>" }
 
-      let_class("InfoBlueprint", parent: Blueprinter::Base) do
+      let_blueprinter_class("InfoBlueprint") do
         <<~'RUBY'
           fields :id
         RUBY
       end
 
-      let_class("InformerBlueprintCollection", parent: Blueprinter::Base) do
+      let_blueprinter_class("InformerBlueprintCollection") do
         <<~'RUBY'
           fields :email
           association :information, blueprint: InfoBlueprint

--- a/spec/support/contexts/mocked_classes.rb
+++ b/spec/support/contexts/mocked_classes.rb
@@ -12,6 +12,7 @@ RSpec.shared_context "mocked_classes" do
     @mocked_classes ||= OpenStruct.new
   end
 
+  # Build a class backed by a source code file
   def self.let_class(class_name, parent: Object, &block)
     source = Tempfile.new.tap do |f|
       if block
@@ -25,15 +26,6 @@ RSpec.shared_context "mocked_classes" do
     end
 
     klass = Class.new(parent, &block)
-
-    if block
-      if defined?(Blueprinter::Base) && parent.ancestors.include?(Blueprinter::Base)
-        klass.class_eval(block.call)
-        Object.send(:remove_const, class_name) if Object.const_defined?(class_name, false)
-        Object.const_set(class_name, klass)
-      end
-    end
-
     klass.define_singleton_method(:name) { class_name }
 
     mocked_classes[class_name] = klass
@@ -42,5 +34,41 @@ RSpec.shared_context "mocked_classes" do
       allow(Object).to receive(:const_get).with(satisfy { |c| c.to_s == class_name.to_s }).and_return(klass)
       allow(Object).to receive(:const_source_location).with(class_name).and_return(source.path)
     end
+  end
+
+  # @private
+  # support circular associations - this holds classes
+  # that are not yet known and will be built later
+  def self.lazy_classes
+    @lazy_classes ||= {}
+  end
+
+  # Blueprinter mock - build an ephemeral class object with support for circular references
+  def self.let_blueprinter_class(class_name, parent: Blueprinter::Base, &block)
+    lazy = lazy_classes
+    mocks = mocked_classes
+
+    klass = lazy.delete(class_name) || Class.new(parent)
+
+    klass.define_singleton_method(:name) { class_name }
+    klass.define_singleton_method(:const_missing) do |name|
+      # defer building the constant in case of a circular reference
+      mocks[name.to_s] || (lazy[name.to_s] ||= Class.new(Blueprinter::Base))
+    end
+
+    klass.class_eval(block.call)
+
+    # support namespaced serializers
+    class_name.split("::").each { |name| mocks[name] = klass }
+
+    before do
+      if lazy.any?
+        raise NameError, "uninitialized constant #{lazy.keys.first}"
+      end
+
+      allow(Object).to receive(:const_get).with(satisfy { |c| c.to_s == class_name.to_s }).and_return(klass)
+    end
+
+    klass
   end
 end


### PR DESCRIPTION
This pull request introduces `let_blueprinter_class` to create Blueprinter mock classes. Since we don't use Prism parsing with Blueprinter, the test setup has to be quite different from the Alba setup - we need to evaluate the classes to ensure Blueprinter's reflection API works correctly.

`let_blueprinter_class` builds class instances for tests, and supports namespaces and circular references.