### PR TITLE
Make exclusive daemons the default

### DIFF
--- a/lib/rage/daemon.rb
+++ b/lib/rage/daemon.rb
@@ -40,20 +40,16 @@
 # end
 # ```
 #
-# ## Exclusive Daemons
+# ## Daemon Scope
 #
-# By default, daemons run in every worker process. Use {exclusive exclusive} when you need exactly one instance
-# across all workers, such as when consuming from a queue where duplicate processing would be problematic:
+# By default, daemons run in exactly one worker process per server. Use {scope scope} to change this behavior:
 #
 # ```ruby
-# class QueueConsumer < Rage::Daemon
-#   exclusive
+# class MetricsCollector < Rage::Daemon
+#   scope :worker
 #
 #   def perform
-#     loop do
-#       job = JobQueue.pop  # only one worker should pop from the queue
-#       process(job)
-#     end
+#     # runs in every worker process
 #   end
 # end
 # ```
@@ -117,37 +113,43 @@ class Rage::Daemon
 
   class << self
     # @private
-    attr_accessor :__exclusive
+    attr_accessor :__level
 
-    # Configures the daemon to run in only one worker process.
+    # Configures the scope at which the daemon runs.
     #
-    # In multi-process deployments, Rage runs daemons in every worker by default.
-    # Use `exclusive` when running multiple instances would cause problems,
-    # such as duplicate message processing or resource contention.
+    # By default, daemons run in one worker process per server (`:node` scope).
+    # Use this method to change the scope when a different behavior is needed.
     #
-    # Rage uses IPC to ensure exactly one worker runs the daemon. If that worker
-    # dies, the daemon will be automatically restarted in another worker.
+    # @param level [Symbol] the scope level
+    # @option level :node One instance per server (default). Rage uses IPC to coordinate
+    #   which worker runs the daemon. If that worker dies, the daemon restarts in another worker.
+    # @option level :worker One instance per worker process. Use this when the daemon performs
+    #   work that needs to run in parallel across workers.
     #
-    # @example
-    #   class QueueConsumer < Rage::Daemon
-    #     exclusive
+    # @example Running in every worker
+    #   class MetricsCollector < Rage::Daemon
+    #     scope :worker
     #
     #     def perform
-    #       # only runs in one worker process
+    #       # runs in every worker process
     #     end
     #   end
-    def exclusive(enabled = true)
-      @__exclusive = enabled
+    def scope(level)
+      unless level == :worker || level == :node
+        raise ArgumentError, "Invalid scope level: #{level.inspect}. Valid options are :node and :worker."
+      end
+
+      @__level = level
     end
 
     # @private
     def inherited(klass)
-      klass.__exclusive = @__exclusive
+      klass.__level = __level
     end
 
     # @private
     def __perform
-      if @__exclusive
+      if __level.nil? || __level == :node
         Rage::Internal.pick_a_worker(purpose: "daemon-#{name}") { __execute }
       else
         __execute

--- a/spec/daemon_spec.rb
+++ b/spec/daemon_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe Rage::Daemon do
   end
 
   before do
+    allow(daemon).to receive(:name).and_return(:TestDaemon)
+    allow(Rage::Internal).to receive(:pick_a_worker).with(purpose: /TestDaemon/).and_yield
+
     allow_any_instance_of(daemon).to receive(:validator).and_return(validator)
     allow(Rage).to receive(:logger).and_return(Rage::Logger.new(STDERR))
   end
@@ -25,6 +28,22 @@ RSpec.describe Rage::Daemon do
           validator.perform
           Rage::Daemon::Stop
         end
+      end
+    end
+
+    it "starts the daemon in one worker" do
+      within_reactor do
+        perform_block = nil
+        expect(Rage::Internal).to receive(:pick_a_worker).with(purpose: /TestDaemon/) do |&block|
+          perform_block = block
+        end
+
+        subject
+        expect(validator).not_to have_received(:perform)
+
+        perform_block.call
+
+        -> { expect(validator).to have_received(:perform).at_least(:once) }
       end
     end
 
@@ -223,10 +242,10 @@ RSpec.describe Rage::Daemon do
     end
   end
 
-  context "with exclusive daemon" do
+  context "with worker-level daemon" do
     let(:daemon) do
       Class.new(Rage::Daemon) do
-        exclusive
+        scope :worker
 
         def perform
           validator.perform
@@ -234,32 +253,34 @@ RSpec.describe Rage::Daemon do
       end
     end
 
-    before do
-      allow(daemon).to receive(:name).and_return(:ExclusiveTestDaemon)
-    end
-
-    it "starts the daemon in one worker" do
+    it "doesn't use Rage::Internal.pick_a_worker" do
       within_reactor do
-        perform_block = nil
-        expect(Rage::Internal).to receive(:pick_a_worker).with(purpose: /ExclusiveTestDaemon/) do |&block|
-          perform_block = block
-        end
-
+        expect(Rage::Internal).not_to receive(:pick_a_worker)
         subject
-        expect(validator).not_to have_received(:perform)
-
-        perform_block.call
 
         -> { expect(validator).to have_received(:perform).at_least(:once) }
       end
     end
   end
 
+  context "with incorrect scope level" do
+    let(:daemon) do
+      Class.new(Rage::Daemon) do
+        def perform
+        end
+      end
+    end
+
+    it "raises an error" do
+      expect { daemon.scope(:unknown) }.to raise_error(/Invalid scope level: :unknown/)
+    end
+  end
+
   context "with inheritance" do
-    context "with inherited exclusive status" do
+    context "with inherited scope level" do
       let(:parent_daemon) do
         Class.new(Rage::Daemon) do
-          exclusive
+          scope :worker
 
           def perform
           end
@@ -273,15 +294,15 @@ RSpec.describe Rage::Daemon do
         end
       end
 
-      it "inherits the exclusive status" do
-        expect(daemon.__exclusive).to be(true)
+      it "inherits the scope level" do
+        expect(daemon.__level).to eq(:worker)
       end
     end
 
-    context "with overriden exclusive status" do
+    context "with overriden scope level" do
       let(:parent_daemon) do
         Class.new(Rage::Daemon) do
-          exclusive
+          scope :worker
 
           def perform
           end
@@ -290,20 +311,20 @@ RSpec.describe Rage::Daemon do
 
       let(:daemon) do
         Class.new(parent_daemon) do
-          exclusive(false)
+          scope :node
 
           def perform
           end
         end
       end
 
-      it "inherits the exclusive status" do
-        expect(daemon.__exclusive).to be(false)
-        expect(parent_daemon.__exclusive).to be(true)
+      it "inherits the scope level" do
+        expect(daemon.__level).to eq(:node)
+        expect(parent_daemon.__level).to eq(:worker)
       end
     end
 
-    context "with set exclusive status" do
+    context "with set scope level" do
       let(:parent_daemon) do
         Class.new(Rage::Daemon) do
           def perform
@@ -313,16 +334,16 @@ RSpec.describe Rage::Daemon do
 
       let(:daemon) do
         Class.new(parent_daemon) do
-          exclusive
+          scope :worker
 
           def perform
           end
         end
       end
 
-      it "sets the exclusive status independently" do
-        expect(daemon.__exclusive).to be(true)
-        expect(parent_daemon.__exclusive).to be_falsey
+      it "sets the scope level independently" do
+        expect(daemon.__level).to eq(:worker)
+        expect(parent_daemon.__level).to be_nil
       end
     end
   end

--- a/spec/integration/test_app/app/daemons/redis_listener_1.rb
+++ b/spec/integration/test_app/app/daemons/redis_listener_1.rb
@@ -1,6 +1,4 @@
 class RedisListener1 < Rage::Daemon
-  exclusive
-
   def initialize
     Rage.logger << "[#{Process.pid}] starting #{self.class.name}\n"
     @redis = Redis.new(url: ENV["TEST_REDIS_URL"])

--- a/spec/integration/test_app/app/daemons/redis_listener_2.rb
+++ b/spec/integration/test_app/app/daemons/redis_listener_2.rb
@@ -1,4 +1,6 @@
 class RedisListener2 < Rage::Daemon
+  scope :worker
+
   def initialize
     Rage.logger << "[#{Process.pid}] starting #{self.class.name}\n"
     @redis = Redis.new(url: ENV["TEST_REDIS_URL"])


### PR DESCRIPTION
* most realistic daemon use cases require exclusivity
* forgetting to use `exclusive` can result in duplicated messages with `Rage::Cable.broadcast` or `Rage::SSE.broadcast` in production
* "daemon" really implies a singular background process