### PR TITLE
Add `Rage::Daemon`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Connection pool improvements (#301).
 - [OpenAPI] Add Blueprinter association parsing with cycle detection (#291)
 - [OpenAPI] Add support for the `view:` option in Blueprinter parser.
+- Add `Rage::Daemon` (#339).
 
 ### Fixed
 

--- a/lib/rage-rb.rb
+++ b/lib/rage-rb.rb
@@ -198,6 +198,7 @@ module Rage
   autoload :Deferred, "rage/deferred/deferred"
   autoload :Events, "rage/events/events"
   autoload :PubSub, "rage/pubsub/pubsub"
+  autoload :Daemon, "rage/daemon"
 end
 
 module RageController

--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -289,6 +289,14 @@ class Rage::Configuration
   end
   # @!endgroup
 
+  # @!group Daemons
+  # Allows configuring daemon settings.
+  # @return [Rage::Configuration::Daemons]
+  def daemons
+    @daemons ||= Daemons.new
+  end
+  # @!endgroup
+
   # @private
   def pubsub
     @pubsub ||= PubSub.new
@@ -1112,6 +1120,48 @@ class Rage::Configuration
     def initialize
       @enabled = false
       @size = 1
+    end
+  end
+
+  class Daemons
+    # @private
+    def initialize
+      @klasses = []
+    end
+
+    # @private
+    attr_reader :klasses
+
+    # Register a new daemon.
+    # @param daemon [Class]
+    # @example
+    #   Rage.configure do
+    #     config.daemons << FileWatcher
+    #   end
+    def <<(daemon)
+      validate!(daemon)
+      @klasses << daemon
+    end
+
+    alias_method :push, :<<
+
+    # Remove a registered daemon.
+    # @param daemon [Class]
+    # @example
+    #   Rage.configure do
+    #     config.daemons.delete(FileWatcher)
+    #   end
+    def delete(daemon)
+      validate!(daemon)
+      @klasses.delete(daemon)
+    end
+
+    private
+
+    def validate!(klass)
+      if !klass.is_a?(Class) || !klass.ancestors.include?(Rage::Daemon)
+        raise ArgumentError, "Cannot add `#{klass}` as a daemon; should inherit `Rage::Daemon`"
+      end
     end
   end
 

--- a/lib/rage/daemon.rb
+++ b/lib/rage/daemon.rb
@@ -116,6 +116,9 @@ class Rage::Daemon
   private_constant :BACKOFF_RESET_INTERVAL
 
   class << self
+    # @private
+    attr_accessor :__exclusive
+
     # Configures the daemon to run in only one worker process.
     #
     # In multi-process deployments, Rage runs daemons in every worker by default.
@@ -133,8 +136,13 @@ class Rage::Daemon
     #       # only runs in one worker process
     #     end
     #   end
-    def exclusive
-      @__exclusive = true
+    def exclusive(enabled = true)
+      @__exclusive = enabled
+    end
+
+    # @private
+    def inherited(klass)
+      klass.__exclusive = @__exclusive
     end
 
     # @private

--- a/lib/rage/daemon.rb
+++ b/lib/rage/daemon.rb
@@ -1,0 +1,230 @@
+# frozen_string_literal: true
+
+##
+# `Rage::Daemon` is an abstraction for running long-lived background processes alongside your application.
+# Use daemons for tasks that need to run continuously, such as listening to message queues, consuming streaming APIs,
+# or maintaining persistent connections to external services.
+#
+# The framework automatically manages daemon lifecycle:
+# - Daemons are started when the server boots
+# - If a daemon exits or crashes, Rage restarts it with exponential backoff
+# - If a worker process dies, Rage restarts the daemon in another worker
+# - On server shutdown, daemons are gracefully stopped
+#
+# ## Defining a Daemon
+#
+# Create a daemon by subclassing `Rage::Daemon` and implementing the {#perform} method:
+#
+# ```ruby
+# class RedisListener < Rage::Daemon
+#   def perform
+#     redis = Redis.new
+#
+#     redis.subscribe("notifications") do |on|
+#       on.message do |channel, message|
+#         Rage::Cable.broadcast("notifications", message)
+#       end
+#     end
+#   end
+# end
+# ```
+#
+# ## Registering Daemons
+#
+# Register daemons in your application configuration:
+#
+# ```ruby
+# # config/application.rb
+# Rage.configure do
+#   config.daemons << RedisListener
+# end
+# ```
+#
+# ## Exclusive Daemons
+#
+# By default, daemons run in every worker process. Use {exclusive exclusive} when you need exactly one instance
+# across all workers, such as when consuming from a queue where duplicate processing would be problematic:
+#
+# ```ruby
+# class QueueConsumer < Rage::Daemon
+#   exclusive
+#
+#   def perform
+#     loop do
+#       job = JobQueue.pop  # only one worker should pop from the queue
+#       process(job)
+#     end
+#   end
+# end
+# ```
+#
+# ## Stopping a Daemon
+#
+# Return {Stop} from {#perform} to explicitly stop a daemon without triggering a restart:
+#
+# ```ruby
+# class BatchProcessor < Rage::Daemon
+#   def perform
+#     while (batch = Batch.next_pending)
+#       process(batch)
+#     end
+#
+#     Stop  # all batches processed, stop the daemon
+#   end
+# end
+# ```
+#
+# ## Cleanup
+#
+# Implement the `cleanup` method to release resources when a daemon stops or restarts:
+#
+# ```ruby
+# class StreamConsumer < Rage::Daemon
+#   def perform
+#     @connection = StreamingAPI.connect
+#     @connection.each { |event| process(event) }
+#   end
+#
+#   def cleanup
+#     @connection&.close
+#   end
+# end
+# ```
+#
+# The `cleanup` method is called:
+# - When {#perform} returns normally
+# - When {#perform} raises an exception (before restart)
+# - When the server is shutting down
+#
+class Rage::Daemon
+  # A sentinel value that can be returned from {#perform} to explicitly stop the daemon.
+  # When returned, the daemon will not be restarted.
+  # @example
+  #   def perform
+  #     return Stop if shutdown_requested?
+  #     # ...
+  #   end
+  Stop = Object.new
+
+  INITIAL_BACKOFF = 0.1
+  private_constant :INITIAL_BACKOFF
+
+  MAX_BACKOFF = 30
+  private_constant :MAX_BACKOFF
+
+  BACKOFF_RESET_INTERVAL = 30
+  private_constant :BACKOFF_RESET_INTERVAL
+
+  class << self
+    # Configures the daemon to run in only one worker process.
+    #
+    # In multi-process deployments, Rage runs daemons in every worker by default.
+    # Use `exclusive` when running multiple instances would cause problems,
+    # such as duplicate message processing or resource contention.
+    #
+    # Rage uses IPC to ensure exactly one worker runs the daemon. If that worker
+    # dies, the daemon will be automatically restarted in another worker.
+    #
+    # @example
+    #   class QueueConsumer < Rage::Daemon
+    #     exclusive
+    #
+    #     def perform
+    #       # only runs in one worker process
+    #     end
+    #   end
+    def exclusive
+      @__exclusive = true
+    end
+
+    # @private
+    def __perform
+      if @__exclusive
+        Rage::Internal.pick_a_worker(purpose: "daemon-#{name}") { __execute }
+      else
+        __execute
+      end
+    end
+
+    private
+
+    def __execute
+      Iodine.on_state(:start_shutdown) do
+        @__stopping = true
+      end
+
+      Fiber.schedule do
+        backoff = INITIAL_BACKOFF
+
+        Rage.logger.with_context(daemon: name) do
+          loop do
+            started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+            begin
+              instance = new
+              result = instance.perform
+              break if result.equal?(Stop) || @__stopping
+              Rage.logger.warn("Daemon exited, restarting...")
+            rescue => e
+              break if @__stopping
+              Rage.logger.error("Daemon failed with exception: #{e.class} (#{e.message}):\n#{e.backtrace.join("\n")}")
+              Rage::Errors.report(e)
+            ensure
+              __cleanup(instance)
+            end
+
+            # reset backoff if ran successfully for a while
+            backoff = INITIAL_BACKOFF if Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at > BACKOFF_RESET_INTERVAL
+            sleep(backoff / 2 + rand * backoff / 2)
+            backoff = (backoff * 2).clamp(INITIAL_BACKOFF, MAX_BACKOFF)
+          end
+        end
+      end
+    end # class << self
+
+    def __cleanup(instance)
+      instance.cleanup if instance.respond_to?(:cleanup)
+    rescue => e
+      Rage.logger.error("Cleanup hook failed with exception: #{e.class} (#{e.message}):\n#{e.backtrace.join("\n")}")
+      Rage::Errors.report(e)
+    end
+  end
+
+  # The main entry point for the daemon's work.
+  #
+  # Implement this method to define what the daemon does. The method should contain
+  # the daemon's main loop or blocking operation. When this method returns normally,
+  # Rage logs a warning and restarts the daemon. Return {Stop} to explicitly stop
+  # the daemon without triggering a restart.
+  #
+  # @return [Object] return {Stop} to stop the daemon; any other return value triggers a restart
+  # @example Listening to a Redis channel
+  #   def perform
+  #     redis = Redis.new
+  #     redis.subscribe("events") do |on|
+  #       on.message { |_, msg| handle(msg) }
+  #     end
+  #   end
+  # @example Polling a queue
+  #   def perform
+  #     loop do
+  #       message = queue.pop
+  #       process(message)
+  #     end
+  #   end
+  # @example Processing until complete
+  #   def perform
+  #     while (item = fetch_next_item)
+  #       process(item)
+  #     end
+  #
+  #     Stop
+  #   end
+  def perform
+  end
+end
+
+Iodine.on_state(:on_start) do
+  Fiber.set_scheduler(Rage::FiberScheduler.new) unless Fiber.scheduler
+  Rage.config.daemons.klasses.each { |klass| klass.__perform }
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1297,4 +1297,41 @@ RSpec.describe Rage::Configuration do
       end
     end
   end
+
+  describe "#daemons" do
+    subject { described_class.new.daemons }
+
+    let(:daemon) { Class.new(Rage::Daemon) }
+
+    it "returns empty list" do
+      expect(subject.klasses).to be_empty
+    end
+
+    it "allows to add a daemon" do
+      subject << daemon
+      expect(subject.klasses).to eq([daemon])
+    end
+
+    context "with a daemon instance" do
+      it "raises an error" do
+        expect {
+          subject << daemon.new
+        }.to raise_error(/should inherit `Rage::Daemon`/)
+
+        expect(subject.klasses).to be_empty
+      end
+    end
+
+    context "with an incorrect class" do
+      let(:daemon) { Class.new }
+
+      it "raises an error" do
+        expect {
+          subject << daemon
+        }.to raise_error(/should inherit `Rage::Daemon`/)
+
+        expect(subject.klasses).to be_empty
+      end
+    end
+  end
 end

--- a/spec/daemon_spec.rb
+++ b/spec/daemon_spec.rb
@@ -1,0 +1,257 @@
+# frozen_string_literal: true
+
+RSpec.describe Rage::Daemon do
+  subject { daemon.__perform }
+
+  let(:validator) { spy }
+
+  before :all do
+    Fiber.set_scheduler(Rage::FiberScheduler.new)
+  end
+
+  after :all do
+    Fiber.set_scheduler(nil)
+  end
+
+  before do
+    allow_any_instance_of(daemon).to receive(:validator).and_return(validator)
+    allow(Rage).to receive(:logger).and_return(Rage::Logger.new(STDERR))
+  end
+
+  context "with a single-action perform" do
+    let(:daemon) do
+      Class.new(Rage::Daemon) do
+        def perform
+          validator.perform
+          Rage::Daemon::Stop
+        end
+      end
+    end
+
+    it "calls perform" do
+      within_reactor do
+        subject
+        -> { expect(validator).to have_received(:perform) }
+      end
+    end
+
+    it "doesn't restart the daemon" do
+      within_reactor do
+        subject
+        sleep 1
+        -> { expect(validator).to have_received(:perform) }
+      end
+    end
+  end
+
+  context "with cleanup" do
+    context "when daemon stops" do
+      let(:daemon) do
+        Class.new(Rage::Daemon) do
+          def perform
+            Rage::Daemon::Stop
+          end
+
+          def cleanup
+            validator.cleanup
+          end
+        end
+      end
+
+      it "calls cleanup" do
+        within_reactor do
+          subject
+          -> { expect(validator).to have_received(:cleanup) }
+        end
+      end
+    end
+
+    context "when daemon raises" do
+      let(:daemon) do
+        Class.new(Rage::Daemon) do
+          def perform
+            raise ZeroDivisionError
+          end
+
+          def cleanup
+            validator.cleanup
+          end
+        end
+      end
+
+      it "calls cleanup" do
+        within_reactor do
+          subject
+          -> { expect(validator).to have_received(:cleanup).at_least(:once) }
+        end
+      end
+
+      it "reports the error" do
+        within_reactor do
+          expect(Rage.logger).to receive(:error).with(/Daemon failed with exception: ZeroDivisionError/).at_least(:once)
+          expect(Rage::Errors).to receive(:report).with(ZeroDivisionError).at_least(:once)
+          subject
+          -> {}
+        end
+      end
+    end
+
+    context "when server stops" do
+      before do
+        allow(Iodine).to receive(:on_state).with(:start_shutdown).and_yield
+      end
+
+      let(:daemon) do
+        Class.new(Rage::Daemon) do
+          def perform
+          end
+
+          def cleanup
+            validator.cleanup
+          end
+        end
+      end
+
+      it "calls cleanup" do
+        within_reactor do
+          subject
+          -> { expect(validator).to have_received(:cleanup) }
+        end
+      end
+    end
+
+    context "when cleanup raises" do
+      let(:daemon) do
+        Class.new(Rage::Daemon) do
+          def perform
+            Rage::Daemon::Stop
+          end
+
+          def cleanup
+            raise ZeroDivisionError
+          end
+        end
+      end
+
+      it "reports the error" do
+        within_reactor do
+          expect(Rage.logger).to receive(:error).with(/Cleanup hook failed with exception: ZeroDivisionError/)
+          expect(Rage::Errors).to receive(:report).with(ZeroDivisionError)
+          expect { subject }.not_to raise_error
+          -> {}
+        end
+      end
+    end
+  end
+
+  context "when initialize raises" do
+    let(:daemon) do
+      Class.new(Rage::Daemon) do
+        def initialize
+          raise ZeroDivisionError
+        end
+
+        def perform
+        end
+      end
+    end
+
+    it "reports the error" do
+      within_reactor do
+        -> do
+          expect(Rage.logger).to receive(:error).with(/Daemon failed with exception: ZeroDivisionError/)
+          expect(Rage::Errors).to receive(:report).with(ZeroDivisionError)
+          expect { subject }.not_to raise_error
+          -> {}
+        end
+      end
+    end
+  end
+
+  context "with restart on exception" do
+    let(:daemon) do
+      Class.new(Rage::Daemon) do
+        def perform
+          validator.perform(@state)
+          @state = rand
+        end
+      end
+    end
+
+    it "creates a new instance" do
+      within_reactor do
+        subject
+        sleep 1
+
+        -> do
+          expect(validator).to have_received(:perform).at_least(:once)
+          expect(validator).not_to have_received(:perform).with(satisfy { |c| !c.nil? })
+        end
+      end
+    end
+  end
+
+  context "with backoff" do
+    let(:daemon) do
+      Class.new(Rage::Daemon) do
+        def perform
+          raise ZeroDivisionError
+        end
+      end
+    end
+
+    before do
+      original_sleep = daemon.method(:sleep)
+
+      allow(daemon).to receive(:sleep) do |timeout|
+        timeouts << timeout
+        original_sleep.call(timeout)
+      end
+    end
+
+    let(:timeouts) { [] }
+
+    it "sleeps with increasing intervals" do
+      within_reactor do
+        subject
+        sleep 1
+
+        -> do
+          expect(timeouts.sort).to eq(timeouts)
+        end
+      end
+    end
+  end
+
+  context "with exclusive daemon" do
+    let(:daemon) do
+      Class.new(Rage::Daemon) do
+        exclusive
+
+        def perform
+          validator.perform
+        end
+      end
+    end
+
+    before do
+      allow(daemon).to receive(:name).and_return(:ExclusiveTestDaemon)
+    end
+
+    it "starts the daemon in one worker" do
+      within_reactor do
+        perform_block = nil
+        expect(Rage::Internal).to receive(:pick_a_worker).with(purpose: /ExclusiveTestDaemon/) do |&block|
+          perform_block = block
+        end
+
+        subject
+        expect(validator).not_to have_received(:perform)
+
+        perform_block.call
+
+        -> { expect(validator).to have_received(:perform).at_least(:once) }
+      end
+    end
+  end
+end

--- a/spec/daemon_spec.rb
+++ b/spec/daemon_spec.rb
@@ -254,4 +254,76 @@ RSpec.describe Rage::Daemon do
       end
     end
   end
+
+  context "with inheritance" do
+    context "with inherited exclusive status" do
+      let(:parent_daemon) do
+        Class.new(Rage::Daemon) do
+          exclusive
+
+          def perform
+          end
+        end
+      end
+
+      let(:daemon) do
+        Class.new(parent_daemon) do
+          def perform
+          end
+        end
+      end
+
+      it "inherits the exclusive status" do
+        expect(daemon.__exclusive).to be(true)
+      end
+    end
+
+    context "with overriden exclusive status" do
+      let(:parent_daemon) do
+        Class.new(Rage::Daemon) do
+          exclusive
+
+          def perform
+          end
+        end
+      end
+
+      let(:daemon) do
+        Class.new(parent_daemon) do
+          exclusive(false)
+
+          def perform
+          end
+        end
+      end
+
+      it "inherits the exclusive status" do
+        expect(daemon.__exclusive).to be(false)
+        expect(parent_daemon.__exclusive).to be(true)
+      end
+    end
+
+    context "with set exclusive status" do
+      let(:parent_daemon) do
+        Class.new(Rage::Daemon) do
+          def perform
+          end
+        end
+      end
+
+      let(:daemon) do
+        Class.new(parent_daemon) do
+          exclusive
+
+          def perform
+          end
+        end
+      end
+
+      it "sets the exclusive status independently" do
+        expect(daemon.__exclusive).to be(true)
+        expect(parent_daemon.__exclusive).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/deferred/deferred_spec.rb
+++ b/spec/deferred/deferred_spec.rb
@@ -69,6 +69,10 @@ RSpec.describe Rage::Deferred do
   end
 
   describe ".__middleware_chain" do
+    before do
+      Rage::Deferred.instance_variable_set(:@__middleware_chain, nil)
+    end
+
     it "initializes middleware chain" do
       allow(Rage.config.deferred.enqueue_middleware).to receive(:objects).and_return(:test_enqueue_middleware_objects)
       allow(Rage.config.deferred.perform_middleware).to receive(:objects).and_return(:test_perform_middleware_objects)

--- a/spec/deferred/middleware_chain_spec.rb
+++ b/spec/deferred/middleware_chain_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Rage::Deferred::MiddlewareChain do
   let(:context) { Rage::Deferred::Context.build(task_class, args, kwargs) }
 
   after do
-    subject
+    described_class.new(enqueue_middleware: [], perform_middleware: [])
   end
 
   context "Enqueue Chain" do

--- a/spec/integration/daemons_spec.rb
+++ b/spec/integration/daemons_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "redis-client"
+
+RSpec.describe "Daemons" do
+  before :all do
+    skip("skipping file server tests") unless ENV["ENABLE_EXTERNAL_TESTS"] == "true"
+  end
+
+  before :all do
+    launch_server(env: { "RAGE_ENV" => "production", "WEB_CONCURRENCY" => "3", "ENABLE_DAEMONS" => "1" })
+  end
+
+  after :all do
+    stop_server
+  end
+
+  let(:redis) { RedisClient.new(url: ENV["TEST_REDIS_URL"]) }
+  let(:logs) { File.readlines("spec/integration/test_app/log/production.log") }
+
+  it "starts daemons" do
+    redis.pubsub.call("PUBLISH", "daemon:test:channel", "hello, world")
+    sleep 1
+
+    daemon_logs = logs.group_by { |line| line.match(/daemon=(\w+)/).to_a.last }
+
+    expect(daemon_logs["RedisListener1"].size).to eq(1)
+    expect(daemon_logs["RedisListener1"].last).to include("message=hello, world")
+
+    expect(daemon_logs["RedisListener2"].size).to eq(3)
+    daemon_logs["RedisListener2"].each do |line|
+      expect(line).to include("message=#{"hello, world".reverse}")
+    end
+  end
+
+  it "restarts daemons if their processes crash" do
+    # kill processes the daemons are attached to
+    exclusive_daemon_pid = logs.
+      find { |line| line.include?("starting RedisListener1") }.
+      match(/\[(\d+)\]/)[1]
+
+    non_exclusive_daemon_pid = logs.
+      find { |line| line.include?("starting RedisListener2") }.
+      match(/\[(\d+)\]/)[1]
+
+    `kill #{exclusive_daemon_pid}`
+    `kill #{non_exclusive_daemon_pid}`
+
+    sleep 1
+
+    # verify they are respawned
+    redis.pubsub.call("PUBLISH", "daemon:test:channel", "hello, world")
+    sleep 1
+
+    logs = File.readlines("spec/integration/test_app/log/production.log").last(4)
+    daemon_logs = logs.group_by { |line| line.match(/daemon=(\w+)/).to_a.last }
+
+    expect(daemon_logs["RedisListener1"].size).to eq(1)
+    expect(daemon_logs["RedisListener2"].size).to eq(3)
+  end
+end

--- a/spec/integration/test_app/Gemfile
+++ b/spec/integration/test_app/Gemfile
@@ -4,6 +4,7 @@ gem "rage-rb"
 gem "alba", "~> 3.0"
 gem "prism"
 gem "redis-client"
+gem "redis"
 
 # Get 50% to 150% boost when parsing JSON.
 # Rage will automatically use FastJsonparser if it is available.

--- a/spec/integration/test_app/app/daemons/redis_listener_1.rb
+++ b/spec/integration/test_app/app/daemons/redis_listener_1.rb
@@ -1,0 +1,20 @@
+class RedisListener1 < Rage::Daemon
+  exclusive
+
+  def initialize
+    Rage.logger << "[#{Process.pid}] starting #{self.class.name}\n"
+    @redis = Redis.new(url: ENV["TEST_REDIS_URL"])
+  end
+
+  def perform
+    @redis.subscribe("daemon:test:channel") do |on|
+      on.message do |_, message|
+        Rage.logger.info message
+      end
+    end
+  end
+
+  def cleanup
+    @redis.close
+  end
+end

--- a/spec/integration/test_app/app/daemons/redis_listener_2.rb
+++ b/spec/integration/test_app/app/daemons/redis_listener_2.rb
@@ -1,0 +1,18 @@
+class RedisListener2 < Rage::Daemon
+  def initialize
+    Rage.logger << "[#{Process.pid}] starting #{self.class.name}\n"
+    @redis = Redis.new(url: ENV["TEST_REDIS_URL"])
+  end
+
+  def perform
+    @redis.subscribe("daemon:test:channel") do |on|
+      on.message do |_, message|
+        Rage.logger.info message.reverse
+      end
+    end
+  end
+
+  def cleanup
+    @redis.close
+  end
+end

--- a/spec/integration/test_app/config/application.rb
+++ b/spec/integration/test_app/config/application.rb
@@ -83,6 +83,12 @@ Rage.configure do
   end
 
   config.blocking_operation_pool.enabled = true
+
+  if ENV["ENABLE_DAEMONS"]
+    config.after_initialize do
+      config.daemons << RedisListener1 << RedisListener2
+    end
+  end
 end
 
 class TestSseObserver < Rage::Telemetry::Handler

--- a/spec/integration/test_app/config/environments/production.rb
+++ b/spec/integration/test_app/config/environments/production.rb
@@ -1,6 +1,6 @@
 Rage.configure do
   # Specify the number of server processes to run. Defaults to number of CPU cores.
-  config.server.workers_count = ENV.fetch("WEB_CONCURRENCY", 1)
+  config.server.workers_count = ENV.fetch("WEB_CONCURRENCY", 1).to_i
 
   # Specify the port the server will listen on.
   config.server.port = 3000


### PR DESCRIPTION
`Rage::Daemon` is an abstraction for running long-lived background processes alongside your application.
Use daemons for tasks that need to run continuously, such as listening to message queues, consuming streaming APIs,
or maintaining persistent connections to external services.

The framework automatically manages daemon lifecycle:
- Daemons are started when the server boots
- If a daemon exits or crashes, Rage restarts it with exponential backoff
- If a worker process dies, Rage restarts the daemon in another worker
- On server shutdown, daemons are gracefully stopped

## Defining a Daemon

Create a daemon by subclassing `Rage::Daemon` and implementing the `#perform` method:

```ruby
class RedisListener < Rage::Daemon
  def perform
    redis = Redis.new

    redis.subscribe("notifications") do |on|
      on.message do |channel, message|
        Rage::Cable.broadcast("notifications", message)
      end
    end
  end
end
```

## Registering Daemons

Register daemons in your application configuration:

```ruby
# config/application.rb
Rage.configure do
  config.daemons << RedisListener
end
```

## Exclusive Daemons

By default, daemons run in every worker process. Use `exclusive` when you need exactly one instance
across all workers, such as when consuming from a queue where duplicate processing would be problematic:

```ruby
class QueueConsumer < Rage::Daemon
  exclusive

  def perform
    loop do
      job = JobQueue.pop  # only one worker should pop from the queue
      process(job)
    end
  end
end
```

## Stopping a Daemon

Return `Stop` from `#perform` to explicitly stop a daemon without triggering a restart:

```ruby
class BatchProcessor < Rage::Daemon
  def perform
    while (batch = Batch.next_pending)
      process(batch)
    end

    Stop  # all batches processed, stop the daemon
  end
end
```

## Cleanup

Implement the `cleanup` method to release resources when a daemon stops or restarts:

```ruby
class StreamConsumer < Rage::Daemon
  def perform
    @connection = StreamingAPI.connect
    @connection.each { |event| process(event) }
  end

  def cleanup
    @connection&.close
  end
end
```

The `cleanup` method is called:
- When `#perform` returns normally
- When `#perform` raises an exception (before restart)
- When the server is shutting down