### PR TITLE
Enable non-blocking process monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [OpenAPI] Add Blueprinter association parsing with cycle detection (#291)
 - [OpenAPI] Add support for the `view:` option in Blueprinter parser.
 - Add `Rage::Daemon` (#339).
+- Enable non-blocking process monitoring (#341).
 
 ### Fixed
 

--- a/lib/rage/fiber_scheduler.rb
+++ b/lib/rage/fiber_scheduler.rb
@@ -152,6 +152,11 @@ class Rage::FiberScheduler
     end
   end
 
+  # Wait for a specified process.
+  def process_wait(pid, flags)
+    Thread.new { Process::Status.wait(pid, flags) }.value
+  end
+
   # Create and schedule a new non-blocking fiber, handling request and user-spawned fibers differently.
   def fiber(&block)
     parent = Fiber.current

--- a/spec/fiber_scheduler_spec.rb
+++ b/spec/fiber_scheduler_spec.rb
@@ -643,4 +643,50 @@ RSpec.describe Rage::FiberScheduler do
       end
     end
   end
+
+  context "#process_wait" do
+    it "waits for processes in a non-blocking manner" do
+      within_reactor do
+        result = Benchmark.realtime do
+          Fiber.schedule { Process.wait(Process.spawn("sleep 1")) }
+        end
+
+        -> { expect(result).to be < 0.1 }
+      end
+    end
+
+    it "resumes the fiber when the process is finished" do
+      within_reactor do
+        result = Benchmark.realtime do
+          Fiber.await([
+            Fiber.schedule { Process.wait(Process.spawn("sleep 1")) }
+          ])
+        end
+
+        -> { expect(0.9..1.1).to cover(result) }
+      end
+    end
+
+    it "resumes the fiber when the process is killed" do
+      within_reactor do
+        pid = nil
+
+        f = Fiber.schedule do
+          pid = Process.spawn("sleep 5")
+          Process.wait(pid)
+        end
+
+        Fiber.schedule do
+          sleep 1
+          Process.kill("TERM", pid)
+        end
+
+        result = Benchmark.realtime do
+          Fiber.await([f])
+        end
+
+        -> { expect(0.9..1.1).to cover(result) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
This pull request introduces a new method to support non-blocking process waiting in the fiber scheduler and adds tests to ensure its correct behavior.

**Fiber Scheduler Enhancements:**

* Added a `process_wait` method to `lib/rage/fiber_scheduler.rb` that waits for a process in a non-blocking way by delegating to a separate thread.

**Testing Improvements:**

* Added a new context for `#process_wait` in `spec/fiber_scheduler_spec.rb` with tests verifying:
  - Non-blocking behavior when waiting for processes.
  - Proper fiber resumption when the process finishes or is killed.