### PR TITLE
Add `FiberScheduler#timeout_after`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - [OpenAPI] Add support for the `root:` option in Blueprinter response annotations (#343).
+- Add `FiberScheduler#timeout_after` (#374).
 
 ### Fixed
 

--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -23,6 +23,7 @@ require "erb"
 # - _RAGE_DISABLE_IO_WRITE_ - disables the `io_write` hook to fix the ["zero-length iov"](https://bugs.ruby-lang.org/issues/19640) error on Ruby < 3.3.
 # - _RAGE_DISABLE_AR_POOL_PATCH_ - disables the `ActiveRecord::ConnectionPool` patch and makes Rage use the original ActiveRecord implementation.
 # - _RAGE_DISABLE_AR_WEAK_CONNECTIONS_ - instructs Rage to not reuse Active Record connections between different fibers. Only applies to Active Record < 7.2.
+# - _RAGE_ENABLE_NON_BLOCKING_TIMEOUT_ - enables the non-blocking `timeout_after` method on the fiber scheduler, which allows timeouts to work cooperatively with fiber-based concurrency.
 #
 class Rage::Configuration
   # @private

--- a/lib/rage/fiber_scheduler.rb
+++ b/lib/rage/fiber_scheduler.rb
@@ -75,19 +75,23 @@ class Rage::FiberScheduler
     Fiber.pause if duration.nil? || duration < 1
   end
 
-  # TODO: GC works a little strange with this closure;
-  #
-  # def timeout_after(duration, exception_class = Timeout::Error, *exception_arguments, &block)
-  #   fiber, block_status = Fiber.current, :running
-  #   ::Iodine.run_after((duration * 1000).to_i) do
-  #     fiber.raise(exception_class, exception_arguments) if block_status == :running
-  #   end
+  if ENV["RAGE_ENABLE_NON_BLOCKING_TIMEOUT"]
+    def timeout_after(duration, exception_class = Timeout::Error, *exception_arguments, &block)
+      f, fulfilled = Fiber.current, false
 
-  #   result = block.call
-  #   block_status = :finished
+      ::Iodine.run_after((duration * 1000).to_i) do
+        if !fulfilled && f.alive?
+          fulfilled = true
+          f.__wait_generation += 1
+          f.raise(exception_class, *exception_arguments)
+        end
+      end
 
-  #   result
-  # end
+      block.call
+    ensure
+      fulfilled = true
+    end
+  end
 
   # Resolve a hostname to IP addresses, caching results for 60 seconds.
   def address_resolve(hostname)

--- a/spec/fiber_scheduler_spec.rb
+++ b/spec/fiber_scheduler_spec.rb
@@ -644,6 +644,212 @@ RSpec.describe Rage::FiberScheduler do
     end
   end
 
+  context "#timeout_after" do
+    it "does not raise when block completes before timeout" do
+      within_reactor do
+        result = Fiber.scheduler.timeout_after(1) do
+          sleep 0.1
+          "completed"
+        end
+
+        -> { expect(result).to eq("completed") }
+      end
+    end
+
+    it "raises Timeout::Error when block exceeds timeout" do
+      within_reactor do
+        error = begin
+          Fiber.scheduler.timeout_after(0.1) do
+            sleep 1
+          end
+        rescue => e
+          e
+        end
+
+        -> { expect(error).to be_a(Timeout::Error) }
+      end
+    end
+
+    it "raises custom exception class" do
+      within_reactor do
+        error = begin
+          Fiber.scheduler.timeout_after(0.1, RuntimeError) do
+            sleep 1
+          end
+        rescue => e
+          e
+        end
+
+        -> { expect(error).to be_a(RuntimeError) }
+      end
+    end
+
+    it "raises custom exception with arguments" do
+      within_reactor do
+        error = begin
+          Fiber.scheduler.timeout_after(0.1, RuntimeError, "custom message") do
+            sleep 1
+          end
+        rescue => e
+          e
+        end
+
+        -> do
+          expect(error).to be_a(RuntimeError)
+          expect(error.message).to eq("custom message")
+        end
+      end
+    end
+
+    it "times out during IO operations" do
+      within_reactor do
+        error = begin
+          Timeout.timeout(0.5) do
+            Net::HTTP.get(URI("#{TEST_HTTP_URL}/timeout"))
+          end
+        rescue => e
+          e
+        end
+
+        -> { expect(error).to be_a(Timeout::Error) }
+      end
+    end
+
+    context "with inner timeouts" do
+      it "inner timeout fires before outer timeout" do
+        within_reactor do
+          error = begin
+            Fiber.scheduler.timeout_after(1) do
+              Fiber.scheduler.timeout_after(0.1) do
+                sleep 2
+              end
+            end
+          rescue => e
+            e
+          end
+
+          -> { expect(error).to be_a(Timeout::Error) }
+        end
+      end
+
+      it "outer timeout fires when inner block is slow" do
+        within_reactor do
+          error = begin
+            Fiber.scheduler.timeout_after(0.1) do
+              Fiber.scheduler.timeout_after(1) do
+                sleep 2
+              end
+            end
+          rescue => e
+            e
+          end
+
+          -> { expect(error).to be_a(Timeout::Error) }
+        end
+      end
+
+      it "inner timeout with custom exception does not affect outer" do
+        within_reactor do
+          error = begin
+            Fiber.scheduler.timeout_after(1, RuntimeError, "outer") do
+              Fiber.scheduler.timeout_after(0.1, ArgumentError, "inner") do
+                sleep 2
+              end
+            end
+          rescue => e
+            e
+          end
+
+          -> do
+            expect(error).to be_a(ArgumentError)
+            expect(error.message).to eq("inner")
+          end
+        end
+      end
+
+      it "completes successfully when inner timeout does not fire" do
+        within_reactor do
+          result = Fiber.scheduler.timeout_after(1) do
+            inner_result = Fiber.scheduler.timeout_after(0.5) do
+              sleep 0.1
+              "inner done"
+            end
+            "outer done with #{inner_result}"
+          end
+
+          -> { expect(result).to eq("outer done with inner done") }
+        end
+      end
+
+      it "rescues inner timeout and continues outer block" do
+        within_reactor do
+          result = Fiber.scheduler.timeout_after(1) do
+            inner_result = begin
+              Fiber.scheduler.timeout_after(0.1, ArgumentError) do
+                sleep 2
+              end
+            rescue ArgumentError
+              "inner timed out"
+            end
+            "outer done: #{inner_result}"
+          end
+
+          -> { expect(result).to eq("outer done: inner timed out") }
+        end
+      end
+
+      it "does not fire stale inner timeout after rescue" do
+        within_reactor do
+          results = []
+
+          result = Fiber.scheduler.timeout_after(2) do
+            begin
+              Fiber.scheduler.timeout_after(0.1) do
+                sleep 1
+              end
+            rescue Timeout::Error
+              results << "inner timeout caught"
+            end
+
+            # Sleep long enough that the inner timeout would have fired again if stale
+            sleep 0.3
+            results << "continued after rescue"
+            results
+          end
+
+          -> { expect(result).to eq(["inner timeout caught", "continued after rescue"]) }
+        end
+      end
+    end
+
+    it "does not reset outer timeout after inner fires" do
+      within_reactor do
+        results = []
+
+        result = Fiber.scheduler.timeout_after(0.3) do
+          begin
+            Fiber.scheduler.timeout_after(0.1) do
+              sleep 1
+            end
+          rescue Timeout::Error
+            results << "inner timeout caught"
+          end
+
+          begin
+            # Sleep long enough that the outer timeout fires
+            sleep 1
+          rescue Timeout::Error
+            results << "outer timeout caught"
+          end
+
+          results
+        end
+
+        -> { expect(result).to eq(["inner timeout caught", "outer timeout caught"]) }
+      end
+    end
+  end
+
   context "#process_wait" do
     it "waits for processes in a non-blocking manner" do
       within_reactor do


### PR DESCRIPTION
The pull request introduces a new non-blocking `timeout_after` method to the fiber scheduler.

Initially, this method has always been commented out because of a memory leak it was introducing. For the life of me, I can't reproduce the leak anymore, and it makes me feel uneasy. On the other hand, if I can't reproduce something could also mean it's not there anymore, so I'll enable the method behind `RAGE_ENABLE_NON_BLOCKING_TIMEOUT` for now.

closes #155