### PR TITLE
Fix error message when RbNaCl is not loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [OpenAPI] Avoid caching a request-specific spec URL in the HTML docs page.
 - [Router] Compose and restore `SCRIPT_NAME` correctly for mounted Rack apps.
 - [OpenAPI] Fix schema registry key collisions for Blueprinter classes referenced under different views.
+- Fixed RbNaCl dependency check to produce correct error message (#361).
 
 ## [1.26.0] - 2026-07-07
 

--- a/lib/rage/cookies.rb
+++ b/lib/rage/cookies.rb
@@ -278,24 +278,22 @@ class Rage::Cookies
 
     private
 
-    def ensure_rbnacl!(purpose:)
+    def ensure_rbnacl!
       return if defined?(RbNaCl) &&
                 Gem::Version.create(RbNaCl::VERSION) >= RBNACL_MIN_VERSION &&
                 Gem::Version.create(RbNaCl::VERSION) < RBNACL_MAX_VERSION
 
       fail <<~ERR
 
-        Rage depends on `rbnacl` [>= #{RBNACL_MIN_VERSION}, < #{RBNACL_MAX_VERSION}] to support #{purpose}. Ensure the following line is added to your Gemfile:
+        Rage depends on `rbnacl` [>= #{RBNACL_MIN_VERSION}, < #{RBNACL_MAX_VERSION}] to support encrypted and signed cookies. Ensure the following line is added to your Gemfile:
         gem "rbnacl"
 
       ERR
     end
 
     def build_key(secret, purpose:)
-      ensure_rbnacl!(purpose: purpose)
-
       if !secret
-        raise "Rage.config.secret_key_base should be set to use #{purpose}"
+        raise "Rage.config.secret_key_base should be set to use encrypted or signed cookies"
       end
 
       RbNaCl::Hash.blake2b("", key: [secret].pack("H*"), digest_size: 32, personal: purpose)
@@ -337,7 +335,10 @@ class Rage::Cookies
       private
 
       def primary_box
-        @primary_box ||= RbNaCl::SimpleBox.from_secret_key(build_key(Rage.config.secret_key_base, purpose: PURPOSE))
+        @primary_box ||= begin
+          ensure_rbnacl!
+          RbNaCl::SimpleBox.from_secret_key(build_key(Rage.config.secret_key_base, purpose: PURPOSE))
+        end
       end
 
       def fallback_boxes
@@ -401,9 +402,10 @@ class Rage::Cookies
       end
 
       def primary_signer
-        @primary_signer ||= RbNaCl::HMAC::SHA512256.new(
-          build_key(Rage.config.secret_key_base, purpose: PURPOSE)
-        )
+        @primary_signer ||= begin
+          ensure_rbnacl!
+          RbNaCl::HMAC::SHA512256.new(build_key(Rage.config.secret_key_base, purpose: PURPOSE))
+        end
       end
 
       def fallback_signers

--- a/spec/controller/api/cookies_spec.rb
+++ b/spec/controller/api/cookies_spec.rb
@@ -12,6 +12,22 @@ RSpec.describe RageController::API do
   let(:request_host) { "cookie.test.com" }
   let(:request_env) { { "HTTP_HOST" => request_host } }
 
+  context "with RbNaCl not loaded" do
+    let(:cookies) { {} }
+
+    it "fails with the correct error message" do
+      hide_const("RbNaCl")
+
+      expect {
+        subject.cookies.encrypted[:session] = "encrypted"
+      }.to raise_error(/Ensure the following line is added to your Gemfile/)
+
+      expect {
+        subject.cookies.signed[:session] = "signed"
+      }.to raise_error(/Ensure the following line is added to your Gemfile/)
+    end
+  end
+
   context "with no cookies" do
     let(:cookies) { {} }
 


### PR DESCRIPTION
This pull request refactors how the `RbNaCl` dependency is checked and improves error handling for missing dependencies in cookie encryption and signing.