### PR TITLE
[Docs] Fix README documentation link text

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Rage prioritizes stable public APIs, long deprecation cycles, and minimal extern
 
 ## Learn More
 
-- Documentation: [https://rage-rb.dev](https://rage-rb.dev/docs/intro)
+- Documentation: [https://rage-rb.dev/docs/intro](https://rage-rb.dev/docs/intro)
 - API Reference: [https://rage-rb.dev/api](https://rage-rb.dev/api)
 - Architecture: [ARCHITECTURE.md](https://github.com/rage-rb/rage/blob/main/ARCHITECTURE.md)
 - Contributing: [CONTRIBUTING.md](https://github.com/rage-rb/rage/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
Fix the README documentation entry so the displayed URL matches the intro docs link.

No behavior changes.