### PR TITLE
[CI][Security] Declare least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+permissions:
+  pull-requests: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ext.yml
+++ b/.github/workflows/ext.yml
@@ -3,6 +3,9 @@ name: Ext Tests
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   appraise:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
 
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description:

Issue #358 reported that the test, extension, documentation, and changelog workflows inherited their `GITHUB_TOKEN` permissions from repository or organization defaults.

This PR gives the test, extension, and documentation workflows read only contents access. It gives the changelog workflow read only pull request access.

This keeps all other token permissions disabled and leaves the existing release workflow permissions unchanged.

Closes #358.

## Checklist:

- [x] I have validated all workflow files using `go run github.com/rhysd/actionlint/cmd/actionlint@latest`.
- [x] I have validated the workflow YAML files using Ruby's YAML parser.
