### PR TITLE
[OpenAPI] Avoid caching request-specific spec URLs in HTML docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- [OpenAPI] Avoid caching a request-specific spec URL in the HTML docs page.
 - [OpenAPI] Fix schema registry key collisions for Blueprinter classes referenced under different views.
 
 ## [1.26.0] - 2026-07-07

--- a/lib/rage/openapi/index.html.erb
+++ b/lib/rage/openapi/index.html.erb
@@ -13,7 +13,7 @@
     <script>
       window.onload = () => {
         window.ui = SwaggerUIBundle({
-          url: '<%= spec_url %>',
+          url: window.location.pathname.replace(/\/?$/, "/json"),
           dom_id: '#swagger-ui',
         });
       };

--- a/lib/rage/openapi/openapi.rb
+++ b/lib/rage/openapi/openapi.rb
@@ -42,11 +42,9 @@ module Rage::OpenAPI
   #     run Rage.openapi.application(namespace: "Api::V2")
   #   end
   def self.application(namespace: nil)
-    html_app = ->(env) do
+    html_app = ->(_) do
       __data_cache[[:page, namespace]] ||= begin
-        scheme, host, path = env["rack.url_scheme"], env["HTTP_HOST"], env["SCRIPT_NAME"]
-        spec_url = "#{scheme}://#{host}#{path}/json"
-        page = ERB.new(File.read("#{__dir__}/index.html.erb")).result(binding)
+        page = ERB.new(File.read("#{__dir__}/index.html.erb")).result
 
         [200, { "content-type" => "text/html; charset=UTF-8" }, [page]]
       end

--- a/spec/openapi/openapi_spec.rb
+++ b/spec/openapi/openapi_spec.rb
@@ -3,6 +3,42 @@
 require "prism"
 
 RSpec.describe Rage::OpenAPI do
+  describe ".application" do
+    subject(:app) { described_class.application }
+
+    let(:first_env) do
+      {
+        "PATH_INFO" => "/",
+        "SCRIPT_NAME" => "/docs-a",
+        "HTTP_HOST" => "first.test:3000",
+        "rack.url_scheme" => "http"
+      }
+    end
+
+    let(:second_env) do
+      {
+        "PATH_INFO" => "/",
+        "SCRIPT_NAME" => "/docs-b",
+        "HTTP_HOST" => "second.test:4000",
+        "rack.url_scheme" => "https"
+      }
+    end
+
+    before do
+      allow(Rage.config).to receive(:middleware).and_return([])
+    end
+
+    it "renders a request-independent html page" do
+      _, _, first_body = app.call(first_env)
+      _, _, second_body = app.call(second_env)
+
+      expect(first_body.join).to eq(second_body.join)
+      expect(first_body.join).to include('url: window.location.pathname.replace(/\/?$/, "/json"),')
+      expect(first_body.join).not_to include("first.test:3000")
+      expect(first_body.join).not_to include("/docs-a/json")
+    end
+  end
+
   describe ".__try_parse_collection" do
     subject { described_class.__try_parse_collection(input) }
 


### PR DESCRIPTION
## Description:

Issue #353 reported that the cached OpenAPI HTML page embeds a request-specific spec URL from the first request.

This PR makes the cached HTML page request-independent by deriving the JSON spec URL from `window.location.pathname` in the browser instead of rendering `rack.url_scheme`, `HTTP_HOST`, and `SCRIPT_NAME` into the cached page.

It also adds a regression spec that covers repeated HTML requests with different hosts and mount paths, and adds a changelog entry for the fix.

### Before fix:

- first request under `/docs-a`: `http://first.test:3000/docs-a/json`
- second request under `/docs-b`: `http://first.test:3000/docs-a/json`
- result: cached HTML reused the first request's spec URL.

### After fix:

- cached HTML no longer embeds request host or mount path.
- Swagger UI resolves the JSON spec URL from the current `window.location.pathname`.
- the cached page works correctly across repeated requests with different hosts and mount paths.

<img width="610" height="305" alt="image" src="https://github.com/user-attachments/assets/2b5cd178-3b60-47c7-baf4-c97dec0488c5" />

Closes #353.

## Checklist:

- [x] I have run focused tests using `bundle exec rspec spec/openapi/openapi_spec.rb`.
- [x] I have run broader OpenAPI tests using `bundle exec rspec spec/openapi`.
- [x] I have run the full test suite using `bundle exec rspec`.
