### PR TITLE
Refactor status normalisation logic in `API#render`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [Router] Fall back to `SERVER_NAME` when deriving exact host constraints.
 - [Cookies] Use request host fallback when resolving cookie domains.
 - [Cookies] Match array-based cookie domains case-insensitively.
+- [API] Reject invalid status symbols in `head` and `render`.
 
 ## [1.25.1] - 2026-06-08
 
@@ -44,7 +45,6 @@
 - [API] Reject malformed or empty HTTP token authorization headers.
 - [Cookies] Strip the port from `HTTP_HOST` before matching configured cookie domains.
 - [Router] Strip the port from `HTTP_HOST` before matching exact host constraints.
-- [API] Reject invalid status symbols in `head` and `render`.
 
 ## [1.24.0] - 2026-05-12
 

--- a/lib/rage/controller/api.rb
+++ b/lib/rage/controller/api.rb
@@ -485,7 +485,6 @@ class RageController::API
   # @note `render` doesn't terminate execution of the action, so if you want to exit an action after rendering, you need to do something like `render(...) and return`.
   def render(json: nil, plain: nil, sse: nil, status: nil)
     raise "Render was called multiple times in this action." if @__rendered
-    normalized_status = status.nil? ? nil : ::Rack::Utils.status_code(status)
     @__rendered = true
 
     if json || plain
@@ -500,14 +499,12 @@ class RageController::API
       @__status = 200
     end
 
-    if normalized_status
-      @__status = normalized_status
-    end
+    @__status = ::Rack::Utils.status_code(status) if status
 
     if sse
       raise ArgumentError, "Cannot render both a standard body and an SSE stream." unless @__body.empty?
 
-      if normalized_status
+      if status
         return if @__status == 204
         raise ArgumentError, "SSE responses only support 200 and 204 statuses." if @__status != 200
       end

--- a/spec/rage/response_spec.rb
+++ b/spec/rage/response_spec.rb
@@ -158,9 +158,16 @@ RSpec.describe Rage::Response do
       expect(subject.status).to eq(204)
     end
 
-    it "does not update status via invalid symbol in render" do
-      expect { controller.render plain: "test_body", status: :not_a_status }.to raise_error(ArgumentError, "Unrecognized status code :not_a_status")
-      expect(subject.status).to eq(204)
+    context "with invalid status symbol in render" do
+      it "updates status if render has a body" do
+        expect { controller.render plain: "test_body", status: :not_a_status }.to raise_error(ArgumentError, "Unrecognized status code :not_a_status")
+        expect(subject.status).to eq(200)
+      end
+
+      it "doesn't update status if render has no body" do
+        expect { controller.render status: :not_a_status }.to raise_error(ArgumentError, "Unrecognized status code :not_a_status")
+        expect(subject.status).to eq(204)
+      end
     end
   end
 end


### PR DESCRIPTION
Refactor status normalisation logic in `RageController::API#render`.

ref #314