### PR TITLE
[CI] Paginate changelog workflow PR file checks

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,10 +24,11 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const { data: files } = await github.rest.pulls.listFiles({
+            const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number
+              pull_number: context.issue.number,
+              per_page: 100
             });
             const hasChangelog = files.some(f => f.filename === 'CHANGELOG.md');
             core.setOutput('has_changelog', hasChangelog);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- [CI] Check all changed PR file pages when requiring changelog updates.
 - [API] Ignore `If-Modified-Since` when `If-None-Match` is present.
 - [API] Use weak comparison for `If-None-Match` validation.
 - [Deferred] Ignore missing temp files during async disk storage cleanup.


### PR DESCRIPTION
## Description:

GitHub paginates `pulls.listFiles` responses. The current changelog workflow only inspects the first response page, so a pull request with more than 30 changed files can update `CHANGELOG.md` on a later page and still fail the check.

This PR switches the workflow to `github.paginate(github.rest.pulls.listFiles, ...)` so the changelog check sees all changed files before deciding whether `CHANGELOG.md` was updated.

It also adds the matching changelog entry.

Closes #337.

## Before fix:

<img width="1600" height="980" alt="image" src="https://github.com/user-attachments/assets/8ac8867d-ef49-4a56-a3dd-eea787c27fba" />

```text
$ ruby repro.rb before

Before fix
repo: rage-rb/rage
workflow_file: before/changelog.yml
real_pr: #266
page1_count: 30
page2_count: 1
link_header_present: true
simulated_total_files: 31
simulated_changelog_page: 2
workflow_uses_paginate: false
result: false
expected_result: true
```

## After fix:

<img width="1600" height="980" alt="image" src="https://github.com/user-attachments/assets/a832a3c0-b90a-4ea8-9746-a4dc039a925f" />

```text
$ ruby repro.rb after

After fix
repo: rage-rb/rage
workflow_file: after/changelog.yml
real_pr: #266
page1_count: 30
page2_count: 1
workflow_uses_paginate: true
workflow_sets_per_page_100: true
simulated_total_files: 31
result: true
expected_result: true
```

## Checklist:


- [x] I have updated `CHANGELOG.md`.
- [x] I have verified the workflow YAML parses using `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/changelog.yml"); puts "YAML OK"'`.

## Note:

This is a workflow only change, so there is no Rage runtime spec that directly exercises it. The meaningful verification here is the YAML parse plus the real GitHub API pagination repro above.
