### PR TITLE
[Router] Remove unused custom constraint scaffold

### DIFF
--- a/lib/rage/router/backend.rb
+++ b/lib/rage/router/backend.rb
@@ -11,7 +11,7 @@ class Rage::Router::Backend
   def initialize
     @routes = []
     @trees = {}
-    @constrainer = Rage::Router::Constrainer.new({})
+    @constrainer = Rage::Router::Constrainer.new
   end
 
   def reset_routes

--- a/lib/rage/router/constrainer.rb
+++ b/lib/rage/router/constrainer.rb
@@ -3,7 +3,7 @@
 class Rage::Router::Constrainer
   attr_reader :strategies
 
-  def initialize(custom_strategies)
+  def initialize
     @strategies = {
       host: Rage::Router::Strategies::Host.new
     }
@@ -13,15 +13,6 @@ class Rage::Router::Constrainer
 
   def strategy_used?(strategy_name)
     @strategies_in_use.include?(strategy_name)
-  end
-
-  def has_constraint_strategy(strategy_name)
-    custom_constraint_strategy = @strategies[strategy_name]
-    if custom_constraint_strategy
-      return custom_constraint_strategy.custom? || strategy_used?(strategy_name)
-    end
-
-    false
   end
 
   def derive_constraints(env)
@@ -56,8 +47,8 @@ class Rage::Router::Constrainer
     end
   end
 
-  # Optimization: build a fast function for deriving the constraints for all the strategies at once. We inline the definitions of the version constraint and the host constraint for performance.
-  # If no constraining strategies are in use (no routes constrain on host, or version, or any custom strategies) then we don't need to derive constraints for each route match, so don't do anything special, and just return undefined
+  # Optimization: build a fast function for deriving the constraints for all the strategies at once. We inline the host constraint derivation for performance.
+  # If no constraining strategies are in use, then we don't need to derive constraints for each route match, so don't do anything special, and just return undefined.
   # This allows us to not allocate an object to hold constraint values if no constraints are defined.
   def __build_derive_constraints
     return if @strategies_in_use.empty?


### PR DESCRIPTION
## Description:

This PR removes unused router custom constraint scaffold.

The router only supports host constraints as of the latest main. `Rage::Router::Backend` always builds `Rage::Router::Constrainer` without any custom strategies in practice, and the constrainer never uses the constructor argument.

This PR removes the unused constructor path and dead helper without changing router behavior.

## Checklist:

- [x] I have run linting checks using `bundle exec rubocop --format simple lib/rage/router/constrainer.rb lib/rage/router/backend.rb`.
- [x] I have run focused tests using `bundle exec rspec spec/router`.