### PR TITLE
Allow to suppress FiberWrapper warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [OpenAPI] Add support for the `view:` option in Blueprinter parser.
 - Add `Rage::Daemon` (#339).
 - Enable non-blocking process monitoring (#341).
+- Allow to suppress FiberWrapper warnings (#347).
 
 ### Fixed
 

--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -638,12 +638,36 @@ class Rage::Configuration
     def initialize
       super
       @objects = [[Rage::FiberWrapper]]
+      @suppress_fiber_wrapper_warning = false
+    end
+
+    # Suppress warnings when inserting middleware before {Rage::FiberWrapper}.
+    #
+    # By default, Rage warns when middleware is inserted before {Rage::FiberWrapper} because such middleware
+    # runs outside the fiber-based request context. This means the middleware won't benefit from Rage's
+    # non-blocking I/O scheduling and must handle the custom response format.
+    #
+    # Use this method when you intentionally want middleware to run outside the request fiber, for example,
+    # to serve static assets without the overhead of creating a fiber for each request.
+    #
+    # @yield The block within which middleware insertion warnings are suppressed
+    # @example Suppress warnings when inserting a static file server
+    #   Rage.configure do
+    #     config.middleware.allow_outside_request_fiber! do
+    #       config.middleware.insert_before 0, MyStaticFileServer
+    #     end
+    #   end
+    def allow_outside_request_fiber!
+      @suppress_fiber_wrapper_warning = true
+      yield
+    ensure
+      @suppress_fiber_wrapper_warning = false
     end
 
     private
 
     def validate!(index, middleware)
-      if index == 0 && @objects[0][0] == Rage::FiberWrapper
+      if index == 0 && @objects[0][0] == Rage::FiberWrapper && !@suppress_fiber_wrapper_warning
         puts "WARNING: inserting the `#{middleware}` middleware before `Rage::FiberWrapper` may cause undefined behavior."
       end
     end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -831,6 +831,77 @@ RSpec.describe Rage::Configuration do
     end
   end
 
+  describe "Middleware#allow_outside_request_fiber!" do
+    subject { described_class.new.middleware }
+
+    it "suppresses warning when inserting middleware before FiberWrapper" do
+      expect {
+        subject.allow_outside_request_fiber! do
+          subject.insert_before(0, :static_middleware)
+        end
+      }.not_to output.to_stdout
+
+      expect(subject.middlewares).to match([[:static_middleware, anything, anything], [Rage::FiberWrapper]])
+    end
+
+    it "allows multiple middleware insertions within the block" do
+      expect {
+        subject.allow_outside_request_fiber! do
+          subject.insert_before(0, :first_middleware)
+          subject.insert_before(0, :second_middleware)
+        end
+      }.not_to output.to_stdout
+
+      expect(subject.middlewares).to match([
+        [:second_middleware, anything, anything],
+        [:first_middleware, anything, anything],
+        [Rage::FiberWrapper]
+      ])
+    end
+
+    it "restores warning suppression after block completes" do
+      subject.allow_outside_request_fiber! do
+        subject.insert_before(0, :first_middleware)
+      end
+
+      # Use a new middleware instance to verify warning triggers when FiberWrapper is at index 0
+      new_middleware = described_class.new.middleware
+      expect {
+        new_middleware.insert_before(0, :new_middleware)
+      }.to output(/WARNING/).to_stdout
+    end
+
+    it "restores warning even if block raises an exception" do
+      expect {
+        subject.allow_outside_request_fiber! do
+          raise "test error"
+        end
+      }.to raise_error("test error")
+
+      # Use a new middleware instance to verify warning triggers when FiberWrapper is at index 0
+      new_middleware = described_class.new.middleware
+      expect {
+        new_middleware.insert_before(0, :new_middleware)
+      }.to output(/WARNING/).to_stdout
+    end
+
+    it "works with insert_before using index 0" do
+      expect {
+        subject.allow_outside_request_fiber! do
+          subject.insert_before(0, :static_middleware)
+        end
+      }.not_to output.to_stdout
+    end
+
+    it "works with insert_before using Rage::FiberWrapper" do
+      expect {
+        subject.allow_outside_request_fiber! do
+          subject.insert_before(Rage::FiberWrapper, :static_middleware)
+        end
+      }.not_to output.to_stdout
+    end
+  end
+
   describe "Rack::Events" do
     subject { config.__finalize }
 


### PR DESCRIPTION
This pull request introduces a mechanism to the middleware configuration system, allowing developers to intentionally suppress warnings when inserting middleware before the `Rage::FiberWrapper`. This is useful for scenarios where certain middleware, such as static file servers, are meant to run outside the fiber-based request context. 