### PR TITLE
[Specs][OpenAPI] Stabilize builder title specs across checkout names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- [Specs][OpenAPI] Stabilize builder specs across checkout directory names.
 - [CI] Check all changed PR file pages when requiring changelog updates.
 - [API] Ignore `If-Modified-Since` when `If-None-Match` is present.
 - [API] Use weak comparison for `If-None-Match` validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@
 
 ### Fixed
 
-- [Specs][OpenAPI] Stabilize builder specs across checkout directory names.
-- [CI] Check all changed PR file pages when requiring changelog updates.
 - [API] Ignore `If-Modified-Since` when `If-None-Match` is present.
 - [API] Use weak comparison for `If-None-Match` validation.
 - [Deferred] Ignore missing temp files during async disk storage cleanup.

--- a/spec/support/contexts/mocked_rage_routes.rb
+++ b/spec/support/contexts/mocked_rage_routes.rb
@@ -2,6 +2,9 @@
 
 RSpec.shared_context "mocked_rage_routes" do
   before do
+    # Keep builder specs stable regardless of the local checkout directory name.
+    allow(Rage).to receive(:root).and_return(Rage.root.class.new("/tmp/rage"))
+
     allow(Rage.__router).to receive(:routes) do
       routes.map do |method_path_component, controller_action_component|
         method, path = method_path_component.split(" ", 2)


### PR DESCRIPTION
## Description:

Issue #345 reported that the mocked OpenAPI builder specs hardcode `"title" => "Rage"` while the current default title is derived from `Rage.root.basename`.

This PR keeps the current runtime behavior unchanged and stabilizes the mocked OpenAPI builder specs by stubbing `Rage.root` to a fixed `rage` path in the shared `mocked_rage_routes` test context.

That keeps the builder specs independent of the local checkout directory basename without changing `Rage::OpenAPI::Converter`.

It also adds the matching changelog entry required by the repository workflow.

Closes #345.

## Before fix:

```text
$ bundle exec ruby /mnt/c/Users/Xeron/Desktop/FOSS/FOSSContributons20/.tmp/openapi-title-drift-evidence/title_repro.rb
default_title: Rage Openapi Title Drift 20260702

$ bundle exec rspec spec/openapi/builder/base_spec.rb:16 --format documentation
Run options: include {:locations=>{"./spec/openapi/builder/base_spec.rb"=>[16]}}

Rage::OpenAPI::Builder
  with no routes
    returns correct schema (FAILED - 1)

expected: {"components"=>{}, "info"=>{"title"=>"Rage", "version"=>"1.0.0"}, "openapi"=>"3.0.0", "paths"=>{}, "tags"=>[]}
got:      {"components"=>{}, "info"=>{"title"=>"Rage Openapi Title Drift 20260702", "version"=>"1.0.0"}, "openapi"=>"3.0.0", "paths"=>{}, "tags"=>[]}

1 example, 1 failure
```

<img width="2279" height="1280" alt="image" src="https://github.com/user-attachments/assets/7241004a-f70f-4918-a06e-8f15aedfe222" />

## After fix:

```text
$ bundle exec ruby /mnt/c/Users/Xeron/Desktop/FOSS/FOSSContributons20/.tmp/openapi-title-drift-evidence/title_repro.rb
default_title: Rage Openapi Title Drift 20260702

$ bundle exec rspec spec/openapi/builder/base_spec.rb:16 --format documentation
Run options: include {:locations=>{"./spec/openapi/builder/base_spec.rb"=>[16]}}

Rage::OpenAPI::Builder
  with no routes
    returns correct schema

1 example, 0 failures

$ bundle exec rspec spec/openapi
427 examples, 0 failures, 1 pending
```

<img width="1590" height="736" alt="image" src="https://github.com/user-attachments/assets/400f68ce-dc50-4199-916c-75ed84eb4bd3" />

## Checklist:

- [x] I have updated `CHANGELOG.md`.
- [x] I have verified the runtime default title is unchanged in a non-`rage` checkout using `bundle exec ruby /mnt/c/Users/Xeron/Desktop/FOSS/FOSSContributons20/.tmp/openapi-title-drift-evidence/title_repro.rb`.
- [x] I have run focused tests in WSL using `bundle exec rspec spec/openapi/builder/base_spec.rb:16 --format documentation`.
- [x] I have run OpenAPI specs in WSL using `bundle exec rspec spec/openapi`.
