### PR TITLE
[CI][Security] Pin GitHub Actions workflow refs to full commit SHAs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Get changed files
         if: steps.skip.outputs.skip == 'false'
         id: changed
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const files = await github.paginate(github.rest.pulls.listFiles, {

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,16 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
         with:
           ruby-version: 3.4
           bundler-cache: true
       - name: Generate documentation
         run: bundle exec yardoc
       - name: Deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/ext.yml
+++ b/.github/workflows/ext.yml
@@ -14,10 +14,10 @@ jobs:
           - '4.0'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ jobs:
           - '3.4'
           - '4.0'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
@@ -37,9 +37,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Code Style
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
       with:
         ruby-version: 3.4
         bundler-cache: true
@@ -49,9 +49,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Docs
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
       with:
         ruby-version: 3.4
         bundler-cache: true
@@ -61,9 +61,9 @@ jobs:
     runs-on: ubuntu-latest
     name: CLI
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
       with:
         ruby-version: 3.4
         bundler-cache: true
@@ -95,9 +95,9 @@ jobs:
     runs-on: ubuntu-latest
     name: CLI DB
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
       with:
         ruby-version: 3.4
         bundler-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
         with:
           bundler-cache: true
           ruby-version: 3.4
 
-      - uses: rubygems/release-gem@v1
+      - uses: rubygems/release-gem@052cc82692552de3ef2b81fd670e41d13cba8092 # v1


### PR DESCRIPTION
## Description:

Issue #351 reported that several GitHub Actions workflows still referenced actions through mutable tags such as `@v6`, `@v1`, and `@v3` instead of full commit SHAs.

This PR pins those workflow action references to the exact current commit SHA while keeping the current major version in trailing comments for readability.

Closes #351.

## Checklist:

- [x] I have validated workflow YAML parsing in WSL using `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f); puts "ok #{f}" }'`.
- [x] I have verified that no mutable workflow action refs remain in WSL using `ruby -e 'bad=[]; Dir[".github/workflows/*.yml"].sort.each { |f| File.foreach(f).with_index(1) { |line, n| bad << "#{f}:#{n}:#{line.strip}" if line =~ /uses:\s+\S+@v\d/ } }; abort bad.join("\n") unless bad.empty?; puts "all workflow action refs are SHA-pinned"'`.
