### PR TITLE
[Router] Compose and restore SCRIPT_NAME for mounted Rack apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- [Router] Compose and restore `SCRIPT_NAME` correctly for mounted Rack apps.
 - [OpenAPI] Fix schema registry key collisions for Blueprinter classes referenced under different views.
 
 ## [1.26.0] - 2026-07-07

--- a/lib/rage/router/backend.rb
+++ b/lib/rage/router/backend.rb
@@ -35,13 +35,17 @@ class Rage::Router::Backend
       # by the time the app is called, `rack.input` is already consumed in `Rage::ParamsParser`
       env["rack.input"].rewind
 
-      env["SCRIPT_NAME"] = path
-      sub_path = env["PATH_INFO"].delete_prefix!(path)
-      env["PATH_INFO"] = "/" if sub_path == ""
+      script_name = env["SCRIPT_NAME"]
+      path_info = env["PATH_INFO"]
+
+      env["SCRIPT_NAME"] = "#{script_name}#{path}"
+      sub_path = path_info.delete_prefix(path)
+      env["PATH_INFO"] = sub_path == "" ? "/" : sub_path
 
       handler.call(env)
     ensure
-      env["PATH_INFO"] = "#{env["SCRIPT_NAME"]}#{sub_path}"
+      env["SCRIPT_NAME"] = script_name
+      env["PATH_INFO"] = path_info
     end
 
     methods.each do |method|

--- a/spec/router/mount_spec.rb
+++ b/spec/router/mount_spec.rb
@@ -28,6 +28,30 @@ RSpec.describe Rage::Router::Backend do
     expect(result).to eq("/rack_app")
   end
 
+  it "composes and restores script name for mounted apps" do
+    seen = nil
+
+    router.mount("/rack_app", ->(env) {
+      seen = { script_name: env["SCRIPT_NAME"], path_info: env["PATH_INFO"] }
+      :rack_app_response
+    }, %w(GET))
+
+    env = {
+      "REQUEST_METHOD" => "GET",
+      "PATH_INFO" => "/rack_app/index",
+      "SCRIPT_NAME" => "/outer",
+      "rack.input" => StringIO.new
+    }
+
+    handler = router.lookup(env)
+    result = handler[:handler].call(env, handler[:params])
+
+    expect(result).to eq(:rack_app_response)
+    expect(seen).to eq({ script_name: "/outer/rack_app", path_info: "/index" })
+    expect(env["SCRIPT_NAME"]).to eq("/outer")
+    expect(env["PATH_INFO"]).to eq("/rack_app/index")
+  end
+
   it "updates path info" do
     router.mount("/rack_app", ->(env) { env["PATH_INFO"] }, %w(GET))
 


### PR DESCRIPTION
## Description:

Issue #355 reported that mounted Rack apps overwrite `SCRIPT_NAME` with only the mount path and do not restore the original value after the mounted app returns.

This PR updates router mount handling to compose `SCRIPT_NAME` from the existing prefix plus the mount path, while still passing the mounted subpath as `PATH_INFO`.

It also restores the original `SCRIPT_NAME` and `PATH_INFO` after the mounted app returns, adds a regression spec that covers both behaviors, and adds a changelog entry for the fix.

### Before the fix:

- before call: `SCRIPT_NAME="/outer"`, `PATH_INFO="/rack_app/index"`
- mounted app saw: `SCRIPT_NAME="/rack_app"`, `PATH_INFO="/index"`
- after call: `SCRIPT_NAME="/rack_app"`, `PATH_INFO="/rack_app/index"`

<img width="1280" height="620" alt="image" src="https://github.com/user-attachments/assets/a113c6bd-9eda-495b-9c49-3b745e49a3de" />

### After the fix:

- before call: `SCRIPT_NAME="/outer"`, `PATH_INFO="/rack_app/index"`
- mounted app sees: `SCRIPT_NAME="/outer/rack_app"`, `PATH_INFO="/index"`
- after call: `SCRIPT_NAME="/outer"`, `PATH_INFO="/rack_app/index"`

<img width="1280" height="620" alt="image" src="https://github.com/user-attachments/assets/26f14d44-e6b3-4e44-995a-f068698a47b3" />

Closes #355.

## Checklist:

- [x] I have run focused tests using `bundle exec rspec spec/router/mount_spec.rb`.
- [x] I have run broader router tests using `bundle exec rspec spec/router`.
- [x] I have run the full test suite using `bundle exec rspec`.
