### PR TITLE
Add the Extension API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add `Rage::Daemon` (#339).
 - Enable non-blocking process monitoring (#341).
 - Allow to suppress FiberWrapper warnings (#347).
+- Add the Extension API (#344).
 
 ### Fixed
 

--- a/lib/rage-rb.rb
+++ b/lib/rage-rb.rb
@@ -84,6 +84,12 @@ module Rage
   #     config.log_level = :debug
   #   end
   def self.configure(&)
+    if Rage::Extension.subclasses.any? && !@__extension_config_applied
+      Rage::Extension.__configurations.each { |block| config.instance_eval(&block) }
+      config.__finalize
+      @__extension_config_applied = true
+    end
+
     config.instance_eval(&)
     config.__finalize
   end
@@ -207,3 +213,4 @@ end
 
 require_relative "rage/env"
 require_relative "rage/internal"
+require_relative "rage/extension"

--- a/lib/rage/extension.rb
+++ b/lib/rage/extension.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# @private
+# This needs much more work to make it public, but it's already enough for inertia-rage.
+class Rage::Extension
+  class << self
+    def initializer(id = name, before: nil, after: nil, &block)
+      __initializers[id] << block
+    end
+
+    def configure(&block)
+      __configurations << block
+    end
+
+    def __initializers
+      @@initializers ||= Hash.new { |h, k| h[k] = [] }
+    end
+
+    def __configurations
+      @@configurations ||= []
+    end
+  end
+end

--- a/lib/rage/extension.rb
+++ b/lib/rage/extension.rb
@@ -12,6 +12,10 @@ class Rage::Extension
       __configurations << block
     end
 
+    def before_server_start(&block)
+      Iodine.on_state(:pre_start, &block)
+    end
+
     def __initializers
       @@initializers ||= Hash.new { |h, k| h[k] = [] }
     end

--- a/lib/rage/setup.rb
+++ b/lib/rage/setup.rb
@@ -7,6 +7,7 @@ rescue LoadError
 end
 
 # Run application initializers
+Rage::Extension.__initializers.values.flatten.each(&:call) if Rage::Extension.subclasses.any?
 Dir["#{Rage.root}/config/initializers/**/*.rb"].each { |initializer| load(initializer) }
 
 require "rage/ext/setup"


### PR DESCRIPTION
This pull request introduces the `Rage::Extension` API, allowing gems to define their own initializers and configuration blocks. 