### PR TITLE
[Router] Fix README regexp constraint wording

### DIFF
--- a/lib/rage/router/README.md
+++ b/lib/rage/router/README.md
@@ -1,6 +1,6 @@
 This is an almost complete rewrite of https://github.com/delvedor/find-my-way.
 
-Currently, the only constraint supported is the `host` constraint. Regexp constraints are likely to be added. Custom/lambda constraints are unlikely to be added.
+Currently, the only constraint supported is the `host` constraint. The constraint value can be either a string or a regular expression. Custom/lambda constraints are unlikely to be added.
 
 Compared to the Rails router, the most notable difference except constraints is that a wildcard segment can only be in the last section of the path and cannot be named.
 


### PR DESCRIPTION
Update the router README to reflect current host constraint support.

Regex host constraints are already supported, so the README should describe the supported string and regular expression values instead of saying they are likely to be added.

No behavior changes.