### PR TITLE
[OpenAPI]: Fix blueprinter registry key normalization and chose correct view when explicitly mentioned for association

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - [OpenAPI] Add support for the `root:` option in Blueprinter response annotations (#343).
 
+### Fixed
+
+- [OpenAPI] Fix schema registry key collisions for Blueprinter classes referenced under different views.
+
 ## [1.26.0] - 2026-07-07
 
 ### Added

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -20,9 +20,10 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
     is_collection, raw_klass_str, serializer_options = Rage::OpenAPI.__parse_serializer_args(klass_str)
     klass = @namespace.const_get(raw_klass_str)
     schema = build_schema(klass, is_collection, serializer_options)
+    registry_key = "#{raw_klass_str}_#{serializer_options[:view] || :default}"
 
-    if @root.schema_registry.key?(raw_klass_str)
-      @root.schema_registry[raw_klass_str] = is_collection ? schema["items"] : schema
+    if @root.schema_registry.key?(registry_key)
+      @root.schema_registry[registry_key] = is_collection ? schema["items"] : schema
     end
 
     schema
@@ -32,19 +33,19 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
 
   private
 
-  def build_schema(klass, is_collection, serializer_options = nil)
-    @parsing_stack.add(klass.name)
-
+  def build_schema(klass, is_collection, serializer_options)
     view_name = serializer_options&.key?(:view) ? serializer_options[:view].to_sym : :default
     reflections = klass.reflections
     view = reflections[view_name]
     raise InvalidViewError, "invalid view #{view_name}" unless view
 
+    @parsing_stack.add([klass.name, view_name])
+
     identifier_fields = extract_fields(reflections[:identifier])
     default_fields = extract_fields(view)
     association_fields = extract_associations(view)
 
-    @parsing_stack.delete(klass.name)
+    @parsing_stack.delete([klass.name, view_name])
 
     schema = identifier_fields.merge(default_fields.merge(association_fields).sort.to_h)
 
@@ -70,14 +71,16 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
       blueprint = association.blueprint
       name, display_name = association.name.to_s, association.display_name.to_s
       is_collection = collection_association?(name)
+      serializer_options = { view: association.view }
 
       item_schema = if blueprint.is_a?(Proc)
         { "type" => "object" }
-      elsif @parsing_stack.include?(blueprint.name)
-        @root.schema_registry[blueprint.name] ||= nil
-        { "$ref" => "#/components/schemas/#{blueprint.name}" }
+      elsif @parsing_stack.include?([blueprint.name, association.view])
+        schema_key = "#{blueprint.name}_#{association.view}"
+        @root.schema_registry[schema_key] ||= nil
+        { "$ref" => "#/components/schemas/#{schema_key}" }
       else
-        build_schema(blueprint, false)
+        build_schema(blueprint, false, serializer_options)
       end
 
       properties[display_name] = is_collection ? { "type" => "array", "items" => item_schema } : item_schema

--- a/spec/openapi/parsers/ext/blueprinter_spec.rb
+++ b/spec/openapi/parsers/ext/blueprinter_spec.rb
@@ -455,7 +455,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
                   "name" => { "type" => "string" },
                   "users" => {
                     "type" => "array",
-                    "items" => { "$ref" => "#/components/schemas/UserBlueprint" }
+                    "items" => { "$ref" => "#/components/schemas/UserBlueprint_default" }
                   }
                 }
               }
@@ -600,7 +600,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
                   "name" => { "type" => "string" },
                   "users" => {
                     "type" => "array",
-                    "items" => { "$ref" => "#/components/schemas/UserBlueprint" }
+                    "items" => { "$ref" => "#/components/schemas/UserBlueprint_default" }
                   }
                 }
               }
@@ -1694,6 +1694,174 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         })
       end
     end
+
+    context "with circular association through default views only (self-referencing pair)" do
+      let_blueprinter_class("DataMiningBase") do
+        <<~'RUBY'
+          field :first_name
+          association :data_mining, blueprint: DataMining
+        RUBY
+      end
+
+      let_blueprinter_class("DataMining") do
+        <<~'RUBY'
+          fields :first_name, :hello_world
+          association :project, blueprint: DataMiningBase
+          view :extended do
+            field :extended_author
+          end
+        RUBY
+      end
+
+      let(:resource) { "DataMiningBase" }
+
+      it "resolves one level then falls back to $ref for the repeated default-view class" do
+        expect { subject }.not_to raise_error
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "first_name" => { "type" => "string" },
+            "data_mining" => {
+              "type" => "object",
+              "properties" => {
+                "first_name" => { "type" => "string" },
+                "hello_world" => { "type" => "string" },
+                "project" => { "$ref" => "#/components/schemas/DataMiningBase_default" }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with circular association where only the outer association pins an explicit view" do
+      let_blueprinter_class("DataMiningBase") do
+        <<~'RUBY'
+          field :first_name
+          view :sample do
+            field :hello_world
+            association :data_mining, blueprint: DataMining
+          end
+        RUBY
+      end
+
+      let_blueprinter_class("DataMining") do
+        <<~'RUBY'
+          fields :first_name, :hello_world
+          association :project, blueprint: DataMiningBase, view: :sample
+        RUBY
+      end
+
+      let(:resource) { "DataMiningBase(view: :sample)" }
+
+      it "keys the circular $ref by the explicit view, not by :default" do
+        expect { subject }.not_to raise_error
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "first_name" => { "type" => "string" },
+            "hello_world" => { "type" => "string" },
+            "data_mining" => {
+              "type" => "object",
+              "properties" => {
+                "first_name" => { "type" => "string" },
+                "hello_world" => { "type" => "string" },
+                "project" => { "$ref" => "#/components/schemas/DataMiningBase_sample" }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with a genuine cycle where both sides pin distinct explicit views" do
+      let_blueprinter_class("ProjectBlueprint") do
+        <<~'RUBY'
+          fields :name
+          view :detailed do
+            association :owner, blueprint: UserBlueprint, view: :extended
+          end
+        RUBY
+      end
+
+      let_blueprinter_class("UserBlueprint") do
+        <<~'RUBY'
+          fields :email
+          view :extended do
+            fields :bio
+            association :projects, blueprint: ProjectBlueprint, view: :detailed
+          end
+        RUBY
+      end
+
+      let(:resource) { "ProjectBlueprint(view: :detailed)" }
+
+      it "detects the cycle via the (class, view) pair and does not confuse it with the default view" do
+        expect { subject }.not_to raise_error
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "name" => { "type" => "string" },
+            "owner" => {
+              "type" => "object",
+              "properties" => {
+                "bio" => { "type" => "string" },
+                "email" => { "type" => "string" },
+                "projects" => {
+                  "type" => "array",
+                  "items" => { "$ref" => "#/components/schemas/ProjectBlueprint_detailed" }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with an association chain that only cycles through one specific view (not a true cycle at the tuple level)" do
+      let_blueprinter_class("DataMiningBase") do
+        <<~'RUBY'
+          field :first_name
+          view :sample do
+            field :hello_world
+            association :data_mining, blueprint: DataMining
+          end
+        RUBY
+      end
+
+      let_blueprinter_class("DataMining") do
+        <<~'RUBY'
+          fields :first_name, :hello_world
+          association :project, blueprint: DataMiningBase
+        RUBY
+      end
+
+      let(:resource) { "DataMiningBase(view: :sample)" }
+
+      it "fully expands instead of using $ref, since the association loops back to the default view, not :sample" do
+        expect { subject }.not_to raise_error
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "first_name" => { "type" => "string" },
+            "hello_world" => { "type" => "string" },
+            "data_mining" => {
+              "type" => "object",
+              "properties" => {
+                "first_name" => { "type" => "string" },
+                "hello_world" => { "type" => "string" },
+                "project" => {
+                  "type" => "object",
+                  "properties" => {
+                    "first_name" => { "type" => "string" }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
   end
 
   describe "collection" do
@@ -1941,7 +2109,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
                     "name" => { "type" => "string" },
                     "users" => {
                       "type" => "array",
-                      "items" => { "$ref" => "#/components/schemas/UserBlueprint" }
+                      "items" => { "$ref" => "#/components/schemas/UserBlueprint_default" }
                     }
                   }
                 }
@@ -2095,7 +2263,7 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
                     "name" => { "type" => "string" },
                     "users" => {
                       "type" => "array",
-                      "items" => { "$ref" => "#/components/schemas/UserBlueprint" }
+                      "items" => { "$ref" => "#/components/schemas/UserBlueprint_default" }
                     }
                   }
                 }
@@ -3285,6 +3453,186 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
                 "id" => { "type" => "string" },
                 "name" => { "type" => "string" },
                 "email" => { "type" => "string" }
+              }
+            }
+          }
+        }
+      })
+    end
+  end
+
+  context "with circular association through default views only (self-referencing pair)" do
+    let(:resource) { "Array<DataMiningBase>" }
+
+    let_blueprinter_class("DataMiningBase") do
+      <<~'RUBY'
+        field :first_name
+        association :data_mining, blueprint: DataMining
+      RUBY
+    end
+
+    let_blueprinter_class("DataMining") do
+      <<~'RUBY'
+        fields :first_name, :hello_world
+        association :project, blueprint: DataMiningBase
+        view :extended do
+          field :extended_author
+        end
+      RUBY
+    end
+
+    it "resolves one level then falls back to $ref for the repeated default-view class" do
+      expect { subject }.not_to raise_error
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "first_name" => { "type" => "string" },
+            "data_mining" => {
+              "type" => "object",
+              "properties" => {
+                "first_name" => { "type" => "string" },
+                "hello_world" => { "type" => "string" },
+                "project" => { "$ref" => "#/components/schemas/DataMiningBase_default" }
+              }
+            }
+          }
+        }
+      })
+    end
+  end
+
+  context "with circular association where only the outer association pins an explicit view" do
+    let(:resource) { "Array<DataMiningBase(view: :sample)>" }
+
+    let_blueprinter_class("DataMiningBase") do
+      <<~'RUBY'
+        field :first_name
+        view :sample do
+          field :hello_world
+          association :data_mining, blueprint: DataMining
+        end
+      RUBY
+    end
+
+    let_blueprinter_class("DataMining") do
+      <<~'RUBY'
+        fields :first_name, :hello_world
+        association :project, blueprint: DataMiningBase, view: :sample
+      RUBY
+    end
+
+    it "keys the circular $ref by the explicit view, not by :default" do
+      expect { subject }.not_to raise_error
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "first_name" => { "type" => "string" },
+            "hello_world" => { "type" => "string" },
+            "data_mining" => {
+              "type" => "object",
+              "properties" => {
+                "first_name" => { "type" => "string" },
+                "hello_world" => { "type" => "string" },
+                "project" => { "$ref" => "#/components/schemas/DataMiningBase_sample" }
+              }
+            }
+          }
+        }
+      })
+    end
+  end
+
+  context "with a genuine cycle where both sides pin distinct explicit views" do
+    let(:resource) { "Array<ProjectBlueprint(view: :detailed)>" }
+
+    let_blueprinter_class("ProjectBlueprint") do
+      <<~'RUBY'
+        fields :name
+        view :detailed do
+          association :owner, blueprint: UserBlueprint, view: :extended
+        end
+      RUBY
+    end
+
+    let_blueprinter_class("UserBlueprint") do
+      <<~'RUBY'
+        fields :email
+        view :extended do
+          fields :bio
+          association :projects, blueprint: ProjectBlueprint, view: :detailed
+        end
+      RUBY
+    end
+
+    it "detects the cycle via the (class, view) pair and does not confuse it with the default view" do
+      expect { subject }.not_to raise_error
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "name" => { "type" => "string" },
+            "owner" => {
+              "type" => "object",
+              "properties" => {
+                "bio" => { "type" => "string" },
+                "email" => { "type" => "string" },
+                "projects" => {
+                  "type" => "array",
+                  "items" => { "$ref" => "#/components/schemas/ProjectBlueprint_detailed" }
+                }
+              }
+            }
+          }
+        }
+      })
+    end
+  end
+
+  context "with an association chain that only cycles through one specific view (not a true cycle at the tuple level)" do
+    let(:resource) { "Array<DataMiningBase(view: :sample)>" }
+
+    let_blueprinter_class("DataMiningBase") do
+      <<~'RUBY'
+        field :first_name
+        view :sample do
+          field :hello_world
+          association :data_mining, blueprint: DataMining
+        end
+      RUBY
+    end
+
+    let_blueprinter_class("DataMining") do
+      <<~'RUBY'
+        fields :first_name, :hello_world
+        association :project, blueprint: DataMiningBase
+      RUBY
+    end
+
+    it "fully expands instead of using $ref, since the association loops back to the default view, not :sample" do
+      expect { subject }.not_to raise_error
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "first_name" => { "type" => "string" },
+            "hello_world" => { "type" => "string" },
+            "data_mining" => {
+              "type" => "object",
+              "properties" => {
+                "first_name" => { "type" => "string" },
+                "hello_world" => { "type" => "string" },
+                "project" => {
+                  "type" => "object",
+                  "properties" => {
+                    "first_name" => { "type" => "string" }
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
### What this PR does ?

If the same Blueprinter class shows up under different views across a spec, say `UserBlueprint(view: :normal)` on one endpoint and `UserBlueprint(view: :extended)` on another, the OpenAPI parser used to track both under the same key: just the class name. That caused two bugs:

1. **One view's schema overwrote the other's.** Whichever view got parsed last "won" in the schema registry, so a `$ref` meant to point at one view's schema could end up resolving to a different view's schema entirely.
2. **False circular-reference detection.** The parser also used bare class names to detect cycles, so it couldn't tell *which* view of a class was already being built, only that the class name was somewhere on the stack.

It's common for one class to have *multiple* associations to the same target class, each pinned to a different view. For example: `# @response DataMining(view: :sample)`

```ruby
class DataMining < Blueprinter::Base
  fields "first_name", :hello_world
  association :project, view: :sample, blueprint: DataMiningBase, name: :classmate
  view :extended do
    field :extended_author
  end
end

class DataMiningBase < Blueprinter::Base
  field :first_name
  association :data_mining, blueprint: DataMining, view: :extended
  view :sample do
    field :hello_world
    association :data_mining, blueprint: DataMining
  end
end
```

Parsing `DataMining` (default view): it associates to `DataMiningBase(view: :sample)`, whose own association loops back to `DataMining`'s **default** view a genuine cycle. Meanwhile, `DataMiningBase`'s *default* view separately associates to `DataMining(view: :extended)` a completely different edge that should never be touched during this parse. With the new implementation the parser will ignore `DataMiningBase(view: :extended)` as `DataMining` points to `sample` view.


### Screenshot

- Before

<img width="1352" height="603" alt="image" src="https://github.com/user-attachments/assets/fdac63e6-2f12-4dce-9d30-39a44036bf63" />


- Afrer

<img width="1344" height="598" alt="image" src="https://github.com/user-attachments/assets/a3e1104b-42d8-47b0-8807-ba7f6747a04d" />
