### PR TITLE
[Deferred] Durable dead-letter storage for deferred tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Gemfile.lock
 # rspec failure tracking
 .rspec_status
 .claude
+/storage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - [OpenAPI] Add `openapi:validate` Rake task for OpenAPI tags validation (#163).
 - [Logger] Add `config.log_redact_keys=` for redacting structured log context.
-- [Deferred] Add durable dead-letter storage for disk-backed tasks that exhaust or abort their retries. Failed tasks retain their execution context and error metadata and can be listed, found, or removed through the backend API; the shared store uses cross-process locking, checksums, torn-write recovery, and crash-durable compaction. Backend task persistence hooks are now named `add_task` and `remove_task`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [OpenAPI] Add `openapi:validate` Rake task for OpenAPI tags validation (#163).
 - [Logger] Add `config.log_redact_keys=` for redacting structured log context.
+- [Deferred] Add durable dead-letter storage for disk-backed tasks that exhaust or abort their retries. Failed tasks retain their execution context and error metadata and can be listed, found, or removed through the backend API; the shared store uses cross-process locking, checksums, torn-write recovery, and crash-durable compaction. Backend task persistence hooks are now named `add_task` and `remove_task`.
 
 ### Fixed
 

--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -878,6 +878,7 @@ class Rage::Configuration
         @backend_options = parse_disk_backend_options(opts)
         Rage::Deferred::Backends::Disk
       when nil
+        @backend_options = {} if RUBY_VERSION.start_with?("3.3.")
         Rage::Deferred::Backends::Nil
       else
         raise ArgumentError, "unsupported backend value; supported keys are `:disk` and `nil`"

--- a/lib/rage/deferred/backends/disk.rb
+++ b/lib/rage/deferred/backends/disk.rb
@@ -9,14 +9,10 @@ require "zlib"
 # * `add_task` - called when a task has to be added to the storage;
 # * `remove_task` - called when a task has to be removed from the storage;
 # * `pending_tasks` - the method should iterate over the underlying storage and return a list of tasks to replay;
-#
-# Additionally, a storage may implement the dead-tasks interface. The store holds tasks that will
-# never be retried again, so they can be inspected and replayed later:
-#
 # * `add_dead_task` - called when a task has exhausted its retries or aborted them;
-# * `list_dead_tasks` - return a list of dead-lettered tasks, newest first;
-# * `find_dead_task` - return a single dead-lettered task;
-# * `remove_dead_tasks` - permanently delete dead-lettered tasks;
+# * `list_dead_tasks` - return a list of dead tasks, newest first;
+# * `find_dead_task` - return a single dead task;
+# * `remove_dead_tasks` - permanently delete dead tasks;
 #
 class Rage::Deferred::Backends::Disk
   def initialize(path:, prefix:, fsync_frequency:)
@@ -165,6 +161,10 @@ class Rage::Deferred::Backends::Disk
     end
 
     # Add a record to the log representing a new task.
+    # @param task [Rage::Deferred::Task]
+    # @param publish_at [Integer, nil]
+    # @param task_id [String, nil]
+    # @return [String]
     def add(task, publish_at: nil, task_id: nil)
       serialized_task = Marshal.dump(task).dump
 
@@ -183,6 +183,7 @@ class Rage::Deferred::Backends::Disk
     end
 
     # Add a record to the log representing a task removal.
+    # @param task_id [String]
     def remove(task_id)
       write_to_storage(build_remove_entry(task_id))
 
@@ -197,6 +198,7 @@ class Rage::Deferred::Backends::Disk
     end
 
     # Return a list of pending tasks in the storage.
+    # @return [Array<(String, Rage::Deferred::Task, Integer, Integer)>
     def pending_tasks
       if @recovered_storages
         # `@recovered_storages` will only be present if the server has previously crashed and left
@@ -347,21 +349,11 @@ class Rage::Deferred::Backends::Disk
   end
 
   ##
-  # The dead-tasks store holding tasks that will never be retried again.
+  # Stores tasks that exhausted or aborted their retries so they can be inspected or replayed.
   #
-  # Unlike the write-ahead log, the store is shared by every worker and every process, so all
-  # operations are guarded by an exclusive lock. The lock is always taken in the non-blocking
-  # mode - a blocking `flock` would freeze the whole worker - and is retried a bounded number
-  # of times before the operation raises.
-  #
-  # Three instance variables make that sharing crash-safe:
-  #
-  # * `@lock_file` — a file that is never renamed. `flock` is tied to an inode, so locking the
-  #   data file would split workers after `rename` (they would hold the old, unlinked inode).
-  # * `@locked` — `flock` on a shared fd re-acquires in the same process, so a second fiber
-  #   would overlap compaction. This flag is the process-local exclusion that `flock` does not give.
-  # * `@tmp_storage_path` — survivors are written here, fsynced, then renamed over the live
-  #   path. Truncating the live file in place can empty it if the process dies mid-write.
+  # All workers and processes share one append-only file. An exclusive, non-blocking file lock
+  # serializes access; lock acquisition is retried briefly before an operation fails. Deletions
+  # replace the file atomically, so a crash cannot leave a partially rewritten store.
   #
   # @private
   class DeadTasksStorage
@@ -377,6 +369,9 @@ class Rage::Deferred::Backends::Disk
     ENTRY_CRC_HEX_WIDTH = 8
     TAIL_SCAN_CHUNK_SIZE = 8_192
 
+    # Open or create the shared dead-tasks store and its stable lock file.
+    # @param path [Pathname] directory in which storage files are kept
+    # @param prefix [String] prefix used for storage file names
     def initialize(path:, prefix:)
       path.mkpath
 
@@ -386,9 +381,17 @@ class Rage::Deferred::Backends::Disk
       @locked = false
 
       File.open(@storage_path, File::WRONLY | File::CREAT | File::BINARY, 0o644) {}
+      sync_storage_directory
     end
 
-    # Add a task to the dead-tasks store.
+    # Persist a failed task and its final error details.
+    # @param task_id [String] id assigned when the task was enqueued
+    # @param context [Object] serializable context needed to replay the task
+    # @param exception [Exception] error raised by the final attempt
+    # @param task_class [Class, String] task class or its name
+    # @param attempts [Integer] number of processing attempts made
+    # @return [String] the persisted task id
+    # @raise [Rage::Deferred::DeadTasksLockTimeout] if the store cannot be locked
     def add(task_id, context, exception, task_class:, attempts:)
       record = {
         id: task_id,
@@ -418,7 +421,11 @@ class Rage::Deferred::Backends::Disk
       end
     end
 
-    # Return a list of dead-lettered tasks, newest first.
+    # Return dead task records, newest first.
+    # @param limit [Integer, nil] maximum number of records to return, or all records if nil
+    # @param offset [Integer] number of newest records to skip
+    # @return [Array<Hash>] task records that could be read successfully
+    # @raise [Rage::Deferred::DeadTasksLockTimeout] if the store cannot be locked
     def list(limit: nil, offset: 0)
       records = read_records.reverse
       records = records.drop(offset) if offset > 0
@@ -427,12 +434,18 @@ class Rage::Deferred::Backends::Disk
       records
     end
 
-    # Return a single dead-lettered task.
+    # Find a dead task by its id.
+    # @param id [String] persisted task id
+    # @return [Hash, nil] the task record, or nil when no record matches
+    # @raise [Rage::Deferred::DeadTasksLockTimeout] if the store cannot be locked
     def find(id)
       read_records.find { |record| record[:id] == id }
     end
 
-    # Permanently delete dead-lettered tasks.
+    # Permanently delete the records with the given ids.
+    # @param ids [String, Array<String>] one or more persisted task ids
+    # @return [Integer] number of distinct records deleted
+    # @raise [Rage::Deferred::DeadTasksLockTimeout] if the store cannot be locked
     def remove(ids)
       ids = Array(ids)
       return 0 if ids.empty?
@@ -465,6 +478,7 @@ class Rage::Deferred::Backends::Disk
 
         if removed_count > 0
           File.rename(@tmp_storage_path, @storage_path)
+          sync_storage_directory
         else
           File.unlink(@tmp_storage_path)
         end
@@ -475,9 +489,15 @@ class Rage::Deferred::Backends::Disk
 
     private
 
-    # A crash during append can leave the final entry without its newline. Appending directly to
-    # that fragment would join it with the next entry and make both fail their CRC checks. Remove
-    # only the incomplete suffix; the following write and fsync persist the repair and new entry.
+    # Persist changes to the live file's directory entry, including file creation and replacement.
+    # @return [void]
+    def sync_storage_directory
+      File.open(@storage_path.dirname, File::RDONLY, &:fsync)
+    end
+
+    # Remove an incomplete final entry left by an interrupted append.
+    # @param storage [File] store opened for reading and writing
+    # @return [void]
     def repair_torn_tail(storage)
       storage.seek(0, IO::SEEK_END)
       end_position = storage.pos
@@ -505,6 +525,10 @@ class Rage::Deferred::Backends::Disk
       storage.truncate(truncate_at)
     end
 
+    # Read valid records, keeping only the latest entry for each task id.
+    # Corrupted or unreadable records are reported and skipped.
+    # @return [Array<Hash>]
+    # @raise [Rage::Deferred::DeadTasksLockTimeout] if the store cannot be locked
     def read_records
       entries = with_lock("read tasks from") do
         result, corrupted_count = {}, 0
@@ -541,7 +565,9 @@ class Rage::Deferred::Backends::Disk
       end
     end
 
-    # Return the id of the record the entry holds, or `nil` if the entry is malformed or corrupted.
+    # Validate a stored entry and extract its task id.
+    # @param entry [String] serialized entry, optionally ending with a newline
+    # @return [String, nil] task id, or nil if the entry is malformed or corrupted
     def entry_id(entry)
       entry = entry.chomp
 
@@ -554,6 +580,10 @@ class Rage::Deferred::Backends::Disk
       entry[id_start...separator_index] if separator_index
     end
 
+    # Serialize a task record as a checksummed, newline-delimited entry.
+    # @param id [String] persisted task id
+    # @param record [Hash] task data to serialize
+    # @return [String] encoded storage entry
     def build_entry(id, record)
       entry = "#{ENTRY_OP}:#{id}:#{Marshal.dump(record).dump}"
       crc = Zlib.crc32(entry).to_s(16).rjust(ENTRY_CRC_HEX_WIDTH, "0")
@@ -561,6 +591,11 @@ class Rage::Deferred::Backends::Disk
       "#{crc}:#{entry}\n"
     end
 
+    # Run an operation while holding the process-wide and file-system locks.
+    # @param operation [String] action used to describe a lock timeout
+    # @yieldreturn [Object] result returned by the protected operation
+    # @return [Object] the block result
+    # @raise [Rage::Deferred::DeadTasksLockTimeout] if the store cannot be locked
     def with_lock(operation)
       attempts = 0
 

--- a/lib/rage/deferred/backends/disk.rb
+++ b/lib/rage/deferred/backends/disk.rb
@@ -6,87 +6,22 @@ require "zlib"
 # `Rage::Deferred::Backends` implements a storage layer to persist deferred tasks.
 # A storage should implement the following instance methods:
 #
-# * `add` - called when a task has to be added to the storage;
-# * `remove` - called when a task has to be removed from the storage;
+# * `add_task` - called when a task has to be added to the storage;
+# * `remove_task` - called when a task has to be removed from the storage;
 # * `pending_tasks` - the method should iterate over the underlying storage and return a list of tasks to replay;
 #
+# Additionally, a storage may implement the dead-tasks interface. The store holds tasks that will
+# never be retried again, so they can be inspected and replayed later:
+#
+# * `add_dead_task` - called when a task has exhausted its retries or aborted them;
+# * `list_dead_tasks` - return a list of dead-lettered tasks, newest first;
+# * `find_dead_task` - return a single dead-lettered task;
+# * `remove_dead_tasks` - permanently delete dead-lettered tasks;
+#
 class Rage::Deferred::Backends::Disk
-  STORAGE_VERSION = "0"
-  STORAGE_SIZE_INCREASE_RATIO = 1.5
-
-  DEFAULT_PUBLISH_AT = "0"
-  DEFAULT_STORAGE_SIZE_LIMIT = 2_000_000
-
   def initialize(path:, prefix:, fsync_frequency:)
-    @storage_path = path
-    @storage_prefix = "#{prefix}#{STORAGE_VERSION}"
-    @fsync_frequency = fsync_frequency
-
-    @storage_path.mkpath
-
-    # try to open and take ownership of all storage files in the storage directory
-    storage_files = @storage_path.glob("#{@storage_prefix}-*").filter_map do |file_path|
-      file = file_path.open("a+b")
-      if file.flock(File::LOCK_EX | File::LOCK_NB)
-        sleep 0.01 # reduce contention between workers
-        file
-      else
-        file.close
-      end
-    end
-
-    # if there are no storage files - create one;
-    # otherwise the first one is used as the main storage; the rest will be merged into the main storage
-    if storage_files.empty?
-      @storage = create_storage
-    else
-      @storage = storage_files[0]
-      @recovered_storages = storage_files[1..] if storage_files.length > 1
-    end
-
-    # include recovered storages from crashed/previous workers
-    all_storages = [@storage, *@recovered_storages].compact
-
-    # find the highest task timestamp across all storage files
-    storage_file_max_timestamp = all_storages.map do |storage|
-      max_timestamp = 0
-      storage.tap(&:rewind).each_line(chomp: true) do |entry|
-        next unless entry[9...12] == "add"
-        timestamp = entry[13..].split("-").first.to_i
-        max_timestamp = timestamp if timestamp > max_timestamp
-      end
-      max_timestamp
-    end.max.to_i
-
-    # apply Lamport IR2(b) From time, clocks and the ordering of
-    # events in a distributed system to guard against clock skew
-    task_id_seed = [Time.now.to_i, storage_file_max_timestamp].max + 1
-
-    @task_id_base, @task_id_i = "#{task_id_seed}-#{Process.pid}", 0
-    Iodine.run_every(1_000) do
-      task_id_seed += 1
-      @task_id_base, @task_id_i = "#{task_id_seed}-#{Process.pid}", 0
-    end
-
-    @storage_size_limit = DEFAULT_STORAGE_SIZE_LIMIT
-    @storage_size = @storage.size
-    @fsync_scheduled = false
-    @should_rotate = false
-
-    # we use different counters for different tasks:
-    # delayed tasks are stored in the hash; for regular tasks we only maintain a counter;
-    # this information is only used during storage rotation
-    @immediate_tasks_in_queue = 0
-    @delayed_tasks = {}
-
-    # ensure data is written to disk
-    @storage_has_changes = false
-    Iodine.run_every(@fsync_frequency) do
-      if @storage_has_changes
-        @storage_has_changes = false
-        @storage.fsync
-      end
-    end
+    @tasks_storage = TasksStorage.new(path:, prefix:, fsync_frequency:)
+    @dead_tasks_storage = DeadTasksStorage.new(path:, prefix:)
   end
 
   # Add a record to the log representing a new task.
@@ -94,185 +29,528 @@ class Rage::Deferred::Backends::Disk
   # @param publish_at [Integer, nil]
   # @param task_id [String, nil]
   # @return [String]
-  def add(task, publish_at: nil, task_id: nil)
-    serialized_task = Marshal.dump(task).dump
-
-    persisted_task_id = task_id || generate_task_id
-
-    entry = build_add_entry(persisted_task_id, serialized_task, publish_at)
-    write_to_storage(entry)
-
-    if publish_at
-      @delayed_tasks[persisted_task_id] = [serialized_task, publish_at]
-    else
-      @immediate_tasks_in_queue += 1
-    end
-
-    persisted_task_id
+  def add_task(task, publish_at: nil, task_id: nil)
+    @tasks_storage.add(task, publish_at:, task_id:)
   end
 
   # Add a record to the log representing a task removal.
   # @param task_id [String]
-  def remove(task_id)
-    write_to_storage(build_remove_entry(task_id))
-
-    if @delayed_tasks.has_key?(task_id)
-      @delayed_tasks.delete(task_id)
-    else
-      @immediate_tasks_in_queue -= 1
-    end
-
-    # rotate the storage once the size is over the limit and all non-delayed tasks are processed
-    rotate_storage if @should_rotate && @immediate_tasks_in_queue == 0
+  def remove_task(task_id)
+    @tasks_storage.remove(task_id)
   end
 
   # Return a list of pending tasks in the storage.
   # @return [Array<(String, Rage::Deferred::Task, Integer, Integer)>
   def pending_tasks
-    if @recovered_storages
-      # `@recovered_storages` will only be present if the server has previously crashed and left
-      # some storage files behind, or if the new cluster is started with fewer workers than before;
-      # TLDR: this code is expected to execute very rarely
-      @recovered_storages.each { |storage| recover_tasks(storage.tap(&:rewind)) }
-    end
+    @tasks_storage.pending_tasks
+  end
 
-    tasks = {}
-    corrupted_tasks_count = 0
+  # Add a task to the dead-tasks store.
+  # @param task_id [String] the id the task was persisted with
+  # @param context [Array] the serializable execution context of the task
+  # @param exception [Exception] the exception raised during the last attempt
+  # @param task_class [Class, String] the class of the task
+  # @param attempts [Integer] the number of attempts made to process the task
+  # @return [String] the id of the dead-task record
+  # @raise [Rage::Deferred::DeadTasksLockTimeout] if the dead-tasks store cannot be locked
+  def add_dead_task(task_id, context, exception, task_class:, attempts:)
+    @dead_tasks_storage.add(task_id, context, exception, task_class:, attempts:)
+  end
 
-    # find pending tasks in the storage
-    @storage.tap(&:rewind).each_line(chomp: true) do |entry|
-      signature, op, payload = entry[0...8], entry[9...12], entry[9..]
-      next if signature&.empty? || payload&.empty? || op&.empty?
+  # Return a list of dead-lettered tasks, newest first.
+  # @param limit [Integer, nil] the maximum number of records to return
+  # @param offset [Integer] the number of records to skip
+  # @return [Array<Hash>]
+  def list_dead_tasks(limit: nil, offset: 0)
+    @dead_tasks_storage.list(limit:, offset:)
+  end
 
-      unless signature == Zlib.crc32(payload).to_s(16).rjust(8, "0")
-        corrupted_tasks_count += 1
-        next
+  # Return a single dead-lettered task.
+  # @param id [String] the id of the dead-task record
+  # @return [Hash, nil]
+  def find_dead_task(id)
+    @dead_tasks_storage.find(id)
+  end
+
+  # Permanently delete dead-lettered tasks.
+  # @param ids [String, Array<String>] the ids of the dead-task records
+  # @return [Integer] the number of deleted records
+  # @raise [Rage::Deferred::DeadTasksLockTimeout] if the dead-tasks store cannot be locked
+  def remove_dead_tasks(ids)
+    @dead_tasks_storage.remove(ids)
+  end
+
+  ##
+  # The write-ahead log holding tasks that are yet to be processed. Every worker owns its own
+  # storage file and never reads the files owned by the other workers, except during recovery.
+  #
+  # @private
+  class TasksStorage
+    STORAGE_VERSION = "0"
+    STORAGE_SIZE_INCREASE_RATIO = 1.5
+
+    DEFAULT_PUBLISH_AT = "0"
+    DEFAULT_STORAGE_SIZE_LIMIT = 2_000_000
+
+    def initialize(path:, prefix:, fsync_frequency:)
+      @storage_path = path
+      @storage_prefix = "#{prefix}#{STORAGE_VERSION}"
+      @fsync_frequency = fsync_frequency
+
+      @storage_path.mkpath
+
+      # try to open and take ownership of all storage files in the storage directory
+      storage_files = @storage_path.glob("#{@storage_prefix}-*").filter_map do |file_path|
+        file = file_path.open("a+b")
+        if file.flock(File::LOCK_EX | File::LOCK_NB)
+          sleep 0.01 # reduce contention between workers
+          file
+        else
+          file.close
+        end
       end
 
-      if op == "add"
-        task_id = entry[13...entry.index(":", 13).to_i]
-        tasks[task_id] = entry
-      elsif op == "rem"
-        task_id = entry[13..]
-        tasks.delete(task_id)
+      # if there are no storage files - create one;
+      # otherwise the first one is used as the main storage; the rest will be merged into the main storage
+      if storage_files.empty?
+        @storage = create_storage
+      else
+        @storage = storage_files[0]
+        @recovered_storages = storage_files[1..] if storage_files.length > 1
+      end
+
+      # include recovered storages from crashed/previous workers
+      all_storages = [@storage, *@recovered_storages].compact
+
+      # find the highest task timestamp across all storage files
+      storage_file_max_timestamp = all_storages.map do |storage|
+        max_timestamp = 0
+        storage.tap(&:rewind).each_line(chomp: true) do |entry|
+          next unless entry[9...12] == "add"
+          timestamp = entry[13..].split("-").first.to_i
+          max_timestamp = timestamp if timestamp > max_timestamp
+        end
+        max_timestamp
+      end.max.to_i
+
+      # apply Lamport IR2(b) From time, clocks and the ordering of
+      # events in a distributed system to guard against clock skew
+      task_id_seed = [Time.now.to_i, storage_file_max_timestamp].max + 1
+
+      @task_id_base, @task_id_i = "#{task_id_seed}-#{Process.pid}", 0
+      Iodine.run_every(1_000) do
+        task_id_seed += 1
+        @task_id_base, @task_id_i = "#{task_id_seed}-#{Process.pid}", 0
+      end
+
+      @storage_size_limit = DEFAULT_STORAGE_SIZE_LIMIT
+      @storage_size = @storage.size
+      @fsync_scheduled = false
+      @should_rotate = false
+
+      # we use different counters for different tasks:
+      # delayed tasks are stored in the hash; for regular tasks we only maintain a counter;
+      # this information is only used during storage rotation
+      @immediate_tasks_in_queue = 0
+      @delayed_tasks = {}
+
+      # ensure data is written to disk
+      @storage_has_changes = false
+      Iodine.run_every(@fsync_frequency) do
+        if @storage_has_changes
+          @storage_has_changes = false
+          @storage.fsync
+        end
       end
     end
 
-    if corrupted_tasks_count != 0
-      puts "WARNING: Detected #{corrupted_tasks_count} corrupted deferred task(s)"
-    end
+    # Add a record to the log representing a new task.
+    def add(task, publish_at: nil, task_id: nil)
+      serialized_task = Marshal.dump(task).dump
 
-    tasks.filter_map do |task_id, entry|
-      _, _, _, serialized_publish_at, serialized_task = entry.split(":", 5)
+      persisted_task_id = task_id || generate_task_id
 
-      task = Marshal.load(serialized_task.undump)
-
-      publish_at = (serialized_publish_at == DEFAULT_PUBLISH_AT ? nil : serialized_publish_at.to_i)
+      entry = build_add_entry(persisted_task_id, serialized_task, publish_at)
+      write_to_storage(entry)
 
       if publish_at
-        @delayed_tasks[task_id] = [serialized_task, publish_at]
+        @delayed_tasks[persisted_task_id] = [serialized_task, publish_at]
       else
         @immediate_tasks_in_queue += 1
       end
 
-      [task_id, task, publish_at]
-
-    rescue ArgumentError, NameError => e
-      puts "ERROR: Can't deserialize the task with id #{task_id}: (#{e.class}) #{e.message}"
-      nil
+      persisted_task_id
     end
-  end
 
-  private
+    # Add a record to the log representing a task removal.
+    def remove(task_id)
+      write_to_storage(build_remove_entry(task_id))
 
-  def generate_task_id
-    @task_id_i += 1
-    "#{@task_id_base}-#{@task_id_i}"
-  end
-
-  def create_storage
-    file = @storage_path.join("#{@storage_prefix}-#{Time.now.strftime("%Y%m%d")}-#{Process.pid}-#{rand(0x100000000).to_s(36)}")
-
-    file.open("a+b").tap { |f| f.flock(File::LOCK_EX) }
-  end
-
-  def write_to_storage(content, adjust_size_limit: false)
-    @storage.write(content)
-    @storage_has_changes = true
-
-    @storage_size += content.bytesize
-    @should_rotate = true if @storage_size >= @storage_size_limit
-
-    if adjust_size_limit
-      # if the data copied from recovered storages or during the rotation takes up most of the storage, we might
-      # end up in an infinite rotation loop; instead, we dynamically increase the storage size limit
-      if @storage_size * STORAGE_SIZE_INCREASE_RATIO >= @storage_size_limit
-        @storage_size_limit *= STORAGE_SIZE_INCREASE_RATIO
-        @should_rotate = false
-      end
-    end
-  end
-
-  def rotate_storage
-    old_storage = @storage
-    @storage = nil # in case `create_storage` ends up blocking the fiber
-
-    # create a new storage and update internal state;
-    # after this point all new tasks will be written to the new storage
-    @should_rotate = false
-    @storage_size = 0
-    @storage_size_limit = DEFAULT_STORAGE_SIZE_LIMIT
-    @storage = create_storage
-
-    # copy delayed tasks to the new storage in batches
-    @delayed_tasks.keys.each_slice(100) do |task_ids|
-      entries = task_ids.filter_map do |task_id|
-        # don't copy the task if it has already been processed during the rotation
-        next unless @delayed_tasks.has_key?(task_id)
-
-        serialized_task, publish_at = @delayed_tasks[task_id]
-        build_add_entry(task_id, serialized_task, publish_at)
+      if @delayed_tasks.has_key?(task_id)
+        @delayed_tasks.delete(task_id)
+      else
+        @immediate_tasks_in_queue -= 1
       end
 
-      write_to_storage(entries.join, adjust_size_limit: true)
-
-      Fiber.pause
+      # rotate the storage once the size is over the limit and all non-delayed tasks are processed
+      rotate_storage if @should_rotate && @immediate_tasks_in_queue == 0
     end
 
-    # delete the old storage ensuring the copied data has already been written to disk
-    Iodine.run_after(@fsync_frequency) do
-      cleanup_storage(old_storage)
+    # Return a list of pending tasks in the storage.
+    def pending_tasks
+      if @recovered_storages
+        # `@recovered_storages` will only be present if the server has previously crashed and left
+        # some storage files behind, or if the new cluster is started with fewer workers than before;
+        # TLDR: this code is expected to execute very rarely
+        @recovered_storages.each { |storage| recover_tasks(storage.tap(&:rewind)) }
+      end
+
+      tasks = {}
+      corrupted_tasks_count = 0
+
+      # find pending tasks in the storage
+      @storage.tap(&:rewind).each_line(chomp: true) do |entry|
+        signature, op, payload = entry[0...8], entry[9...12], entry[9..]
+        next if signature&.empty? || payload&.empty? || op&.empty?
+
+        unless signature == Zlib.crc32(payload).to_s(16).rjust(8, "0")
+          corrupted_tasks_count += 1
+          next
+        end
+
+        if op == "add"
+          task_id = entry[13...entry.index(":", 13).to_i]
+          tasks[task_id] = entry
+        elsif op == "rem"
+          task_id = entry[13..]
+          tasks.delete(task_id)
+        end
+      end
+
+      if corrupted_tasks_count != 0
+        puts "WARNING: Detected #{corrupted_tasks_count} corrupted deferred task(s)"
+      end
+
+      tasks.filter_map do |task_id, entry|
+        _, _, _, serialized_publish_at, serialized_task = entry.split(":", 5)
+
+        task = Marshal.load(serialized_task.undump)
+
+        publish_at = (serialized_publish_at == DEFAULT_PUBLISH_AT ? nil : serialized_publish_at.to_i)
+
+        if publish_at
+          @delayed_tasks[task_id] = [serialized_task, publish_at]
+        else
+          @immediate_tasks_in_queue += 1
+        end
+
+        [task_id, task, publish_at]
+
+      rescue ArgumentError, NameError => e
+        puts "ERROR: Can't deserialize the task with id #{task_id}: (#{e.class}) #{e.message}"
+        nil
+      end
+    end
+
+    private
+
+    def generate_task_id
+      @task_id_i += 1
+      "#{@task_id_base}-#{@task_id_i}"
+    end
+
+    def create_storage
+      file = @storage_path.join("#{@storage_prefix}-#{Time.now.strftime("%Y%m%d")}-#{Process.pid}-#{rand(0x100000000).to_s(36)}")
+
+      file.open("a+b").tap { |f| f.flock(File::LOCK_EX) }
+    end
+
+    def write_to_storage(content, adjust_size_limit: false)
+      @storage.write(content)
+      @storage_has_changes = true
+
+      @storage_size += content.bytesize
+      @should_rotate = true if @storage_size >= @storage_size_limit
+
+      if adjust_size_limit
+        # if the data copied from recovered storages or during the rotation takes up most of the storage, we might
+        # end up in an infinite rotation loop; instead, we dynamically increase the storage size limit
+        if @storage_size * STORAGE_SIZE_INCREASE_RATIO >= @storage_size_limit
+          @storage_size_limit *= STORAGE_SIZE_INCREASE_RATIO
+          @should_rotate = false
+        end
+      end
+    end
+
+    def rotate_storage
+      old_storage = @storage
+      @storage = nil # in case `create_storage` ends up blocking the fiber
+
+      # create a new storage and update internal state;
+      # after this point all new tasks will be written to the new storage
+      @should_rotate = false
+      @storage_size = 0
+      @storage_size_limit = DEFAULT_STORAGE_SIZE_LIMIT
+      @storage = create_storage
+
+      # copy delayed tasks to the new storage in batches
+      @delayed_tasks.keys.each_slice(100) do |task_ids|
+        entries = task_ids.filter_map do |task_id|
+          # don't copy the task if it has already been processed during the rotation
+          next unless @delayed_tasks.has_key?(task_id)
+
+          serialized_task, publish_at = @delayed_tasks[task_id]
+          build_add_entry(task_id, serialized_task, publish_at)
+        end
+
+        write_to_storage(entries.join, adjust_size_limit: true)
+
+        Fiber.pause
+      end
+
+      # delete the old storage ensuring the copied data has already been written to disk
+      Iodine.run_after(@fsync_frequency) do
+        cleanup_storage(old_storage)
+      end
+    end
+
+    def build_add_entry(task_id, serialized_task, publish_at)
+      entry = "add:#{task_id}:#{publish_at || DEFAULT_PUBLISH_AT}:#{serialized_task}"
+      crc = Zlib.crc32(entry).to_s(16).rjust(8, "0")
+
+      "#{crc}:#{entry}\n"
+    end
+
+    def build_remove_entry(task_id)
+      entry = "rem:#{task_id}"
+      crc = Zlib.crc32(entry).to_s(16).rjust(8, "0")
+
+      "#{crc}:#{entry}\n"
+    end
+
+    def recover_tasks(storage)
+      # copy records to the main storage
+      while (content = storage.read(262_144))
+        write_to_storage(content, adjust_size_limit: true)
+      end
+
+      Iodine.run_after(@fsync_frequency) do
+        cleanup_storage(storage)
+      end
+    end
+
+    def cleanup_storage(storage)
+      path = storage.path
+      storage.close
+      File.unlink(path) if File.exist?(path)
     end
   end
 
-  def build_add_entry(task_id, serialized_task, publish_at)
-    entry = "add:#{task_id}:#{publish_at || DEFAULT_PUBLISH_AT}:#{serialized_task}"
-    crc = Zlib.crc32(entry).to_s(16).rjust(8, "0")
+  ##
+  # The dead-tasks store holding tasks that will never be retried again.
+  #
+  # Unlike the write-ahead log, the store is shared by every worker and every process, so all
+  # operations are guarded by an exclusive lock. The lock is always taken in the non-blocking
+  # mode - a blocking `flock` would freeze the whole worker - and is retried a bounded number
+  # of times before the operation raises.
+  #
+  # Three instance variables make that sharing crash-safe:
+  #
+  # * `@lock_file` — a file that is never renamed. `flock` is tied to an inode, so locking the
+  #   data file would split workers after `rename` (they would hold the old, unlinked inode).
+  # * `@locked` — `flock` on a shared fd re-acquires in the same process, so a second fiber
+  #   would overlap compaction. This flag is the process-local exclusion that `flock` does not give.
+  # * `@tmp_storage_path` — survivors are written here, fsynced, then renamed over the live
+  #   path. Truncating the live file in place can empty it if the process dies mid-write.
+  #
+  # @private
+  class DeadTasksStorage
+    STORAGE_VERSION = "0"
 
-    "#{crc}:#{entry}\n"
-  end
+    LOCK_MAX_ATTEMPTS = 20
+    LOCK_RETRY_INTERVAL = 0.01
+    LOCK_MAX_RETRY_INTERVAL = 0.1
 
-  def build_remove_entry(task_id)
-    entry = "rem:#{task_id}"
-    crc = Zlib.crc32(entry).to_s(16).rjust(8, "0")
+    BACKTRACE_LIMIT = 20
 
-    "#{crc}:#{entry}\n"
-  end
+    ENTRY_OP = "dead_task"
+    ENTRY_CRC_HEX_WIDTH = 8
 
-  def recover_tasks(storage)
-    # copy records to the main storage
-    while (content = storage.read(262_144))
-      write_to_storage(content, adjust_size_limit: true)
+    def initialize(path:, prefix:)
+      path.mkpath
+
+      @storage_path = path.join("#{prefix}dead_tasks-#{STORAGE_VERSION}")
+      @tmp_storage_path = Pathname("#{@storage_path}.tmp")
+      @lock_file = File.open(path.join("#{prefix}dead_tasks.lock"), File::WRONLY | File::CREAT, 0o644)
+      @locked = false
+
+      File.open(@storage_path, File::WRONLY | File::CREAT | File::BINARY, 0o644) {}
     end
 
-    Iodine.run_after(@fsync_frequency) do
-      cleanup_storage(storage)
-    end
-  end
+    # Add a task to the dead-tasks store.
+    def add(task_id, context, exception, task_class:, attempts:)
+      record = {
+        id: task_id,
+        task_class: task_class.to_s,
+        attempts: attempts.to_i,
+        # the timestamp the task was originally enqueued at is a part of its id
+        enqueued_at: task_id.to_s.split("-").first.to_i,
+        failed_at: Time.now.to_i,
+        exception_class: exception.class.name,
+        exception_message: exception.message.to_s,
+        backtrace: exception.backtrace&.first(BACKTRACE_LIMIT) || [],
+        # the context is stored as an opaque blob so that reading the record never depends
+        # on the task class being loadable in the process that reads it
+        context: Marshal.dump(context)
+      }
 
-  def cleanup_storage(storage)
-    path = storage.path
-    storage.close
-    File.unlink(path) if File.exist?(path)
+      entry = build_entry(task_id, record)
+
+      with_lock("add a task to") do
+        File.open(@storage_path, File::WRONLY | File::APPEND | File::BINARY) do |storage|
+          storage.write(entry)
+          storage.fsync
+        end
+
+        task_id
+      end
+    end
+
+    # Return a list of dead-lettered tasks, newest first.
+    def list(limit: nil, offset: 0)
+      records = read_records.reverse
+      records = records.drop(offset) if offset > 0
+      records = records.first(limit) if limit
+
+      records
+    end
+
+    # Return a single dead-lettered task.
+    def find(id)
+      read_records.find { |record| record[:id] == id }
+    end
+
+    # Permanently delete dead-lettered tasks.
+    def remove(ids)
+      ids = Array(ids)
+      return 0 if ids.empty?
+
+      index = {}
+      ids.each { |id| index[id] = true }
+
+      with_lock("delete tasks from") do
+        removed_ids = {}
+
+        File.open(@tmp_storage_path, File::WRONLY | File::CREAT | File::TRUNC | File::BINARY, 0o644) do |tmp|
+          File.open(@storage_path, File::RDONLY | File::BINARY) do |storage|
+            storage.each_line do |entry|
+              id = entry_id(entry)
+
+              if id.nil?
+                next # drop corrupted records; they can neither be listed nor deleted otherwise
+              elsif index[id]
+                removed_ids[id] = true
+              else
+                tmp.write(entry)
+              end
+            end
+          end
+
+          tmp.fsync unless removed_ids.empty?
+        end
+
+        removed_count = removed_ids.length
+
+        if removed_count > 0
+          File.rename(@tmp_storage_path, @storage_path)
+        else
+          File.unlink(@tmp_storage_path)
+        end
+
+        removed_count
+      end
+    end
+
+    private
+
+    def read_records
+      entries = with_lock("read tasks from") do
+        result, corrupted_count = {}, 0
+
+        File.open(@storage_path, File::RDONLY | File::BINARY) do |storage|
+          storage.each_line(chomp: true) do |entry|
+            id = entry_id(entry)
+
+            if id.nil?
+              corrupted_count += 1
+              next
+            end
+
+            # the same task can be dead-lettered more than once if the worker crashed
+            # before the task was removed from the write-ahead log
+            result.delete(id)
+            result[id] = entry
+          end
+        end
+
+        if corrupted_count != 0
+          puts "WARNING: Detected #{corrupted_count} corrupted dead-lettered task(s)"
+        end
+
+        result
+      end
+
+      entries.filter_map do |id, entry|
+        _, _, _, serialized_record = entry.split(":", 4)
+        Marshal.load(serialized_record.undump)
+      rescue ArgumentError, NameError, TypeError => e
+        puts "ERROR: Can't deserialize the dead-lettered task with id #{id}: (#{e.class}) #{e.message}"
+        nil
+      end
+    end
+
+    # Return the id of the record the entry holds, or `nil` if the entry is malformed or corrupted.
+    def entry_id(entry)
+      entry = entry.chomp
+
+      signature, payload = entry[0...ENTRY_CRC_HEX_WIDTH], entry[(ENTRY_CRC_HEX_WIDTH + 1)..]
+      return if signature.nil? || payload.nil? || !payload.start_with?("#{ENTRY_OP}:")
+      return unless signature == Zlib.crc32(payload).to_s(16).rjust(ENTRY_CRC_HEX_WIDTH, "0")
+
+      id_start = ENTRY_CRC_HEX_WIDTH + 1 + ENTRY_OP.length + 1
+      separator_index = entry.index(":", id_start)
+      entry[id_start...separator_index] if separator_index
+    end
+
+    def build_entry(id, record)
+      entry = "#{ENTRY_OP}:#{id}:#{Marshal.dump(record).dump}"
+      crc = Zlib.crc32(entry).to_s(16).rjust(ENTRY_CRC_HEX_WIDTH, "0")
+
+      "#{crc}:#{entry}\n"
+    end
+
+    def with_lock(operation)
+      attempts = 0
+
+      until !@locked && @lock_file.flock(File::LOCK_EX | File::LOCK_NB)
+        attempts += 1
+
+        if attempts == LOCK_MAX_ATTEMPTS
+          raise Rage::Deferred::DeadTasksLockTimeout, "Could not lock the dead tasks store to #{operation} it"
+        end
+
+        # `sleep` is handled by the fiber scheduler and yields the fiber instead of the worker
+        sleep [LOCK_RETRY_INTERVAL * attempts, LOCK_MAX_RETRY_INTERVAL].min
+      end
+
+      @locked = true
+
+      begin
+        yield
+      ensure
+        @lock_file.flock(File::LOCK_UN)
+        @locked = false
+      end
+    end
   end
 end

--- a/lib/rage/deferred/backends/disk.rb
+++ b/lib/rage/deferred/backends/disk.rb
@@ -375,6 +375,7 @@ class Rage::Deferred::Backends::Disk
 
     ENTRY_OP = "dead_task"
     ENTRY_CRC_HEX_WIDTH = 8
+    TAIL_SCAN_CHUNK_SIZE = 8_192
 
     def initialize(path:, prefix:)
       path.mkpath
@@ -407,7 +408,8 @@ class Rage::Deferred::Backends::Disk
       entry = build_entry(task_id, record)
 
       with_lock("add a task to") do
-        File.open(@storage_path, File::WRONLY | File::APPEND | File::BINARY) do |storage|
+        File.open(@storage_path, File::RDWR | File::APPEND | File::BINARY) do |storage|
+          repair_torn_tail(storage)
           storage.write(entry)
           storage.fsync
         end
@@ -472,6 +474,36 @@ class Rage::Deferred::Backends::Disk
     end
 
     private
+
+    # A crash during append can leave the final entry without its newline. Appending directly to
+    # that fragment would join it with the next entry and make both fail their CRC checks. Remove
+    # only the incomplete suffix; the following write and fsync persist the repair and new entry.
+    def repair_torn_tail(storage)
+      storage.seek(0, IO::SEEK_END)
+      end_position = storage.pos
+      return if end_position == 0
+
+      storage.seek(-1, IO::SEEK_END)
+      return if storage.read(1) == "\n"
+
+      position = end_position
+      truncate_at = 0
+
+      while position > 0
+        chunk_start = [position - TAIL_SCAN_CHUNK_SIZE, 0].max
+        storage.seek(chunk_start, IO::SEEK_SET)
+        chunk = storage.read(position - chunk_start)
+
+        if (newline_index = chunk.rindex("\n"))
+          truncate_at = chunk_start + newline_index + 1
+          break
+        end
+
+        position = chunk_start
+      end
+
+      storage.truncate(truncate_at)
+    end
 
     def read_records
       entries = with_lock("read tasks from") do

--- a/lib/rage/deferred/backends/nil.rb
+++ b/lib/rage/deferred/backends/nil.rb
@@ -4,13 +4,27 @@ class Rage::Deferred::Backends::Nil
   def initialize(**)
   end
 
-  def add(_, **)
+  def add_task(_, **)
   end
 
-  def remove(_)
+  def remove_task(_)
   end
 
   def pending_tasks
     []
+  end
+
+  def add_dead_task(_, _, _, **)
+  end
+
+  def list_dead_tasks(**)
+    []
+  end
+
+  def find_dead_task(_)
+  end
+
+  def remove_dead_tasks(_)
+    0
   end
 end

--- a/lib/rage/deferred/deferred.rb
+++ b/lib/rage/deferred/deferred.rb
@@ -70,7 +70,7 @@ module Rage::Deferred
       __queue.schedule(task_id, task_wrapper, publish_in:)
     rescue => e
       puts "ERROR: Failed to load deferred task #{task_id}: #{e.class} (#{e.message}). Removing task from the queue."
-      __backend.remove(task_id)
+      __backend.remove_task(task_id)
     end
   end
 
@@ -98,6 +98,10 @@ module Rage::Deferred
   end
 
   class PushTimeout < StandardError
+  end
+
+  # Raised when a dead-tasks store operation cannot acquire the lock within the retry budget.
+  class DeadTasksLockTimeout < StandardError
   end
 end
 

--- a/lib/rage/deferred/queue.rb
+++ b/lib/rage/deferred/queue.rb
@@ -21,7 +21,7 @@ class Rage::Deferred::Queue
       [delay_until_i - current_time_i, delay_until_i] if delay_until_i > current_time_i
     end
 
-    persisted_task_id = @backend.add(context, publish_at:, task_id:)
+    persisted_task_id = @backend.add_task(context, publish_at:, task_id:)
     schedule(persisted_task_id, context, publish_in:)
   end
 
@@ -41,14 +41,14 @@ class Rage::Deferred::Queue
           result = task.new.__perform(context)
 
           if result == true
-            @backend.remove(task_id)
+            @backend.remove_task(task_id)
           else
             attempts = Rage::Deferred::Context.inc_attempts(context)
             retry_in = task.__next_retry_in(attempts, result)
             if retry_in
               enqueue(context, delay: retry_in, task_id:)
             else
-              @backend.remove(task_id)
+              abandon_task(task_id, context, result, task_class: task, attempts:)
             end
           end
 
@@ -73,5 +73,10 @@ class Rage::Deferred::Queue
         raise Rage::Deferred::PushTimeout, "could not enqueue deferred task within #{@backpressure.timeout} seconds"
       end
     end
+  end
+
+  def abandon_task(task_id, context, result, task_class:, attempts:)
+    @backend.add_dead_task(task_id, context, result, task_class:, attempts:)
+    @backend.remove_task(task_id)
   end
 end

--- a/spec/daemon_spec.rb
+++ b/spec/daemon_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe Rage::Daemon do
     allow(Rage::Internal).to receive(:pick_a_worker).with(purpose: /TestDaemon/).and_yield
 
     allow_any_instance_of(daemon).to receive(:validator).and_return(validator)
-    allow(Rage).to receive(:logger).and_return(Rage::Logger.new(STDERR))
+    # writing to a real file descriptor from inside the reactor hands it over to Iodine,
+    # which closes it once the reactor stops
+    allow(Rage).to receive(:logger).and_return(Rage::Logger.new(StringIO.new))
   end
 
   context "with a single-action perform" do

--- a/spec/deferred/backends/disk_spec.rb
+++ b/spec/deferred/backends/disk_spec.rb
@@ -12,16 +12,23 @@ RSpec.describe Rage::Deferred::Backends::Disk do
   end
 
   describe "#initialize" do
-    before do
-      backend
-    end
-
     it "creates the storage path if it doesn't exist" do
+      backend
       expect(storage_path).to exist
     end
 
     it "creates a storage file if none exist" do
+      backend
       expect(storage_path.glob("#{prefix}0-*").size).to eq(1)
+    end
+
+    it "fsyncs the storage directory after ensuring the dead-tasks file exists" do
+      directory = instance_double(File)
+      allow(File).to receive(:open).and_call_original
+      expect(File).to receive(:open).with(storage_path, File::RDONLY).and_yield(directory)
+      expect(directory).to receive(:fsync)
+
+      backend
     end
   end
 
@@ -230,6 +237,18 @@ RSpec.describe Rage::Deferred::Backends::Disk do
       expect(backend.remove_dead_tasks("1-1-1")).to eq(1)
       expect(backend.list_dead_tasks.map { |record| record[:id] }).to eq(["2-2-2"])
       expect(storage_path.join("#{prefix}dead_tasks-0.tmp")).not_to exist
+    end
+
+    it "fsyncs the storage directory after replacing the live file" do
+      add_dead_task("1-1-1")
+      dead_tasks_storage = backend.instance_variable_get(:@dead_tasks_storage)
+      dead_tasks_path = storage_path.join("#{prefix}dead_tasks-0")
+      tmp_storage_path = Pathname("#{dead_tasks_path}.tmp")
+
+      expect(File).to receive(:rename).with(tmp_storage_path, dead_tasks_path).ordered.and_call_original
+      expect(dead_tasks_storage).to receive(:sync_storage_directory).ordered.and_call_original
+
+      backend.remove_dead_tasks("1-1-1")
     end
 
     it "leaves the queue untouched when no ids match" do

--- a/spec/deferred/backends/disk_spec.rb
+++ b/spec/deferred/backends/disk_spec.rb
@@ -187,6 +187,34 @@ RSpec.describe Rage::Deferred::Backends::Disk do
     end
   end
 
+  describe "#add_dead_task" do
+    let(:exception) { RuntimeError.new("boom") }
+    let(:context) { ["SendWelcomeEmail", [], {}, 0] }
+    let(:dead_tasks_path) { storage_path.join("#{prefix}dead_tasks-0") }
+
+    def add_dead_task(task_id)
+      backend.add_dead_task(task_id, context, exception, task_class: "SendWelcomeEmail", attempts: 3)
+    end
+
+    it "repairs an incomplete final entry before appending" do
+      add_dead_task("1-1-1")
+      dead_tasks_path.open("ab") { |storage| storage.write("deadbeef:dead_task:partial") }
+
+      add_dead_task("2-2-2")
+
+      expect(backend.list_dead_tasks.map { |record| record[:id] }).to eq(["2-2-2", "1-1-1"])
+    end
+
+    it "repairs a file containing only an incomplete entry before appending" do
+      backend
+      dead_tasks_path.open("wb") { |storage| storage.write("deadbeef:dead_task:partial") }
+
+      add_dead_task("1-1-1")
+
+      expect(backend.list_dead_tasks.map { |record| record[:id] }).to eq(["1-1-1"])
+    end
+  end
+
   describe "#remove_dead_tasks" do
     let(:exception) { RuntimeError.new("boom") }
     let(:context) { ["SendWelcomeEmail", [], {}, 0] }

--- a/spec/deferred/backends/disk_spec.rb
+++ b/spec/deferred/backends/disk_spec.rb
@@ -13,8 +13,12 @@ RSpec.describe Rage::Deferred::Backends::Disk do
 
   describe "#initialize" do
     it "creates the storage path if it doesn't exist" do
-      backend
-      expect(storage_path).to exist
+      nested_path = storage_path.join("a/b")
+      expect(nested_path).not_to exist
+
+      described_class.new(path: nested_path, prefix: prefix, fsync_frequency: fsync_frequency)
+
+      expect(nested_path).to exist
     end
 
     it "creates a storage file if none exist" do
@@ -194,76 +198,377 @@ RSpec.describe Rage::Deferred::Backends::Disk do
     end
   end
 
-  describe "#add_dead_task" do
+  describe "dead tasks" do
     let(:exception) { RuntimeError.new("boom") }
     let(:context) { ["SendWelcomeEmail", [], {}, 0] }
     let(:dead_tasks_path) { storage_path.join("#{prefix}dead_tasks-0") }
+    let(:tmp_storage_path) { Pathname("#{dead_tasks_path}.tmp") }
+    let(:lock_path) { storage_path.join("#{prefix}dead_tasks.lock") }
+    let(:dead_tasks_storage) { backend.instance_variable_get(:@dead_tasks_storage) }
 
-    def add_dead_task(task_id)
-      backend.add_dead_task(task_id, context, exception, task_class: "SendWelcomeEmail", attempts: 3)
+    def add_dead_task(task_id, exception = self.exception, context: self.context, attempts: 3)
+      backend.add_dead_task(task_id, context, exception, task_class: "SendWelcomeEmail", attempts:)
     end
 
-    it "repairs an incomplete final entry before appending" do
+    def raised_exception(message = "boom")
+      raise message
+    rescue => e
+      e
+    end
+
+    def stored_entries
+      dead_tasks_path.binread.each_line.map do |line|
+        crc, op, id, payload = line.chomp.split(":", 4)
+        { line:, crc:, op:, id:, payload:, expected_crc: Zlib.crc32("#{op}:#{id}:#{payload}").to_s(16).rjust(8, "0") }
+      end
+    end
+
+    def stored_records
+      stored_entries.map { |entry| Marshal.load(entry[:payload].undump) }
+    end
+
+    describe "#initialize" do
+      it "creates an empty live store and a lock file" do
+        backend
+
+        expect(dead_tasks_path).to exist
+        expect(dead_tasks_path.size).to eq(0)
+        expect(lock_path).to exist
+      end
+
+      it "does not truncate an existing live store when a second backend is opened" do
+        add_dead_task("1-1-1")
+        bytes = dead_tasks_path.binread
+
+        described_class.new(path: storage_path, prefix: prefix, fsync_frequency: fsync_frequency)
+
+        expect(dead_tasks_path.binread).to eq(bytes)
+      end
+    end
+
+    describe "#add_dead_task" do
+      it "writes a checksummed newline-delimited entry" do
+        exception = raised_exception
+        started_at = Time.now.to_i
+
+        returned = add_dead_task("1700000000-99-3", exception)
+        finished_at = Time.now.to_i
+
+        expect(returned).to eq("1700000000-99-3")
+        expect(dead_tasks_path.binread).to end_with("\n")
+        expect(dead_tasks_path.binread.count("\n")).to eq(1)
+
+        entry = stored_entries.first
+        expect(entry[:crc]).to eq(entry[:expected_crc])
+        expect(entry[:op]).to eq("dead_task")
+        expect(entry[:id]).to eq("1700000000-99-3")
+
+        record = stored_records.first
+        expect(record[:id]).to eq("1700000000-99-3")
+        expect(record[:task_class]).to eq("SendWelcomeEmail")
+        expect(record[:attempts]).to eq(3)
+        expect(record[:enqueued_at]).to eq(1_700_000_000)
+        expect(record[:failed_at]).to be_between(started_at, finished_at)
+        expect(record[:exception_class]).to eq("RuntimeError")
+        expect(record[:exception_message]).to eq("boom")
+        expect(record[:backtrace]).to be_an(Array)
+        expect(record[:backtrace]).not_to be_empty
+        expect(record[:context]).to eq(Marshal.dump(context))
+      end
+
+      it "appends without rewriting existing entries" do
+        add_dead_task("1-1-1")
+        first = dead_tasks_path.binread
+        add_dead_task("2-2-2")
+
+        expect(dead_tasks_path.binread).to start_with(first)
+        expect(stored_entries.map { |entry| [entry[:id], entry[:crc] == entry[:expected_crc]] }).to eq(
+          [["1-1-1", true], ["2-2-2", true]]
+        )
+      end
+
+      it "keeps a context containing a newline as a single record" do
+        newline_context = ["SendWelcomeEmail", ["line\nbreak"], {}, nil, nil, nil, nil]
+
+        add_dead_task("1-1-1", context: newline_context)
+
+        expect(dead_tasks_path.binread.count("\n")).to eq(1)
+        expect(stored_entries.first[:crc]).to eq(stored_entries.first[:expected_crc])
+        expect(Marshal.load(stored_records.first[:context])).to eq(newline_context)
+      end
+
+      it "caps the stored backtrace" do
+        exception = raised_exception
+        exception.set_backtrace(Array.new(50) { |i| "frame#{i}" })
+
+        add_dead_task("1-1-1", exception)
+
+        expect(stored_records.first[:backtrace]).to eq(Array.new(20) { |i| "frame#{i}" })
+      end
+
+      it "fsyncs the live file after appending" do
+        backend
+        fsynced = []
+        allow_any_instance_of(File).to receive(:fsync).and_wrap_original do |original|
+          fsynced << original.receiver.path
+          original.call
+        end
+
+        add_dead_task("1-1-1")
+
+        expect(fsynced).to eq([dead_tasks_path.to_s])
+      end
+
+      it "repairs an incomplete final entry before appending" do
+        add_dead_task("1-1-1")
+        dead_tasks_path.open("ab") { |storage| storage.write("deadbeef:dead_task:partial") }
+
+        add_dead_task("2-2-2")
+
+        expect(backend.list_dead_tasks.map { |record| record[:id] }).to eq(["2-2-2", "1-1-1"])
+      end
+
+      it "repairs a file containing only an incomplete entry before appending" do
+        backend
+        dead_tasks_path.open("wb") { |storage| storage.write("deadbeef:dead_task:partial") }
+
+        add_dead_task("1-1-1")
+
+        expect(backend.list_dead_tasks.map { |record| record[:id] }).to eq(["1-1-1"])
+      end
+
+      it "repairs a torn tail longer than one scan chunk" do
+        add_dead_task("1-1-1")
+        first = dead_tasks_path.binread
+        dead_tasks_path.open("ab") { |storage| storage.write("\x01" * 20_000) }
+
+        add_dead_task("2-2-2")
+
+        expect(stored_entries.map { |entry| entry[:id] }).to eq(["1-1-1", "2-2-2"])
+        expect(dead_tasks_path.binread).to eq(first + stored_entries.last[:line])
+      end
+
+      it "repairs a torn tail that starts exactly one chunk from the end" do
+        add_dead_task("1-1-1")
+        first = dead_tasks_path.binread
+        dead_tasks_path.open("ab") { |storage|
+          storage.write("\x01" * described_class::DeadTasksStorage::TAIL_SCAN_CHUNK_SIZE)
+        }
+
+        add_dead_task("2-2-2")
+
+        expect(stored_entries.map { |entry| entry[:id] }).to eq(["1-1-1", "2-2-2"])
+        expect(dead_tasks_path.binread).to eq(first + stored_entries.last[:line])
+      end
+
+      it "truncates a file that is a single oversized incomplete write" do
+        backend
+        dead_tasks_path.open("wb") { |storage| storage.write("\x01" * 20_000) }
+
+        add_dead_task("1-1-1")
+
+        expect(stored_entries.map { |entry| entry[:id] }).to eq(["1-1-1"])
+        expect(dead_tasks_path.binread).to eq(stored_entries.first[:line])
+      end
+
+      it "raises when another open file description holds the lock" do
+        stub_const("#{described_class}::DeadTasksStorage::LOCK_MAX_ATTEMPTS", 1)
+        backend
+        holder = File.open(lock_path, File::WRONLY)
+        holder.flock(File::LOCK_EX)
+
+        begin
+          expect {
+            add_dead_task("1-1-1")
+          }.to raise_error(Rage::Deferred::DeadTasksLockTimeout, /add a task to/)
+          expect(dead_tasks_path.size).to eq(0)
+
+          File.open(lock_path, File::WRONLY) do |third|
+            expect(third.flock(File::LOCK_EX | File::LOCK_NB)).to eq(false)
+          end
+
+          holder.flock(File::LOCK_UN)
+          add_dead_task("1-1-1")
+          expect(stored_entries.map { |entry| entry[:id] }).to eq(["1-1-1"])
+        ensure
+          holder.flock(File::LOCK_UN)
+          holder.close
+        end
+      end
+
+      it "caps lock-retry backoff" do
+        intervals = []
+        allow(dead_tasks_storage).to receive(:sleep) { |interval| intervals << interval }
+        dead_tasks_storage.instance_variable_set(:@locked, true)
+
+        expect { add_dead_task("1-1-1") }.to raise_error(Rage::Deferred::DeadTasksLockTimeout)
+
+        expect(intervals.size).to eq(19)
+        expect(intervals).to eq((1..19).map { |attempt| [0.01 * attempt, 0.1].min })
+        expect(intervals.max).to eq(described_class::DeadTasksStorage::LOCK_MAX_RETRY_INTERVAL)
+      end
+    end
+
+    describe "#remove_dead_tasks" do
+      it "removes the given dead tasks and keeps the others" do
+        add_dead_task("1-1-1")
+        add_dead_task("2-2-2")
+
+        expect(backend.remove_dead_tasks("1-1-1")).to eq(1)
+        expect(backend.list_dead_tasks.map { |record| record[:id] }).to eq(["2-2-2"])
+        expect(tmp_storage_path).not_to exist
+      end
+
+      it "removes several ids given as an array" do
+        add_dead_task("1-1-1")
+        add_dead_task("2-2-2")
+        add_dead_task("3-3-3")
+        surviving = stored_entries[1]
+
+        expect(backend.remove_dead_tasks(["1-1-1", "3-3-3"])).to eq(2)
+        expect(dead_tasks_path.binread).to eq(surviving[:line])
+        expect(tmp_storage_path).not_to exist
+      end
+
+      it "counts duplicate ids in the argument once" do
+        add_dead_task("1-1-1")
+        add_dead_task("2-2-2")
+
+        expect(backend.remove_dead_tasks(["1-1-1", "1-1-1"])).to eq(1)
+        expect(stored_entries.map { |entry| entry[:id] }).to eq(["2-2-2"])
+      end
+
+      it "returns zero for empty input without creating a temp file" do
+        add_dead_task("1-1-1")
+        bytes = dead_tasks_path.binread
+
+        expect(backend.remove_dead_tasks(nil)).to eq(0)
+        expect(backend.remove_dead_tasks([])).to eq(0)
+        expect(dead_tasks_path.binread).to eq(bytes)
+        expect(tmp_storage_path).not_to exist
+      end
+
+      it "leaves an empty live file when every id is removed" do
+        add_dead_task("1-1-1")
+        add_dead_task("2-2-2")
+
+        expect(backend.remove_dead_tasks(["1-1-1", "2-2-2"])).to eq(2)
+        expect(dead_tasks_path).to exist
+        expect(dead_tasks_path.size).to eq(0)
+        expect(tmp_storage_path).not_to exist
+      end
+
+      it "counts a twice-written id as a single deletion" do
+        add_dead_task("1-1-1")
+        add_dead_task("1-1-1")
+
+        expect(backend.remove_dead_tasks("1-1-1")).to eq(1)
+        expect(dead_tasks_path.size).to eq(0)
+      end
+
+      it "drops corrupted and torn lines when a matching id is rewritten out" do
+        add_dead_task("1-1-1")
+        add_dead_task("2-2-2")
+        surviving = stored_entries[1]
+        dead_tasks_path.open("ab") { |storage| storage.write("garbage\npartial") }
+
+        expect(backend.remove_dead_tasks("1-1-1")).to eq(1)
+        expect(dead_tasks_path.binread).to eq(surviving[:line])
+      end
+
+      it "leaves corrupted residue in place when no ids match" do
+        add_dead_task("1-1-1")
+        dead_tasks_path.open("ab") { |storage| storage.write("garbage\npartial") }
+        bytes = dead_tasks_path.binread
+
+        expect(backend.remove_dead_tasks("absent")).to eq(0)
+        expect(dead_tasks_path.binread).to eq(bytes)
+        expect(tmp_storage_path).not_to exist
+      end
+
+      it "truncates a stale temp file instead of appending to it" do
+        add_dead_task("1-1-1")
+        add_dead_task("2-2-2")
+        surviving = stored_entries[1]
+        tmp_storage_path.open("wb") { |storage| storage.write("stale-tmp-contents\n") }
+
+        expect(backend.remove_dead_tasks("1-1-1")).to eq(1)
+        expect(dead_tasks_path.binread).to eq(surviving[:line])
+        expect(dead_tasks_path.binread).not_to include("stale-tmp-contents")
+        expect(tmp_storage_path).not_to exist
+      end
+
+      it "releases the lock when the rewrite raises" do
+        add_dead_task("1-1-1")
+        File.unlink(dead_tasks_path)
+
+        expect { backend.remove_dead_tasks("1-1-1") }.to raise_error(Errno::ENOENT)
+
+        File.open(lock_path, File::WRONLY) do |lock|
+          expect(lock.flock(File::LOCK_EX | File::LOCK_NB)).to be_truthy
+        end
+
+        File.open(dead_tasks_path, File::WRONLY | File::CREAT | File::BINARY, 0o644) {}
+        add_dead_task("2-2-2")
+        expect(stored_entries.map { |entry| entry[:id] }).to eq(["2-2-2"])
+      end
+
+      it "fsyncs the storage directory after replacing the live file" do
+        add_dead_task("1-1-1")
+
+        expect(File).to receive(:rename).with(tmp_storage_path, dead_tasks_path).ordered.and_call_original
+        expect(dead_tasks_storage).to receive(:sync_storage_directory).ordered.and_call_original
+
+        backend.remove_dead_tasks("1-1-1")
+      end
+
+      it "fsyncs the temp file and directory only when a record is removed" do
+        add_dead_task("1-1-1")
+        add_dead_task("2-2-2")
+        fsynced = []
+        allow_any_instance_of(File).to receive(:fsync).and_wrap_original do |original|
+          fsynced << original.receiver.path
+          original.call
+        end
+
+        backend.remove_dead_tasks("1-1-1")
+        expect(fsynced).to eq([tmp_storage_path.to_s, storage_path.to_s])
+
+        fsynced.clear
+        backend.remove_dead_tasks("absent")
+        expect(fsynced).to eq([])
+      end
+
+      it "leaves the queue untouched when no ids match" do
+        add_dead_task("1-1-1")
+
+        expect(backend.remove_dead_tasks("nope")).to eq(0)
+        expect(backend.list_dead_tasks.map { |record| record[:id] }).to eq(["1-1-1"])
+        expect(tmp_storage_path).not_to exist
+      end
+
+      it "raises instead of reporting zero when the store is already locked" do
+        stub_const("#{described_class}::DeadTasksStorage::LOCK_MAX_ATTEMPTS", 1)
+        dead_tasks_storage.instance_variable_set(:@locked, true)
+
+        expect {
+          backend.remove_dead_tasks("1-1-1")
+        }.to raise_error(Rage::Deferred::DeadTasksLockTimeout, /delete tasks from/)
+      end
+    end
+
+    it "shares one store across two backend instances" do
+      other = described_class.new(path: storage_path, prefix: prefix, fsync_frequency: fsync_frequency)
+
       add_dead_task("1-1-1")
-      dead_tasks_path.open("ab") { |storage| storage.write("deadbeef:dead_task:partial") }
+      other.add_dead_task("2-2-2", context, exception, task_class: "SendWelcomeEmail", attempts: 3)
+      add_dead_task("3-3-3")
 
-      add_dead_task("2-2-2")
-
-      expect(backend.list_dead_tasks.map { |record| record[:id] }).to eq(["2-2-2", "1-1-1"])
-    end
-
-    it "repairs a file containing only an incomplete entry before appending" do
-      backend
-      dead_tasks_path.open("wb") { |storage| storage.write("deadbeef:dead_task:partial") }
-
-      add_dead_task("1-1-1")
-
-      expect(backend.list_dead_tasks.map { |record| record[:id] }).to eq(["1-1-1"])
-    end
-  end
-
-  describe "#remove_dead_tasks" do
-    let(:exception) { RuntimeError.new("boom") }
-    let(:context) { ["SendWelcomeEmail", [], {}, 0] }
-
-    def add_dead_task(task_id)
-      backend.add_dead_task(task_id, context, exception, task_class: "SendWelcomeEmail", attempts: 3)
-    end
-
-    it "removes the given dead tasks and keeps the others" do
-      add_dead_task("1-1-1")
-      add_dead_task("2-2-2")
-
-      expect(backend.remove_dead_tasks("1-1-1")).to eq(1)
-      expect(backend.list_dead_tasks.map { |record| record[:id] }).to eq(["2-2-2"])
-      expect(storage_path.join("#{prefix}dead_tasks-0.tmp")).not_to exist
-    end
-
-    it "fsyncs the storage directory after replacing the live file" do
-      add_dead_task("1-1-1")
-      dead_tasks_storage = backend.instance_variable_get(:@dead_tasks_storage)
-      dead_tasks_path = storage_path.join("#{prefix}dead_tasks-0")
-      tmp_storage_path = Pathname("#{dead_tasks_path}.tmp")
-
-      expect(File).to receive(:rename).with(tmp_storage_path, dead_tasks_path).ordered.and_call_original
-      expect(dead_tasks_storage).to receive(:sync_storage_directory).ordered.and_call_original
-
-      backend.remove_dead_tasks("1-1-1")
-    end
-
-    it "leaves the queue untouched when no ids match" do
-      add_dead_task("1-1-1")
-
-      expect(backend.remove_dead_tasks("nope")).to eq(0)
-      expect(backend.list_dead_tasks.map { |record| record[:id] }).to eq(["1-1-1"])
-      expect(storage_path.join("#{prefix}dead_tasks-0.tmp")).not_to exist
-    end
-
-    it "raises instead of reporting zero when the store is already locked" do
-      stub_const("#{described_class}::DeadTasksStorage::LOCK_MAX_ATTEMPTS", 1)
-      backend.instance_variable_get(:@dead_tasks_storage).instance_variable_set(:@locked, true)
-
-      expect { backend.remove_dead_tasks("1-1-1") }.to raise_error(Rage::Deferred::DeadTasksLockTimeout)
+      expect(stored_entries.map { |entry| [entry[:id], entry[:crc] == entry[:expected_crc]] }).to eq(
+        [["1-1-1", true], ["2-2-2", true], ["3-3-3", true]]
+      )
+      expect(storage_path.glob("#{prefix}dead_tasks-0")).to eq([dead_tasks_path])
+      expect(storage_path.glob("#{prefix}dead_tasks.lock")).to eq([lock_path])
     end
   end
 end

--- a/spec/deferred/backends/disk_spec.rb
+++ b/spec/deferred/backends/disk_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Rage::Deferred::Backends::Disk do
   let(:prefix) { "test_prefix" }
   let(:fsync_frequency) { 100 }
   let(:backend) { described_class.new(path: storage_path, prefix: prefix, fsync_frequency: fsync_frequency) }
+  let(:tasks_storage) { backend.instance_variable_get(:@tasks_storage) }
 
   after do
     FileUtils.remove_entry(storage_path)
@@ -20,32 +21,32 @@ RSpec.describe Rage::Deferred::Backends::Disk do
     end
 
     it "creates a storage file if none exist" do
-      expect(storage_path.glob("#{prefix}*").size).to eq(1)
+      expect(storage_path.glob("#{prefix}0-*").size).to eq(1)
     end
   end
 
-  describe "#add" do
+  describe "#add_task" do
     let(:task) { double("Rage::Deferred::Task") }
     let(:publish_at) { Time.now.to_i }
     let(:task_id) { "custom_task_id" }
 
     it "adds a task with a custom task ID" do
-      backend.add(task, publish_at: publish_at, task_id: task_id)
+      backend.add_task(task, publish_at: publish_at, task_id: task_id)
       expect(backend.pending_tasks.map(&:first)).to include(task_id)
     end
 
     it "adds a task with an auto-generated task ID" do
-      task_id = backend.add(task, publish_at: publish_at)
+      task_id = backend.add_task(task, publish_at: publish_at)
       expect(backend.pending_tasks.map(&:first)).to include(task_id)
     end
   end
 
-  describe "#remove" do
+  describe "#remove_task" do
     let(:task) { double("Rage::Deferred::Task") }
-    let(:task_id) { backend.add(task) }
+    let(:task_id) { backend.add_task(task) }
 
     it "removes a task by its ID" do
-      backend.remove(task_id)
+      backend.remove_task(task_id)
       expect(backend.pending_tasks.map(&:first)).not_to include(task_id)
     end
   end
@@ -55,7 +56,7 @@ RSpec.describe Rage::Deferred::Backends::Disk do
     let(:publish_at) { Time.now.to_i }
 
     before do
-      backend.add(task, publish_at: publish_at)
+      backend.add_task(task, publish_at: publish_at)
     end
 
     it "returns a list of pending tasks" do
@@ -65,33 +66,32 @@ RSpec.describe Rage::Deferred::Backends::Disk do
     end
 
     it "handles corrupted entries gracefully" do
-      backend.instance_variable_get(:@storage).write("corrupted_entry\n")
+      tasks_storage.instance_variable_get(:@storage).write("corrupted_entry\n")
       expect { backend.pending_tasks }.not_to raise_error
     end
   end
 
   describe "#rotate_storage" do
     let(:task) { double("Rage::Deferred::Task") }
-    let(:task_id) { backend.add(task) }
+    let(:task_id) { backend.add_task(task) }
 
     before do
-      allow(backend).to receive(:rotate_storage).and_call_original
       task_id
-      backend.instance_variable_set(:@should_rotate, true)
+      tasks_storage.instance_variable_set(:@should_rotate, true)
     end
 
     it "rotates the storage when conditions are met" do
-      backend.remove(task_id)
-      expect(storage_path.glob("#{prefix}*").size).to eq(2)
+      backend.remove_task(task_id)
+      expect(storage_path.glob("#{prefix}0-*").size).to eq(2)
     end
 
     it "ignores missing old storage files during async cleanup" do
       scheduled_cleanups = []
       allow(Iodine).to receive(:run_after) { |_, &block| scheduled_cleanups << block }
 
-      old_storage = backend.instance_variable_get(:@storage)
+      old_storage = tasks_storage.instance_variable_get(:@storage)
 
-      backend.remove(task_id)
+      backend.remove_task(task_id)
       File.unlink(old_storage.path)
 
       expect(scheduled_cleanups.size).to eq(1)
@@ -118,7 +118,7 @@ RSpec.describe Rage::Deferred::Backends::Disk do
       storage.flock(File::LOCK_UN)
 
       backend = described_class.new(path: storage_path, prefix: prefix, fsync_frequency: fsync_frequency)
-      task_id = backend.add(task)
+      task_id = backend.add_task(task)
 
       expect(task_id.split("-").first.to_i).to be > future_timestamps.max
     end
@@ -139,7 +139,7 @@ RSpec.describe Rage::Deferred::Backends::Disk do
       end
 
       backend = described_class.new(path: storage_path, prefix: prefix, fsync_frequency: fsync_frequency)
-      task_id = backend.add(task)
+      task_id = backend.add_task(task)
 
       expect(task_id.split("-").first.to_i).to be > future_timestamps.max
     end
@@ -152,7 +152,7 @@ RSpec.describe Rage::Deferred::Backends::Disk do
       allow(recovered_storage).to receive(:rewind)
       allow(recovered_storage).to receive(:read).with(262_144).and_return(nil)
 
-      backend.instance_variable_set(:@recovered_storages, [recovered_storage])
+      tasks_storage.instance_variable_set(:@recovered_storages, [recovered_storage])
       backend.pending_tasks
 
       expect(scheduled_cleanups.size).to eq(1)
@@ -161,7 +161,7 @@ RSpec.describe Rage::Deferred::Backends::Disk do
 
     it "With empty storage file." do
       before_init = Time.now.to_i
-      task_id = backend.add(task)
+      task_id = backend.add_task(task)
       expect(task_id.split("-").first.to_i).to be >= before_init + 1
     end
 
@@ -181,9 +181,42 @@ RSpec.describe Rage::Deferred::Backends::Disk do
       before_init = Time.now.to_i
 
       backend = described_class.new(path: storage_path, prefix: prefix, fsync_frequency: fsync_frequency)
-      task_id = backend.add(task)
+      task_id = backend.add_task(task)
 
       expect(task_id.split("-").first.to_i).to be >= before_init + 1
+    end
+  end
+
+  describe "#remove_dead_tasks" do
+    let(:exception) { RuntimeError.new("boom") }
+    let(:context) { ["SendWelcomeEmail", [], {}, 0] }
+
+    def add_dead_task(task_id)
+      backend.add_dead_task(task_id, context, exception, task_class: "SendWelcomeEmail", attempts: 3)
+    end
+
+    it "removes the given dead tasks and keeps the others" do
+      add_dead_task("1-1-1")
+      add_dead_task("2-2-2")
+
+      expect(backend.remove_dead_tasks("1-1-1")).to eq(1)
+      expect(backend.list_dead_tasks.map { |record| record[:id] }).to eq(["2-2-2"])
+      expect(storage_path.join("#{prefix}dead_tasks-0.tmp")).not_to exist
+    end
+
+    it "leaves the queue untouched when no ids match" do
+      add_dead_task("1-1-1")
+
+      expect(backend.remove_dead_tasks("nope")).to eq(0)
+      expect(backend.list_dead_tasks.map { |record| record[:id] }).to eq(["1-1-1"])
+      expect(storage_path.join("#{prefix}dead_tasks-0.tmp")).not_to exist
+    end
+
+    it "raises instead of reporting zero when the store is already locked" do
+      stub_const("#{described_class}::DeadTasksStorage::LOCK_MAX_ATTEMPTS", 1)
+      backend.instance_variable_get(:@dead_tasks_storage).instance_variable_set(:@locked, true)
+
+      expect { backend.remove_dead_tasks("1-1-1") }.to raise_error(Rage::Deferred::DeadTasksLockTimeout)
     end
   end
 end

--- a/spec/deferred/queue_spec.rb
+++ b/spec/deferred/queue_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Rage::Deferred::Queue do
-  let(:backend) { double("backend", add: "task-id", remove: nil) }
+  let(:backend) { double("backend", add_task: "task-id", remove_task: nil, add_dead_task: nil) }
   let(:task_class) { double("task_class") }
   let(:task_instance) { double("task_instance", __perform: true) }
 
@@ -23,7 +23,7 @@ RSpec.describe Rage::Deferred::Queue do
 
   describe "#enqueue" do
     it "adds the task to the backend" do
-      expect(backend).to receive(:add).with(task_context, publish_at: nil, task_id: nil).and_return("new-id")
+      expect(backend).to receive(:add_task).with(task_context, publish_at: nil, task_id: nil).and_return("new-id")
       subject.enqueue(task_context)
     end
 
@@ -35,7 +35,7 @@ RSpec.describe Rage::Deferred::Queue do
     context "with a delay" do
       it "correctly calculates publish_at and publish_in" do
         delay = 60
-        expect(backend).to receive(:add).with(task_context, publish_at: Time.now.to_i + delay, task_id: nil)
+        expect(backend).to receive(:add_task).with(task_context, publish_at: Time.now.to_i + delay, task_id: nil)
         expect(subject).to receive(:schedule).with("task-id", task_context, publish_in: delay)
         subject.enqueue(task_context, delay:)
       end
@@ -44,7 +44,7 @@ RSpec.describe Rage::Deferred::Queue do
     context "with a delay_until" do
       it "correctly calculates publish_at and publish_in" do
         delay_until = Time.now + 120
-        expect(backend).to receive(:add).with(task_context, publish_at: delay_until.to_i, task_id: nil)
+        expect(backend).to receive(:add_task).with(task_context, publish_at: delay_until.to_i, task_id: nil)
         expect(subject).to receive(:schedule).with("task-id", task_context, publish_in: 120)
         subject.enqueue(task_context, delay_until:)
       end
@@ -94,7 +94,7 @@ RSpec.describe Rage::Deferred::Queue do
     context "when task completes successfully" do
       it "removes the task from the backend" do
         allow(task_instance).to receive(:__perform).and_return(true)
-        expect(backend).to receive(:remove).with("task-id")
+        expect(backend).to receive(:remove_task).with("task-id")
         subject.schedule("task-id", task_context)
       end
     end
@@ -116,9 +116,12 @@ RSpec.describe Rage::Deferred::Queue do
       end
 
       context "and should not be retried" do
-        it "removes the task from the backend" do
+        it "writes the task to the dead-tasks store before removing it from the WAL" do
           allow(task_class).to receive(:__next_retry_in).with(1, error).and_return(nil)
-          expect(backend).to receive(:remove).with("task-id")
+          expect(backend).to receive(:add_dead_task).with(
+            "task-id", task_context, error, task_class: task_class, attempts: 1
+          ).ordered
+          expect(backend).to receive(:remove_task).with("task-id").ordered
           subject.schedule("task-id", task_context)
         end
       end


### PR DESCRIPTION
# Deferred Backends Approach

## Class dependencies

```mermaid
classDiagram
    class Queue {
        -backend
        +initialize(backend)
        +enqueue(...)
        +schedule(...)
    }

    class Nil {
        +initialize(**)
        +add_task(...)
        +remove_task(...)
        +pending_tasks()
        +add_dead_task(...)
        +list_dead_tasks(...)
        +find_dead_task(...)
        +remove_dead_tasks(...)
    }

    class Disk {
        -TasksStorage tasks_storage
        -DeadTasksStorage dead_tasks_storage
        +initialize(path:, prefix:, fsync_frequency:)
        +add_task(...)
        +remove_task(...)
        +pending_tasks()
        +add_dead_task(...)
        +list_dead_tasks(...)
        +find_dead_task(...)
        +remove_dead_tasks(...)
    }

    class DiskTasksStorage["Disk::TasksStorage"] {
        - path
        - prefix
        - fsync_frequency
        +add(task, publish_at:, task_id:)
        +remove(task_id)
        +pending_tasks()
    }

    class DiskDeadTasksStorage["Disk::DeadTasksStorage"] {
        - path
        - prefix
        +add(task_id, context, exception, task_class:, attempts:)
        +list(limit:, offset:)
        +find(id)
        +remove(ids)
    }

    Queue --> Nil : backend
    Queue --> Disk : backend

    Disk *-- DiskTasksStorage : tasks_storage
    Disk *-- DiskDeadTasksStorage : dead_tasks_storage
```



Runtime call shape:

```ruby
backend.add_task(...)
backend.remove_task(...)
backend.pending_tasks
backend.add_dead_task(...)
backend.list_dead_tasks(...)
backend.find_dead_task(...)
backend.remove_dead_tasks(...)
```



## File interfaces

`**[lib/rage/deferred/backends/disk.rb](lib/rage/deferred/backends/disk.rb)**`

```ruby
class Rage::Deferred::Backends::Disk
  def initialize(path:, prefix:, fsync_frequency:)
    @tasks_storage = TasksStorage.new(path:, prefix:, fsync_frequency:)
    @dead_tasks_storage = DeadTasksStorage.new(path:, prefix:)
  end

  def add_task(task, publish_at: nil, task_id: nil) end
  def remove_task(task_id) end
  def pending_tasks end
  def add_dead_task(task_id, context, exception, task_class:, attempts:) end
  def list_dead_tasks(limit: nil, offset: 0) end
  def find_dead_task(id) end
  def remove_dead_tasks(ids) end

  class TasksStorage
    def initialize(path:, prefix:, fsync_frequency:)
      # WAL setup
    end

    def add(task, publish_at: nil, task_id: nil) end
    def remove(task_id) end
    def pending_tasks end
  end

  class DeadTasksStorage
    STORAGE_VERSION = "0"

    def initialize(path:, prefix:)
      # live file: {path}/{prefix}dead_tasks-{STORAGE_VERSION}
    end

    def add(task_id, context, exception, task_class:, attempts:) end
    def list(limit: nil, offset: 0) end
    def find(id) end
    def remove(ids) end
  end
end
```

`**[lib/rage/deferred/backends/nil.rb](lib/rage/deferred/backends/nil.rb)**`

```ruby
class Rage::Deferred::Backends::Nil
  def initialize(**)
  end

  def add_task(_, **) end
  def remove_task(_) end
  def pending_tasks = []
  def add_dead_task(_, _, _, **) end
  def list_dead_tasks(**) = []
  def find_dead_task(_) end
  def remove_dead_tasks(_) = 0
end
```



## Configuration

Keep the existing public API. Do not add `tasks=` / `dead_tasks=` knobs — that would be a breaking change.

`**[lib/rage/configuration.rb](lib/rage/configuration.rb)**` (`Deferred`) stays as today:

- `**backend=**` — `:disk` (with optional `:path`, `:prefix`, `:fsync_frequency`) or `nil`
- `**backend**` getter — `@backend_class.new(**@backend_options)` (one facade instance)

```ruby
Rage.configure do
  config.deferred.backend = :disk
  # or:
  config.deferred.backend = :disk, path: "my_storage", prefix: "deferred-", fsync_frequency: 0.5
end
```

The Disk facade receives that same options hash. It passes `path` / `prefix` / `fsync_frequency` to `TasksStorage` (WAL). `DeadTasksStorage` reuses `path` and `prefix` only — no separate DLQ knobs, no `fsync_frequency`.

WAL init globs `#{prefix}#{STORAGE_VERSION}-*` (e.g. `deferred-0-*`). The DLQ file must not match that pattern. Use a **constant basename** (`dead_tasks`) plus its own `STORAGE_VERSION` in the filename (same idea as WAL: bump the constant when the on-disk format changes, leave old files alone):

```text
{path}/{prefix}dead_tasks-{STORAGE_VERSION}
# default: storage/deferred-dead_tasks-0
# custom prefix "jobs-": storage/jobs-dead_tasks-0
```

`deferred-dead_tasks-0` does not match `deferred-0-*`, so WAL will not claim the DLQ file on boot. Do **not** put the WAL version immediately after the configured prefix (e.g. `deferred-0-dead_tasks`) — that *would* match the WAL glob. `prefix` still comes from `backend=` so a custom prefix applies to both stores.

For `backend = nil`, the facade methods remain no-ops. `Nil` has no nested storage classes.

## Writing to the dead-tasks store

Give-up in `[Queue#schedule](lib/rage/deferred/queue.rb)` writes the dead task **before** removing it from the tasks WAL. If `add_dead_task` raises, the WAL entry stays (at-least-once). Success path: durable DLQ write, then `remove_task`.

One shared data file (`{path}/{prefix}dead_tasks-{STORAGE_VERSION}`) so listing all dead tasks is a single scan.

### Race conditions and other issues

The design must account for three failure categories across writes and locking. Each one is paired with its resolution below.

#### Mid-write crash

##### During record add

A crash during `add` can leave the final record only partially written and without its terminating newline. CRC validation makes that fragment unreadable, but it does not make the next append safe. Appending a new record directly joins it to the fragment, producing one corrupted line. The new record can then be lost even though its write and `fsync` succeed and Queue removes its WAL entry.

**Resolution.** Repair the tail under the lock file before every append. Open the data file for read/write append, check its final byte, and do nothing when the file is empty or already ends with `\n`. Otherwise, scan backward in bounded-memory chunks for the previous newline and truncate immediately after it; truncate to zero when the file contains no complete line. Then append the new record and `fsync`. The same `fsync` persists both the truncation and the new entry, while every earlier complete record remains untouched.

##### During rewrite on removal

Truncating and rewriting the live file in place can leave it empty or half-written if the process dies. The dead tasks are then gone for good: they already left the WAL.

**Resolution.** Write the survivors to a temp file, `fsync` it, then `rename` the temp over the live data path. A crash during the temp write leaves the live file unchanged, and an orphan `.tmp` is harmless.

#### Multi-worker race

`flock` is tied to an **inode**, not to a path. A worker that keeps a long-lived fd on the data file and then `rename`s a new file onto that path leaves the other workers holding the **old**, now unlinked, inode. Their writes go to a ghost file, and a later `remove` can `rename` that ghost back over the live path:

```mermaid
sequenceDiagram
  participant Path as live_path
  participant WA as WorkerA
  participant WB as WorkerB

  WA->>Path: open plus flock inode1
  WB->>Path: open plus flock inode1
  WA->>WA: write tmp, fsync
  WA->>Path: rename tmp over path
  Note over Path: path now inode2
  Note over WA,WB: A may reopen inode2. B still holds inode1
  WB->>WB: flock inode1 succeeds
  WB->>WB: write ghost inode1
  Note over Path: live file is inode2, B is invisible
```



There are two ways out.

**Resolution: lock file (selected).** Flock a file that is **never** renamed (`{prefix}dead_tasks.lock`). Open the data file **by path** only while holding that lock. After `rename`, waiters still serialize on the same lock inode; the next data `open(path)` sees the new image. Never cache a data fd — keep only `@lock` from init, and let every `add` / `list` / `find` / `remove` open the data path under that lock.

```mermaid
sequenceDiagram
  participant Lock as dlq_lock
  participant Path as live_path
  participant WA as WorkerA
  participant WB as WorkerB

  WA->>Lock: LOCK_NB
  WB->>Lock: LOCK_NB fails, sleep
  WA->>Path: open, read, write tmp, fsync
  WA->>Path: rename tmp over live
  WA->>Lock: unlock
  WB->>Lock: LOCK_NB ok
  WB->>Path: open path, sees compacted file
```



```text
storage/{prefix}dead_tasks-{ver}       data, may be renamed
storage/{prefix}dead_tasks.lock        lock only, never renamed
storage/{prefix}dead_tasks-{ver}.tmp   compaction staging
```

- Pros: lock inode never changes, so `rename` of data cannot split workers; `remove` needs no data-fd reopen dance; hard to regress by caching a data fd.
- Cons: extra file on disk; two paths to keep straight (lock vs data); lock file must never be renamed or unlinked as part of compact.

**Alternative: temp as journal, in-place live write (no live** `rename`**).** Keep the live inode so long-lived `flock` on the data file still works. Write the new image to `.tmp`, `fsync`, then **overwrite** the live file (truncate + write + `fsync`), then unlink `.tmp`. Crash during temp write: live DLQ intact. Crash during live overwrite: live file may be torn until **recovery copies a complete temp back onto live**.

```mermaid
flowchart TD
  startNode[remove under lock]
  writeTmp[write plus fsync tmp]
  overwriteLive[truncate write fsync live same inode]
  unlinkTmp[unlink tmp]
  crashTmp[crash during tmp: use live DLQ]
  crashLive[crash during live write: restore from complete tmp]

  startNode --> writeTmp
  writeTmp --> overwriteLive
  overwriteLive --> unlinkTmp
  writeTmp -.-> crashTmp
  overwriteLive -.-> crashLive
```



- Pros: live inode stays stable, so a long-lived data `flock` still serializes workers; no lock file; crash during tmp write leaves live DLQ intact.
- Cons: crash during live overwrite tears the DLQ until recovery from a complete temp; must detect a complete journal and run recovery at boot; writes the image twice.

Does not mean “always trust DLQ after any crash” unless recovery ran.

#### Same-worker fibers

Rage runs one OS thread per worker with many fibers on it, so a blocking `LOCK_EX` is out: it parks the thread and stalls every fiber in the process. Contenders take `LOCK_EX | LOCK_NB` and `sleep` to retry instead. That serializes other processes, but not the other fibers in this one: `flock` on a shared fd does not exclude them, and a second `LOCK_EX` on that fd succeeds as a re-acquire. Two give-up fibers can then overlap, and one `ensure` can unlock while the other is still mid-compaction.

**Resolution.** A process-local flag in the same retry loop as `flock` (`until !@locked && @lock.flock(...)`): set it on acquire, clear it in `ensure`.

Non-blocking lock and temp-file rewrite are complementary: `LOCK_NB` + `sleep` avoids freezing the worker while **waiting** for the lock; temp → `fsync` → `rename` avoids wiping the store if a crash happens mid-**rewrite**.

### Add algorithm

Append one record under the **lock file**. Serialize the record before acquiring the lock so serialization does not extend the lock hold time. If lock acquisition retries, the fiber-aware `sleep` yields execution while preserving the local `entry` value. Open the data file **by path** only while the lock is held; do not keep a long-lived data fd.

Initialization creates the live data file when needed and `fsync`s its parent directory so the file's directory entry is durable before any dead task can be added and removed from the WAL.

1. Serialize the record into a CRC-prefixed log line
2. Acquire `LOCK_EX | LOCK_NB` on `{prefix}dead_tasks.lock` and set the process-local locked flag; raise `DeadTasksLockTimeout` if the retry cap is hit
3. Open the live data path for read/write append
4. If the file does not end with `\n`, scan backward to the previous newline and truncate the incomplete suffix; truncate to zero if there is no complete line
5. Write the line and `fsync`
6. Unlock the lock file and clear the locked flag in `ensure`

`flock` with `LOCK_NB` returns false immediately when another worker holds the lock. The lock helper then yields the fiber with sleep before retrying. If the lock is not acquired within the fixed retry limit, it raises DeadTasksLockTimeout, leaving the task in the WAL for recovery.

A crash mid-write can still leave a **partial last line**. Reads drop it as corrupted, and the next `add` removes that incomplete suffix under the lock before appending. Every earlier complete line remains intact. There is no temp file on this path: repairing only the invalid tail and then `fsync`ing the repair with the new entry is sufficient.

### Remove algorithm

For a non-empty list of IDs, scan and compact the store under the **lock file**. Open the live data file by path while holding the lock and write valid records that should remain into a temporary file. Replace the live file only when at least one requested ID was found. Do not keep a long-lived data fd.

1. return `0` immediately when it is empty
2. Acquire `LOCK_EX | LOCK_NB` on `{prefix}dead_tasks.lock` and set the process-local locked flag; raise `DeadTasksLockTimeout` if the retry cap is hit
3. Create or truncate `{prefix}dead_tasks-{STORAGE_VERSION}.tmp`, then open the live data path
4. Read the live file one line at a time:
   - omit malformed or CRC-invalid records from the temporary file
   - record each requested task ID that was found
   - copy every other valid record to the temporary file
5. If no requested ID was found, close and unlink the temporary file without `fsync`, leave the live file unchanged, and return `0`
6. If at least one requested ID was found, `fsync` the temporary file
7. `rename` the temporary file over the live data path
8. `fsync` the parent directory so the replacement directory entry is durable
9. Return the number of distinct requested IDs that were found and removed
10. Unlock the lock file and clear the locked flag in `ensure`

```text
Worker A (remove A): flock(.lock) → open path → tmp without A → fsync tmp → rename → fsync dir → unlock .lock
Worker B (remove B): (waiting on .lock)
Worker B:            flock(.lock) → open path (A already gone) → tmp without B → fsync tmp → rename → fsync dir → unlock
```

If the process dies mid-temp write, the live data file is unchanged; an orphan temp is harmless. Malformed or CRC-invalid records are removed only when at least one requested ID was found and the temporary file replaces the live file. The parent-directory `fsync` makes the replacement durable before a later add can rely on the new live inode.

**Lock contention during compaction.** `remove` holds the shared lock while it scans the live file, writes and `fsync`s the temporary file, renames it, and `fsync`s the parent directory. The lock duration therefore grows with the size of the dead-tasks store. Other operations use bounded non-blocking retries and raise `DeadTasksLockTimeout` if they cannot acquire the lock. If `add` times out, Queue leaves the task in the WAL so it can be recovered on the next start. This favors at-least-once recovery over waiting indefinitely for the lock.

### Durability and crash consistency summary

1. **Only one operation uses the store at a time.** The permanent lock file ensures that only one process or worker accesses the dead-tasks store at a time. The local `@locked` flag provides the same protection between fibers inside one worker. After taking the lock, every operation opens the live data file by its current path, so it sees the result of the latest completed removal.

   **What this guarantees:** two operations cannot run at the same time and overwrite each other's changes. If the lock cannot be acquired before the timeout, the operation does not change the dead-tasks store. A timed-out add leaves the task in the WAL.

2. **The dead-tasks storage file is safely created.** Initialization creates the live data file when it does not exist and then `fsync`s the storage directory. Creating a file changes its directory, and a later `fsync` of the file itself does not guarantee that its filename will survive a host crash. Without the directory `fsync`, the first dead-task record could be durably written to the file while the file is no longer reachable by its expected name after recovery.

   **What this guarantees:** after initialization returns, a host crash cannot lose the live filename from an existing storage directory. If initialization is interrupted, the file may or may not exist, but no dead-task write has succeeded yet and the next initialization can safely create or open it again.

3. **An unfinished final write is discarded before the next add.** Before appending a record, `add` checks whether the file ends with a complete line. If it does not, `add` truncates the unfinished trailing fragment back to the last complete line. It does not recover the interrupted record. It then writes the new checksummed record and `fsync`s the live file before returning.

   **What this guarantees:** after `add` returns, the new record and all earlier complete records are durable. If a crash interrupts the add, the file may end with an incomplete record. Reads ignore that fragment, the next add discards it before writing, and Queue keeps the interrupted task in the WAL because its DLQ add did not succeed. A complete newline-terminated record that fails its CRC is not removed by `add`; reads skip it and a later compaction currently drops it.

4. **A removal never rewrites the live file in place.** `remove` writes all records that should remain to a temporary file and `fsync`s it. It then renames the temporary file over the live file and `fsync`s the storage directory before returning.

   **What this guarantees:** after `remove` returns, both the remaining records and the replacement of the live file are durable. The removed records cannot reappear after a crash when the filesystem provides the expected `fsync` and rename guarantees.

   A crash before the rename leaves the old live file unchanged and may leave an unused temporary file. A crash after the rename but before the directory `fsync` finishes may recover either the old or the new version of the live file. In that case the removal never returned successfully, so its result was not acknowledged.

5. **A task is written to the dead-tasks store before it leaves the WAL.** Queue calls `add_dead_task` and waits for it to succeed before recording the corresponding removal in the tasks WAL.

   **What this guarantees:** a task cannot be successfully removed from the WAL before it has been durably written to the dead-tasks store. A crash between these two operations can leave the task in both stores and cause it to be replayed. The handoff therefore provides at-least-once rather than exactly-once behavior. It can create a duplicate record, but it does not silently lose the task.

These guarantees assume a local filesystem that supports file locks, atomic renames within one directory, and reliable `fsync` for files and directories. They cover worker termination, process crashes, and host or OS crashes. They do not cover damaged storage, storage that reports a successful `fsync` without saving the data, or network filesystems with weaker guarantees.

If a filesystem operation raises an error, the operation is not considered successful even though part of it may already be visible. In particular, the rename happens before the directory `fsync`. If that `fsync` fails, callers cannot know whether the removal will survive a later host crash. Retrying the removal and finding no matching record does not prove that the earlier rename is durable.
