### PR TITLE
Correctly check content type for custom renderers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+## [1.26.1] - 2026-07-17
+
+### Fixed
+
+- Correctly check content type for custom renderers (#357).
+
 ## [1.26.0] - 2026-07-07
 
 ### Added

--- a/lib/rage/controller/api.rb
+++ b/lib/rage/controller/api.rb
@@ -425,7 +425,7 @@ class RageController::API
     end
   end # class << self
 
-  DEFAULT_CONTENT_TYPE = "application/json; charset=utf-8"
+  DEFAULT_CONTENT_TYPE = "application/json; charset=utf-8".dup
   private_constant :DEFAULT_CONTENT_TYPE
 
   # @private
@@ -492,7 +492,7 @@ class RageController::API
         json.is_a?(String) ? json : json.to_json
       else
         ct = @__headers["content-type"]
-        @__headers["content-type"] = "text/plain; charset=utf-8" if ct.nil? || ct == DEFAULT_CONTENT_TYPE
+        @__headers["content-type"] = "text/plain; charset=utf-8" if ct.nil? || ct.equal?(DEFAULT_CONTENT_TYPE)
         plain.to_s
       end
 

--- a/lib/rage/version.rb
+++ b/lib/rage/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rage
-  VERSION = "1.26.0"
+  VERSION = "1.26.1"
 end

--- a/spec/configuration/custom_renderer_spec.rb
+++ b/spec/configuration/custom_renderer_spec.rb
@@ -184,5 +184,24 @@ RSpec.describe Rage::Configuration do
         [202, { "content-type" => "application/json; charset=utf-8" }, ["{\"message\":\"test\"}"]]
       )
     end
+
+    it "doesn't overwrite default content type for renderers with implicit render" do
+      config.renderer(:jsonld) do |data|
+        headers["content-type"] = "application/json; charset=utf-8"
+        data.merge(:@context => "https://schema.org").to_json
+      end
+
+      config.__finalize
+
+      controller = build_controller do
+        define_method(:index) do
+          render jsonld: { name: "Alice" }
+        end
+      end
+
+      expect(run_action(controller, :index)).to match(
+        [200, { "content-type" =>  "application/json; charset=utf-8" }, [include("Alice")]]
+      )
+    end
   end
 end

--- a/spec/configuration/custom_renderer_spec.rb
+++ b/spec/configuration/custom_renderer_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe Rage::Configuration do
       end
 
       expect(run_action(controller, :index)).to match(
-        [200, { "content-type" =>  "application/json; charset=utf-8" }, [include("Alice")]]
+        [200, { "content-type" => "application/json; charset=utf-8" }, [include("Alice")]]
       )
     end
   end


### PR DESCRIPTION
This fixes a bug where content type is overwritten to `text/plain` if a custom renderer sets the (default) application-json content type using implicit render.