### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [1.26.0] - 2026-07-07
+
 ### Added
 
 - [OpenAPI] Add support for blueprint inheritance. Child blueprints now inherit fields from parent blueprints.

--- a/lib/rage/version.rb
+++ b/lib/rage/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rage
-  VERSION = "1.25.1"
+  VERSION = "1.26.0"
 end

--- a/rage.gemspec
+++ b/rage.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "thor", "~> 1.0"
   spec.add_dependency "rack", "< 4"
-  spec.add_dependency "rage-iodine", "~> 5.2"
+  spec.add_dependency "rage-iodine", "~> 5.5"
   spec.add_dependency "zeitwerk", "~> 2.6"
   spec.add_dependency "rack-test", "~> 2.1"
   spec.add_dependency "rake", ">= 12.0"


### PR DESCRIPTION
This pull request prepares for the 1.26.0 release by updating the version, changelog, and the `rage-iodine` dependency.