### PR TITLE
Correctly enqueue deferred tasks with positional arguments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
       max-parallel: 1
       matrix:
         ruby:
+          - '3.3.0'
           - '3.3'
           - '3.4'
           - '4.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - [OpenAPI] Add `openapi:validate` Rake task for OpenAPI tags validation (#163).
 
+### Fixed
+
+- Correctly enqueue deferred tasks with only positional arguments on Ruby < 3.3.4 (#385).
+
 ## [1.27.0] - 2026-08-06
 
 ### Added

--- a/lib/rage/deferred/task.rb
+++ b/lib/rage/deferred/task.rb
@@ -73,6 +73,7 @@ module Rage::Deferred::Task
         Rage.logger.with_context(task_log_context) do
           args = Rage::Deferred::Context.get_args(context)
           kwargs = Rage::Deferred::Context.get_kwargs(context)
+          kwargs ||= {} if RUBY_VERSION.start_with?("3.3.")
 
           perform(*args, **kwargs)
         end

--- a/spec/deferred/task_spec.rb
+++ b/spec/deferred/task_spec.rb
@@ -319,6 +319,17 @@ RSpec.describe Rage::Deferred::Task do
         expect(task).to have_received(:perform).with("arg1", kwarg: "kwarg1")
       end
 
+      context "without keyword arugments" do
+        before do
+          allow(Rage::Deferred::Context).to receive(:get_kwargs).with(context).and_return(nil)
+        end
+
+        it "calls perform with correct arguments" do
+          task.__perform(context)
+          expect(task).to have_received(:perform).with("arg1")
+        end
+      end
+
       it "logs with context and tag" do
         task.__perform(context)
         expect(logger).to have_received(:with_context).with({ task: "MyTask", attempt: 2 })


### PR DESCRIPTION
This pull request introduces compatibility improvements for Ruby < 3.3.4, ensuring that deferred tasks work correctly when keyword arguments are missing.

fixes #384 