### PR TITLE
[Telemetry] Add `Rage::Telemetry.every` for periodic block scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [OpenAPI] Add support for the `root:` option in Blueprinter response annotations (#343).
 - Add `FiberScheduler#timeout_after` (#374).
+- [Telemetry] Add `Rage::Telemetry.every(interval_ms, &block)`, a generic scheduling primitive for running recurring work on the reactor — e.g. sampling metrics or measuring event loop lag. (#379)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - [OpenAPI] Add support for the `root:` option in Blueprinter response annotations (#343).
 - Add `FiberScheduler#timeout_after` (#374).
-- [Telemetry] Add Rage::Telemetry.every(ms, &block), allowing external gems (e.g. opentelemetry-instrumentation) to run custom code on the same interval and measure event loop lag
+- [Telemetry] Add `Rage::Telemetry.every(interval_ms, &block)`, a generic scheduling primitive for running recurring work on the reactor — e.g. sampling metrics or measuring event loop lag. (#379)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [OpenAPI] Add support for the `root:` option in Blueprinter response annotations (#343).
 - Add `FiberScheduler#timeout_after` (#374).
+- [Telemetry] Add Rage::Telemetry.every(ms, &block), allowing external gems (e.g. opentelemetry-instrumentation) to run custom code on the same interval and measure event loop lag
 
 ### Fixed
 

--- a/lib/rage/telemetry/telemetry.rb
+++ b/lib/rage/telemetry/telemetry.rb
@@ -36,27 +36,23 @@ module Rage::Telemetry
     __registry.keys
   end
 
-  # The block is executed on the reactor thread and is yielded the scheduling lag in milliseconds -
-  # the difference between the expected and actual execution times. Keep the block fast and non-blocking.
+  # Registers a block to be executed repeatedly at a fixed interval while the server is running.
+  # The block runs on the reactor thread, alongside every fiber. Keep it fast and non-blocking.
+  # If the server is not running yet, execution is deferred and starts once the server starts.
   #
   # @param interval_ms [Integer] the execution interval in milliseconds
-  # @yield [Integer] the scheduling lag in milliseconds
-  # @example Periodically record the event loop lag
-  #   Rage::Telemetry.every(100) do |lag|
-  #     MyMetrics.record_loop_lag(lag)
+  # @example Periodically sample GC stats
+  #   Rage::Telemetry.every(1000) { MyMetrics.record_gc_stats(GC.stat) }
+  #
+  # @example Measure event loop lag
+  #   last_run_at = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+  #   Rage::Telemetry.every(100) do
+  #     now = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+  #     MyMetrics.record_loop_lag([now - last_run_at - 100, 0].max)
+  #     last_run_at = now
   #   end
   def self.every(interval_ms, &block)
-    schedule_block = -> do
-      last_run_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
-
-      Iodine.run_every(interval_ms) do
-        current_run_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
-        lag_ms = [current_run_time - last_run_time - interval_ms, 0].max
-
-        block.call(lag_ms)
-        last_run_time = current_run_time
-      end
-    end
+    schedule_block = -> { Iodine.run_every(interval_ms, &block) }
 
     if Iodine.running?
       schedule_block.call

--- a/lib/rage/telemetry/telemetry.rb
+++ b/lib/rage/telemetry/telemetry.rb
@@ -39,7 +39,7 @@ module Rage::Telemetry
   # The block is executed on the reactor thread and is yielded the scheduling lag in milliseconds -
   # the difference between the expected and actual execution times. Keep the block fast and non-blocking.
   #
-  # @param ms [Integer] the execution interval in milliseconds
+  # @param interval_ms [Integer] the execution interval in milliseconds
   # @yield [Integer] the scheduling lag in milliseconds
   # @example Periodically record the event loop lag
   #   Rage::Telemetry.every(100) do |lag|

--- a/lib/rage/telemetry/telemetry.rb
+++ b/lib/rage/telemetry/telemetry.rb
@@ -36,6 +36,19 @@ module Rage::Telemetry
     __registry.keys
   end
 
+  # Registers a block to be executed repeatedly at a fixed interval while the server is running.
+  # The block is run inside a fiber, so blocking I/O inside it (e.g. flushing metrics to a
+  # collector) will not block the server.
+  #
+  # @param interval_ms [Integer] the execution interval in milliseconds
+  # @example Periodically sample GC stats
+  #   Rage::Telemetry.every(1000) { MyMetrics.record_gc_stats(GC.stat) }
+  def self.every(interval_ms, &block)
+    Iodine.run_every(interval_ms) do
+      Fiber.schedule { block.call }
+    end
+  end
+
   # @private
   def self.__registry
     @__registry ||= Spans.constants.each_with_object({}) do |const, memo|

--- a/lib/rage/telemetry/telemetry.rb
+++ b/lib/rage/telemetry/telemetry.rb
@@ -36,6 +36,35 @@ module Rage::Telemetry
     __registry.keys
   end
 
+  # The block is executed on the reactor thread and is yielded the scheduling lag in milliseconds -
+  # the difference between the expected and actual execution times. Keep the block fast and non-blocking.
+  #
+  # @param ms [Integer] the execution interval in milliseconds
+  # @yield [Integer] the scheduling lag in milliseconds
+  # @example Periodically record the event loop lag
+  #   Rage::Telemetry.every(100) do |lag|
+  #     MyMetrics.record_loop_lag(lag)
+  #   end
+  def self.every(interval_ms, &block)
+    schedule_block = -> do
+      last_run_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+
+      Iodine.run_every(interval_ms) do
+        current_run_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+        lag_ms = [current_run_time - last_run_time - interval_ms, 0].max
+
+        block.call(lag_ms)
+        last_run_time = current_run_time
+      end
+    end
+
+    if Iodine.running?
+      schedule_block.call
+    else
+      Iodine.on_state(:on_start, &schedule_block)
+    end
+  end
+
   # @private
   def self.__registry
     @__registry ||= Spans.constants.each_with_object({}) do |const, memo|

--- a/spec/telemetry/telemetry_spec.rb
+++ b/spec/telemetry/telemetry_spec.rb
@@ -105,52 +105,6 @@ RSpec.describe Rage::Telemetry do
         expect(received).to eq([0])
       end
     end
-
-    context "within the reactor" do
-      before do
-        Fiber.set_scheduler(Rage::FiberScheduler.new)
-      end
-
-      after do
-        Fiber.set_scheduler(nil)
-      end
-
-      it "periodically executes the block" do
-        counter = 0
-
-        within_reactor do
-          described_class.every(50) { counter += 1 }
-          sleep 0.28
-
-          -> { expect(counter).to be >= 3 }
-        end
-      end
-
-      it "yields a non-negative scheduling lag" do
-        lags = []
-
-        within_reactor do
-          described_class.every(50) { |lag| lags << lag }
-          sleep 0.28
-
-          -> {
-            expect(lags).not_to be_empty
-            expect(lags).to all(be >= 0)
-          }
-        end
-      end
-
-      it "executes blocks registered before the server start" do
-        counter = 0
-        described_class.every(50) { counter += 1 }
-
-        within_reactor do
-          sleep 0.28
-
-          -> { expect(counter).to be >= 3 }
-        end
-      end
-    end
   end
 
   describe "SpanResult" do

--- a/spec/telemetry/telemetry_spec.rb
+++ b/spec/telemetry/telemetry_spec.rb
@@ -73,36 +73,17 @@ RSpec.describe Rage::Telemetry do
 
         described_class.every(100) {}
       end
-    end
 
-    context "lag calculation" do
-      let(:timer_block) { @timer_block }
-
-      before do
+      it "forwards the block to Iodine.run_every unchanged" do
         allow(Iodine).to receive(:running?).and_return(true)
-        allow(Iodine).to receive(:run_every) { |&block| @timer_block = block }
-      end
 
-      it "yields the delay past the expected interval" do
-        allow(Process).to receive(:clock_gettime).and_return(1000, 1130, 1230)
+        received_block = nil
+        allow(Iodine).to receive(:run_every) { |_ms, &block| received_block = block }
 
-        received = []
-        described_class.every(100) { |lag| received << lag }
+        my_block = -> { :did_run }
+        described_class.every(100, &my_block)
 
-        2.times { timer_block.call }
-
-        expect(received).to eq([30, 0])
-      end
-
-      it "clamps negative lag to zero" do
-        allow(Process).to receive(:clock_gettime).and_return(1000, 1099)
-
-        received = []
-        described_class.every(100) { |lag| received << lag }
-
-        timer_block.call
-
-        expect(received).to eq([0])
+        expect(received_block.call).to eq(:did_run)
       end
     end
   end

--- a/spec/telemetry/telemetry_spec.rb
+++ b/spec/telemetry/telemetry_spec.rb
@@ -56,6 +56,42 @@ RSpec.describe Rage::Telemetry do
     end
   end
 
+  describe ".every" do
+    context "when the reactor is not running" do
+      it "registers the timer, which Iodine defers until the server starts" do
+        allow(Iodine).to receive(:running?).and_return(false)
+        expect(Iodine).to receive(:run_every).with(100)
+
+        described_class.every(100) {}
+      end
+    end
+
+    context "when the reactor is running" do
+      it "registers the timer immediately" do
+        allow(Iodine).to receive(:running?).and_return(true)
+        expect(Iodine).to receive(:run_every).with(100)
+
+        described_class.every(100) {}
+      end
+
+      it "executes the block in a fiber via Iodine.run_every" do
+        allow(Iodine).to receive(:running?).and_return(true)
+
+        received_block = nil
+        allow(Iodine).to receive(:run_every) { |_ms, &block| received_block = block }
+
+        Fiber.set_scheduler(Rage::FiberScheduler.new)
+        my_block = -> { :did_run }
+        described_class.every(100, &my_block)
+
+        fiber = received_block.call
+        expect(fiber.__get_result).to eq(:did_run)
+      ensure
+        Fiber.set_scheduler(nil)
+      end
+    end
+  end
+
   describe "SpanResult" do
     subject { described_class::SpanResult }
 

--- a/spec/telemetry/telemetry_spec.rb
+++ b/spec/telemetry/telemetry_spec.rb
@@ -56,6 +56,103 @@ RSpec.describe Rage::Telemetry do
     end
   end
 
+  describe ".every" do
+    context "when the reactor is not running" do
+      it "defers registration until the server starts" do
+        allow(Iodine).to receive(:running?).and_return(false)
+        expect(Iodine).to receive(:on_state).with(:on_start)
+
+        described_class.every(100) {}
+      end
+    end
+
+    context "when the reactor is running" do
+      it "registers the timer immediately" do
+        allow(Iodine).to receive(:running?).and_return(true)
+        expect(Iodine).to receive(:run_every).with(100)
+
+        described_class.every(100) {}
+      end
+    end
+
+    context "lag calculation" do
+      let(:timer_block) { @timer_block }
+
+      before do
+        allow(Iodine).to receive(:running?).and_return(true)
+        allow(Iodine).to receive(:run_every) { |&block| @timer_block = block }
+      end
+
+      it "yields the delay past the expected interval" do
+        allow(Process).to receive(:clock_gettime).and_return(1000, 1130, 1230)
+
+        received = []
+        described_class.every(100) { |lag| received << lag }
+
+        2.times { timer_block.call }
+
+        expect(received).to eq([30, 0])
+      end
+
+      it "clamps negative lag to zero" do
+        allow(Process).to receive(:clock_gettime).and_return(1000, 1099)
+
+        received = []
+        described_class.every(100) { |lag| received << lag }
+
+        timer_block.call
+
+        expect(received).to eq([0])
+      end
+    end
+
+    context "within the reactor" do
+      before do
+        Fiber.set_scheduler(Rage::FiberScheduler.new)
+      end
+
+      after do
+        Fiber.set_scheduler(nil)
+      end
+
+      it "periodically executes the block" do
+        counter = 0
+
+        within_reactor do
+          described_class.every(50) { counter += 1 }
+          sleep 0.28
+
+          -> { expect(counter).to be >= 3 }
+        end
+      end
+
+      it "yields a non-negative scheduling lag" do
+        lags = []
+
+        within_reactor do
+          described_class.every(50) { |lag| lags << lag }
+          sleep 0.28
+
+          -> {
+            expect(lags).not_to be_empty
+            expect(lags).to all(be >= 0)
+          }
+        end
+      end
+
+      it "executes blocks registered before the server start" do
+        counter = 0
+        described_class.every(50) { counter += 1 }
+
+        within_reactor do
+          sleep 0.28
+
+          -> { expect(counter).to be >= 3 }
+        end
+      end
+    end
+  end
+
   describe "SpanResult" do
     subject { described_class::SpanResult }
 


### PR DESCRIPTION

### What this PR does?

- `Rage::Telemetry.every` now schedules each tick via `Fiber.schedule` instead of calling the block inline in the root fiber

### Why this design?

- Iodine timers fire in the root fiber, which blocks the reactor thread
- Inside a scheduler fiber, the block's I/O hooks into the fiber scheduler and yields to the reactor, keeping the server responsive

