### PR TITLE
[OpenAPI]: Add support for blueprinter root key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [OpenAPI] Add support for the `view:` option in Blueprinter parser.
 - Add `Rage::Daemon` (#339).
 - Enable non-blocking process monitoring (#341).
+- [OpenAPI] Add support for the `root:` option in Blueprinter response annotations.
 
 ### Fixed
 

--- a/lib/rage/openapi/openapi.rb
+++ b/lib/rage/openapi/openapi.rb
@@ -120,7 +120,7 @@ module Rage::OpenAPI
 
   # @private
   def self.__try_parse_collection(str)
-    if str =~ /^Array<([\w\s:\(\),]+)>$/ || str =~ /^\[([\w\s:\(\),]+)\]$/
+    if str =~ /^Array<([\w\s:\(\),'\"]+)>$/ || str =~ /^\[([\w\s:\(\),'\"]+)\]$/
       [true, $1]
     else
       [false, str]

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -49,7 +49,7 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
     properties = identifier_fields.merge(default_fields.merge(association_fields).sort.to_h)
 
     schema = if serializer_options&.key?(:root)
-      { serializer_options[:root] => { "type" => "object", "properties" => properties } }
+      { serializer_options[:root].to_s => { "type" => "object", "properties" => properties } }
     else
       properties
     end

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -46,7 +46,13 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
 
     @parsing_stack.delete(klass.name)
 
-    schema = identifier_fields.merge(default_fields.merge(association_fields).sort.to_h)
+    properties = identifier_fields.merge(default_fields.merge(association_fields).sort.to_h)
+
+    schema = if serializer_options&.key?(:root)
+      { serializer_options[:root] => { "type" => "object", "properties" => properties } }
+    else
+      properties
+    end
 
     result = { "type" => "object" }
     result["properties"] = schema if schema.any?

--- a/lib/rage/openapi/parsers/ext/blueprinter.rb
+++ b/lib/rage/openapi/parsers/ext/blueprinter.rb
@@ -35,7 +35,7 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
   def build_schema(klass, is_collection, serializer_options = nil)
     @parsing_stack.add(klass.name)
 
-    view_name = serializer_options&.key?(:view) ? serializer_options[:view] : :default
+    view_name = serializer_options&.key?(:view) ? serializer_options[:view].to_sym : :default
     reflections = klass.reflections
     view = reflections[view_name]
     raise InvalidViewError, "invalid view #{view_name}" unless view
@@ -46,18 +46,17 @@ class Rage::OpenAPI::Parsers::Ext::Blueprinter
 
     @parsing_stack.delete(klass.name)
 
-    properties = identifier_fields.merge(default_fields.merge(association_fields).sort.to_h)
-
-    schema = if serializer_options&.key?(:root)
-      { serializer_options[:root].to_s => { "type" => "object", "properties" => properties } }
-    else
-      properties
-    end
+    schema = identifier_fields.merge(default_fields.merge(association_fields).sort.to_h)
 
     result = { "type" => "object" }
     result["properties"] = schema if schema.any?
     result = { "type" => "array", "items" => result } if is_collection
-    result
+
+    if serializer_options&.key?(:root)
+      { "type" => "object", "properties" => { serializer_options[:root].to_s => result } }
+    else
+      result
+    end
   end
 
   def extract_fields(view)

--- a/spec/openapi/parsers/ext/blueprinter_spec.rb
+++ b/spec/openapi/parsers/ext/blueprinter_spec.rb
@@ -1607,6 +1607,93 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         })
       end
     end
+
+    context "with root: as symbol and view: as string" do
+      let(:resource) { "UserBlueprintMixedA(view: 'normal', root: :user)" }
+
+      let_blueprinter_class("UserBlueprintMixedA") do
+        <<~'RUBY'
+          fields :id
+          view :normal do
+            fields :name, :email
+          end
+        RUBY
+      end
+
+      it "handles mixed symbol and string annotation values" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "user" => {
+              "type" => "object",
+              "properties" => {
+                "id" => { "type" => "string" },
+                "name" => { "type" => "string" },
+                "email" => { "type" => "string" }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with root: as string and view: as symbol" do
+      let(:resource) { "UserBlueprintMixedB(view: :normal, root: 'user')" }
+
+      let_blueprinter_class("UserBlueprintMixedB") do
+        <<~'RUBY'
+          fields :id
+          view :normal do
+            fields :name, :email
+          end
+        RUBY
+      end
+
+      it "handles mixed string and symbol annotation values" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "user" => {
+              "type" => "object",
+              "properties" => {
+                "id" => { "type" => "string" },
+                "name" => { "type" => "string" },
+                "email" => { "type" => "string" }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with both view: and root: as strings" do
+      let(:resource) { "UserBlueprintMixedC(view: 'normal', root: 'user')" }
+
+      let_blueprinter_class("UserBlueprintMixedC") do
+        <<~'RUBY'
+          fields :id
+          view :normal do
+            fields :name, :email
+          end
+        RUBY
+      end
+
+      it "handles both annotation values as strings" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "user" => {
+              "type" => "object",
+              "properties" => {
+                "id" => { "type" => "string" },
+                "name" => { "type" => "string" },
+                "email" => { "type" => "string" }
+              }
+            }
+          }
+        })
+      end
+    end
   end
 
   describe "collection" do
@@ -2984,13 +3071,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
       RUBY
     end
 
-    it "wraps the array items schema under the specified root key" do
+    it "wraps the array schema under the specified root key" do
       is_expected.to eq({
-        "type" => "array",
-        "items" => {
-          "type" => "object",
-          "properties" => {
-            "users" => {
+        "type" => "object",
+        "properties" => {
+          "users" => {
+            "type" => "array",
+            "items" => {
               "type" => "object",
               "properties" => {
                 "id" => { "type" => "string" },
@@ -3016,13 +3103,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
       RUBY
     end
 
-    it "wraps the named view's items schema under the root key" do
+    it "wraps the named view's array schema under the root key" do
       is_expected.to eq({
-        "type" => "array",
-        "items" => {
-          "type" => "object",
-          "properties" => {
-            "users" => {
+        "type" => "object",
+        "properties" => {
+          "users" => {
+            "type" => "array",
+            "items" => {
               "type" => "object",
               "properties" => {
                 "id" => { "type" => "string" },
@@ -3046,13 +3133,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
       RUBY
     end
 
-    it "includes the identifier inside the root key's items" do
+    it "includes the identifier inside the root key's array items" do
       is_expected.to eq({
-        "type" => "array",
-        "items" => {
-          "type" => "object",
-          "properties" => {
-            "users" => {
+        "type" => "object",
+        "properties" => {
+          "users" => {
+            "type" => "array",
+            "items" => {
               "type" => "object",
               "properties" => {
                 "uuid" => { "type" => "string" },
@@ -3082,13 +3169,13 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
       RUBY
     end
 
-    it "includes associations inside the root key's items" do
+    it "includes associations inside the root key's array" do
       is_expected.to eq({
-        "type" => "array",
-        "items" => {
-          "type" => "object",
-          "properties" => {
-            "users" => {
+        "type" => "object",
+        "properties" => {
+          "users" => {
+            "type" => "array",
+            "items" => {
               "type" => "object",
               "properties" => {
                 "email" => { "type" => "string" },
@@ -3102,6 +3189,102 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
                     }
                   }
                 }
+              }
+            }
+          }
+        }
+      })
+    end
+  end
+
+  context "with root: as symbol and view: as string" do
+    let(:resource) { "Array<UserBlueprintMixedA(view: 'normal', root: :users)>" }
+
+    let_blueprinter_class("UserBlueprintMixedA") do
+      <<~'RUBY'
+        fields :id
+        view :normal do
+          fields :name, :email
+        end
+      RUBY
+    end
+
+    it "handles mixed symbol and string annotation values" do
+      is_expected.to eq({
+        "type" => "object",
+        "properties" => {
+          "users" => {
+            "type" => "array",
+            "items" => {
+              "type" => "object",
+              "properties" => {
+                "id" => { "type" => "string" },
+                "name" => { "type" => "string" },
+                "email" => { "type" => "string" }
+              }
+            }
+          }
+        }
+      })
+    end
+  end
+
+  context "with root: as string and view: as symbol" do
+    let(:resource) { "Array<UserBlueprintMixedB(view: :normal, root: 'users')>" }
+
+    let_blueprinter_class("UserBlueprintMixedB") do
+      <<~'RUBY'
+        fields :id
+        view :normal do
+          fields :name, :email
+        end
+      RUBY
+    end
+
+    it "handles mixed string and symbol annotation values" do
+      is_expected.to eq({
+        "type" => "object",
+        "properties" => {
+          "users" => {
+            "type" => "array",
+            "items" => {
+              "type" => "object",
+              "properties" => {
+                "id" => { "type" => "string" },
+                "name" => { "type" => "string" },
+                "email" => { "type" => "string" }
+              }
+            }
+          }
+        }
+      })
+    end
+  end
+
+  context "with both view: and root: as strings" do
+    let(:resource) { "Array<UserBlueprintMixedC(view: 'normal', root: 'users')>" }
+
+    let_blueprinter_class("UserBlueprintMixedC") do
+      <<~'RUBY'
+        fields :id
+        view :normal do
+          fields :name, :email
+        end
+      RUBY
+    end
+
+    it "handles both annotation values as strings" do
+      is_expected.to eq({
+        "type" => "object",
+        "properties" => {
+          "users" => {
+            "type" => "array",
+            "items" => {
+              "type" => "object",
+              "properties" => {
+                "id" => { "type" => "string" },
+                "name" => { "type" => "string" },
+                "email" => { "type" => "string" }
               }
             }
           }

--- a/spec/openapi/parsers/ext/blueprinter_spec.rb
+++ b/spec/openapi/parsers/ext/blueprinter_spec.rb
@@ -1484,6 +1484,129 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
         })
       end
     end
+
+    context "with a root key option" do
+      let(:resource) { "UserBlueprint(root: :user)" }
+
+      let_blueprinter_class("UserBlueprint") do
+        <<~'RUBY'
+          fields :id, :name, :email
+        RUBY
+      end
+
+      it "wraps the schema under the specified root key" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "user" => {
+              "type" => "object",
+              "properties" => {
+                "id" => { "type" => "string" },
+                "name" => { "type" => "string" },
+                "email" => { "type" => "string" }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with a root key and a named view combined" do
+      let(:resource) { "UserBlueprint(view: :normal, root: :user)" }
+
+      let_blueprinter_class("UserBlueprint") do
+        <<~'RUBY'
+          fields :id
+          view :normal do
+            fields :name, :email
+          end
+        RUBY
+      end
+
+      it "wraps the named view's schema under the root key" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "user" => {
+              "type" => "object",
+              "properties" => {
+                "id" => { "type" => "string" },
+                "name" => { "type" => "string" },
+                "email" => { "type" => "string" }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with a root key and an identifier" do
+      let(:resource) { "UserBlueprint(root: :user)" }
+
+      let_blueprinter_class("UserBlueprint") do
+        <<~'RUBY'
+          identifier :uuid
+          fields :name, :email
+        RUBY
+      end
+
+      it "includes the identifier inside the root key" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "user" => {
+              "type" => "object",
+              "properties" => {
+                "uuid" => { "type" => "string" },
+                "name" => { "type" => "string" },
+                "email" => { "type" => "string" }
+              }
+            }
+          }
+        })
+      end
+    end
+
+    context "with a root key and an association" do
+      let(:resource) { "UserBlueprint(root: :user)" }
+
+      let_blueprinter_class("ProjectBlueprint") do
+        <<~'RUBY'
+          fields :id, :name
+        RUBY
+      end
+
+      let_blueprinter_class("UserBlueprint") do
+        <<~'RUBY'
+          fields :email
+          association :projects, blueprint: ProjectBlueprint
+        RUBY
+      end
+
+      it "includes associations inside the root key" do
+        is_expected.to eq({
+          "type" => "object",
+          "properties" => {
+            "user" => {
+              "type" => "object",
+              "properties" => {
+                "email" => { "type" => "string" },
+                "projects" => {
+                  "type" => "array",
+                  "items" => {
+                    "type" => "object",
+                    "properties" => {
+                      "id" => { "type" => "string" },
+                      "name" => { "type" => "string" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        })
+      end
+    end
   end
 
   describe "collection" do
@@ -2846,6 +2969,141 @@ RSpec.describe Rage::OpenAPI::Parsers::Ext::Blueprinter do
             "name" => { "type" => "string" },
             "age" => { "type" => "string" },
             "role" => { "type" => "string" }
+          }
+        }
+      })
+    end
+  end
+
+  context "with a root key option" do
+    let(:resource) { "Array<UserBlueprintRootCollection(root: :users)>" }
+
+    let_blueprinter_class("UserBlueprintRootCollection") do
+      <<~'RUBY'
+        fields :id, :name, :email
+      RUBY
+    end
+
+    it "wraps the array items schema under the specified root key" do
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "users" => {
+              "type" => "object",
+              "properties" => {
+                "id" => { "type" => "string" },
+                "name" => { "type" => "string" },
+                "email" => { "type" => "string" }
+              }
+            }
+          }
+        }
+      })
+    end
+  end
+
+  context "with a root key and a named view combined" do
+    let(:resource) { "Array<UserBlueprintRootViewCollection(view: :normal, root: :users)>" }
+
+    let_blueprinter_class("UserBlueprintRootViewCollection") do
+      <<~'RUBY'
+        fields :id
+        view :normal do
+          fields :name, :email
+        end
+      RUBY
+    end
+
+    it "wraps the named view's items schema under the root key" do
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "users" => {
+              "type" => "object",
+              "properties" => {
+                "id" => { "type" => "string" },
+                "name" => { "type" => "string" },
+                "email" => { "type" => "string" }
+              }
+            }
+          }
+        }
+      })
+    end
+  end
+
+  context "with a root key and an identifier" do
+    let(:resource) { "Array<UserBlueprintRootIdentifierCollection(root: :users)>" }
+
+    let_blueprinter_class("UserBlueprintRootIdentifierCollection") do
+      <<~'RUBY'
+        identifier :uuid
+        fields :name, :email
+      RUBY
+    end
+
+    it "includes the identifier inside the root key's items" do
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "users" => {
+              "type" => "object",
+              "properties" => {
+                "uuid" => { "type" => "string" },
+                "name" => { "type" => "string" },
+                "email" => { "type" => "string" }
+              }
+            }
+          }
+        }
+      })
+    end
+  end
+
+  context "with a root key and an association" do
+    let(:resource) { "Array<UserBlueprintRootAssocCollection(root: :users)>" }
+
+    let_blueprinter_class("ProjectBlueprintRootAssoc") do
+      <<~'RUBY'
+        fields :id, :name
+      RUBY
+    end
+
+    let_blueprinter_class("UserBlueprintRootAssocCollection") do
+      <<~'RUBY'
+        fields :email
+        association :projects, blueprint: ProjectBlueprintRootAssoc
+      RUBY
+    end
+
+    it "includes associations inside the root key's items" do
+      is_expected.to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => {
+            "users" => {
+              "type" => "object",
+              "properties" => {
+                "email" => { "type" => "string" },
+                "projects" => {
+                  "type" => "array",
+                  "items" => {
+                    "type" => "object",
+                    "properties" => {
+                      "id" => { "type" => "string" },
+                      "name" => { "type" => "string" }
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       })


### PR DESCRIPTION
What this PR does?

Add Support for `root key`

Example

```
  # @response DataMining(view: :extended, root: :user)

```

### Screnshot

- Before

<img width="1345" height="676" alt="image" src="https://github.com/user-attachments/assets/1f280bc1-29ca-4d1f-bb0d-e7c04043f575" />


- After

<img width="1361" height="730" alt="image" src="https://github.com/user-attachments/assets/11cd9c0d-191c-4b8b-a70b-2a6ee7b59b9d" />
