### PR TITLE
[Logger] Add structured log context redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - [OpenAPI] Add `openapi:validate` Rake task for OpenAPI tags validation (#163).
+- [Logger] Add `config.filter_parameters` for filtering structured log context.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Added
 
 - [OpenAPI] Add `openapi:validate` Rake task for OpenAPI tags validation (#163).
-- [Logger] Add `config.filter_parameters` for filtering structured log context.
+- [Logger] Add `config.log_redact_keys=` for redacting structured log context.
 
 ### Fixed
 

--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -256,6 +256,25 @@ class Rage::Configuration
   def log_tags
     @log_tags ||= LogTags.new
   end
+
+  # Allows configuring case-insensitive partial matches for filtering structured log context keys.
+  # Matching keys will have their values replaced with `"[FILTERED]"` before the log entry is written.
+  # @return [Rage::Configuration::FilterParameters]
+  #
+  # @example Filter common secrets from structured logs
+  #   Rage.configure do
+  #     config.filter_parameters = [:password, :token, :secret]
+  #   end
+  def filter_parameters
+    @filter_parameters ||= FilterParameters.new
+  end
+
+  # Replace the current list of filtered log parameter keys.
+  # @param parameters [String, Symbol, Array<String, Symbol>, nil] one or more parameter filters
+  def filter_parameters=(parameters)
+    @filter_parameters = FilterParameters.new
+    @filter_parameters << parameters if parameters
+  end
   # @!endgroup
 
   # @!group Telemetry Configuration
@@ -407,6 +426,18 @@ class Rage::Configuration
         obj.each { |item| validate_input!(item) }
       elsif !obj.respond_to?(:to_str) && !obj.respond_to?(:call)
         raise ArgumentError, "custom log tag has to be a string, an array of strings, or respond to `#call`"
+      end
+    end
+  end
+
+  class FilterParameters < LogContext
+    private
+
+    def validate_input!(obj)
+      if obj.is_a?(Array)
+        obj.each { |item| validate_input!(item) }
+      elsif !obj.is_a?(String) && !obj.is_a?(Symbol)
+        raise ArgumentError, "filter parameters have to be strings, symbols, or arrays of strings and symbols"
       end
     end
   end
@@ -1276,6 +1307,10 @@ class Rage::Configuration
     if @log_tags
       Rage.__log_processor.add_custom_tags(@log_tags.objects)
       @logger.dynamic_tags = Rage.__log_processor.dynamic_tags
+    end
+
+    if @filter_parameters
+      @logger.filter_parameters = @filter_parameters.objects
     end
 
     if before_boot && @blocking_operation_pool&.enabled

--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -73,6 +73,8 @@ class Rage::Configuration
     else
       raise ArgumentError, "Invalid logger: must be an instance of `Rage::Logger`, respond to `#call`, or implement all standard Ruby Logger methods (`#debug`, `#info`, `#warn`, `#error`, `#fatal`, `#unknown`)"
     end
+
+    @logger.log_redact_keys = @log_redact_keys if @logger && defined?(@log_redact_keys)
   end
 
   # Returns the log formatter used by Rage.
@@ -257,25 +259,40 @@ class Rage::Configuration
     @log_tags ||= LogTags.new
   end
 
-  # Allows configuring case-insensitive partial matches for filtering structured log context keys.
-  # Matching keys will have their values replaced with `"[FILTERED]"` before the log entry is written.
-  # @return [Rage::Configuration::FilterParameters]
+  # Allows configuring case-insensitive partial matches for redacting structured log context keys.
+  # Matching keys will have their values replaced with `"[REDACTED]"` before the log entry is written.
   #
-  # @example Filter common secrets from structured logs
+  # @param keys [String, Symbol, Array<String, Symbol>, nil] one or more keys to redact
+  # @example Redact common secrets from structured logs
   #   Rage.configure do
-  #     config.filter_parameters = [:password, :token, :secret]
+  #     config.log_redact_keys = [:password, :token, :secret]
   #   end
-  def filter_parameters
-    @filter_parameters ||= FilterParameters.new
-  end
-
-  # Replace the current list of filtered log parameter keys.
-  # @param parameters [String, Symbol, Array<String, Symbol>, nil] one or more parameter filters
-  def filter_parameters=(parameters)
-    @filter_parameters = FilterParameters.new
-    @filter_parameters << parameters if parameters
+  def log_redact_keys=(keys)
+    @log_redact_keys = normalize_log_redact_keys(keys)
+    @logger.log_redact_keys = @log_redact_keys if @logger
   end
   # @!endgroup
+
+  private def normalize_log_redact_keys(keys)
+    return nil if keys.nil?
+
+    validate_log_redact_keys!(keys)
+
+    normalized_keys = Array(keys).flatten.filter_map do |key|
+      key = key.to_s
+      key unless key.empty?
+    end.uniq
+
+    normalized_keys.any? ? normalized_keys.freeze : nil
+  end
+
+  private def validate_log_redact_keys!(keys)
+    if keys.is_a?(Array)
+      keys.each { |key| validate_log_redact_keys!(key) }
+    elsif !keys.is_a?(String) && !keys.is_a?(Symbol)
+      raise ArgumentError, "log redact keys have to be strings, symbols, or arrays of strings and symbols"
+    end
+  end
 
   # @!group Telemetry Configuration
   # Allows configuring telemetry settings.
@@ -426,18 +443,6 @@ class Rage::Configuration
         obj.each { |item| validate_input!(item) }
       elsif !obj.respond_to?(:to_str) && !obj.respond_to?(:call)
         raise ArgumentError, "custom log tag has to be a string, an array of strings, or respond to `#call`"
-      end
-    end
-  end
-
-  class FilterParameters < LogContext
-    private
-
-    def validate_input!(obj)
-      if obj.is_a?(Array)
-        obj.each { |item| validate_input!(item) }
-      elsif !obj.is_a?(String) && !obj.is_a?(Symbol)
-        raise ArgumentError, "filter parameters have to be strings, symbols, or arrays of strings and symbols"
       end
     end
   end
@@ -1309,8 +1314,8 @@ class Rage::Configuration
       @logger.dynamic_tags = Rage.__log_processor.dynamic_tags
     end
 
-    if @filter_parameters
-      @logger.filter_parameters = @filter_parameters.objects
+    if defined?(@log_redact_keys)
+      @logger.log_redact_keys = @log_redact_keys
     end
 
     if before_boot && @blocking_operation_pool&.enabled

--- a/lib/rage/logger/logger.rb
+++ b/lib/rage/logger/logger.rb
@@ -60,11 +60,13 @@ class Rage::Logger
     fatal: Logger::FATAL,
     unknown: Logger::UNKNOWN
   }
+  FILTERED = "[FILTERED]".freeze
+  private_constant :FILTERED
 
   attr_reader :level, :formatter
 
   # @private
-  attr_reader :dynamic_tags, :dynamic_context
+  attr_reader :dynamic_tags, :dynamic_context, :filter_parameters
 
   # @private
   attr_reader :external_logger
@@ -132,6 +134,29 @@ class Rage::Logger
     rebuild!
   end
 
+  # @private
+  def filter_parameters=(filter_parameters)
+    if filter_parameters&.any?
+      normalized_filters = filter_parameters.filter_map do |filter|
+        filter = filter.to_s.downcase
+        filter unless filter.empty?
+      end.uniq
+
+      if normalized_filters.any?
+        @filter_parameters = normalized_filters.freeze
+        @filter_parameters_matcher = Regexp.union(@filter_parameters)
+      else
+        @filter_parameters = nil
+        @filter_parameters_matcher = nil
+      end
+    else
+      @filter_parameters = nil
+      @filter_parameters_matcher = nil
+    end
+
+    rebuild!
+  end
+
   # Add custom keys to an entry.
   #
   # @param context [Hash] a hash of custom keys
@@ -196,7 +221,7 @@ class Rage::Logger
         RUBY
       elsif @external_logger.is_a?(External::Static)
         # an object that implements Ruby's Logger interface is used as a logger
-        write_call = <<~RUBY
+        write_call = build_filtered_context_call(<<~RUBY)
           @external_logger.wrapped.#{level_name}(
             #{build_formatter_call(level_name, level_val)}
           )
@@ -233,7 +258,7 @@ class Rage::Logger
           request_info: "Fiber[:__rage_logger_final].freeze"
         })
 
-        write_call = <<~RUBY
+        write_call = build_filtered_context_call(<<~RUBY)
           @external_logger.wrapped.call(#{parameters})
         RUBY
 
@@ -253,7 +278,7 @@ class Rage::Logger
           end
         RUBY
       else
-        write_call = <<~RUBY
+        write_call = build_filtered_context_call(<<~RUBY)
           @logdev.write(
             #{build_formatter_call(level_name, level_val)}
           )
@@ -293,6 +318,42 @@ class Rage::Logger
       <<~RUBY
         @formatter.call(#{level_val}, Time.now, nil, block_given? ? yield : msg)
       RUBY
+    end
+  end
+
+  def build_filtered_context_call(write_call)
+    return write_call unless @filter_parameters
+
+    <<~RUBY
+      with_filtered_context do
+        #{write_call}
+      end
+    RUBY
+  end
+
+  def with_filtered_context
+    context = Fiber[:__rage_logger_context]
+    return yield if context.nil? || context.empty?
+
+    Fiber[:__rage_logger_context] = filter_value(context)
+    yield
+  ensure
+    Fiber[:__rage_logger_context] = context
+  end
+
+  def filter_value(value)
+    if value.is_a?(Hash)
+      value.each_with_object({}) do |(key, nested_value), filtered|
+        filtered[key] = if @filter_parameters_matcher.match?(key.to_s.downcase)
+          FILTERED
+        else
+          filter_value(nested_value)
+        end
+      end
+    elsif value.is_a?(Array)
+      value.map { |item| filter_value(item) }
+    else
+      value
     end
   end
 

--- a/lib/rage/logger/logger.rb
+++ b/lib/rage/logger/logger.rb
@@ -60,13 +60,13 @@ class Rage::Logger
     fatal: Logger::FATAL,
     unknown: Logger::UNKNOWN
   }
-  FILTERED = "[FILTERED]"
-  private_constant :FILTERED
+  REDACTED = "[REDACTED]"
+  private_constant :REDACTED
 
   attr_reader :level, :formatter
 
   # @private
-  attr_reader :dynamic_tags, :dynamic_context, :filter_parameters
+  attr_reader :dynamic_tags, :dynamic_context, :log_redact_keys
 
   # @private
   attr_reader :external_logger
@@ -135,23 +135,13 @@ class Rage::Logger
   end
 
   # @private
-  def filter_parameters=(filter_parameters)
-    if filter_parameters&.any?
-      normalized_filters = filter_parameters.filter_map do |filter|
-        filter = filter.to_s.downcase
-        filter unless filter.empty?
-      end.uniq
-
-      if normalized_filters.any?
-        @filter_parameters = normalized_filters.freeze
-        @filter_parameters_matcher = Regexp.union(@filter_parameters)
-      else
-        @filter_parameters = nil
-        @filter_parameters_matcher = nil
-      end
+  def log_redact_keys=(log_redact_keys)
+    if log_redact_keys&.any?
+      @log_redact_keys = log_redact_keys
+      @log_redact_keys_matcher = Regexp.union(log_redact_keys.map { |key| Regexp.new(Regexp.escape(key), Regexp::IGNORECASE) })
     else
-      @filter_parameters = nil
-      @filter_parameters_matcher = nil
+      @log_redact_keys = nil
+      @log_redact_keys_matcher = nil
     end
 
     rebuild!
@@ -221,7 +211,7 @@ class Rage::Logger
         RUBY
       elsif @external_logger.is_a?(External::Static)
         # an object that implements Ruby's Logger interface is used as a logger
-        write_call = build_filtered_context_call(<<~RUBY)
+        write_call = build_redacted_context_call(<<~RUBY)
           @external_logger.wrapped.#{level_name}(
             #{build_formatter_call(level_name, level_val)}
           )
@@ -258,7 +248,7 @@ class Rage::Logger
           request_info: "Fiber[:__rage_logger_final].freeze"
         })
 
-        write_call = build_filtered_context_call(<<~RUBY)
+        write_call = build_redacted_context_call(<<~RUBY)
           @external_logger.wrapped.call(#{parameters})
         RUBY
 
@@ -278,7 +268,7 @@ class Rage::Logger
           end
         RUBY
       else
-        write_call = build_filtered_context_call(<<~RUBY)
+        write_call = build_redacted_context_call(<<~RUBY)
           @logdev.write(
             #{build_formatter_call(level_name, level_val)}
           )
@@ -321,37 +311,37 @@ class Rage::Logger
     end
   end
 
-  def build_filtered_context_call(write_call)
-    return write_call unless @filter_parameters
+  def build_redacted_context_call(write_call)
+    return write_call unless @log_redact_keys
 
     <<~RUBY
-      with_filtered_context do
+      with_redacted_context do
         #{write_call}
       end
     RUBY
   end
 
-  def with_filtered_context
+  def with_redacted_context
     context = Fiber[:__rage_logger_context]
     return yield if context.nil? || context.empty?
 
-    Fiber[:__rage_logger_context] = filter_value(context)
+    Fiber[:__rage_logger_context] = redact_value(context)
     yield
   ensure
     Fiber[:__rage_logger_context] = context
   end
 
-  def filter_value(value)
+  def redact_value(value)
     if value.is_a?(Hash)
-      value.each_with_object({}) do |(key, nested_value), filtered|
-        filtered[key] = if @filter_parameters_matcher.match?(key.to_s.downcase)
-          FILTERED
+      value.each_with_object({}) do |(key, nested_value), redacted|
+        redacted[key] = if @log_redact_keys_matcher.match?(key.to_s)
+          REDACTED
         else
-          filter_value(nested_value)
+          redact_value(nested_value)
         end
       end
     elsif value.is_a?(Array)
-      value.map { |item| filter_value(item) }
+      value.map { |item| redact_value(item) }
     else
       value
     end

--- a/lib/rage/logger/logger.rb
+++ b/lib/rage/logger/logger.rb
@@ -60,7 +60,7 @@ class Rage::Logger
     fatal: Logger::FATAL,
     unknown: Logger::UNKNOWN
   }
-  FILTERED = "[FILTERED]".freeze
+  FILTERED = "[FILTERED]"
   private_constant :FILTERED
 
   attr_reader :level, :formatter

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -341,67 +341,49 @@ RSpec.describe Rage::Configuration do
     end
   end
 
-  describe "#filter_parameters" do
-    subject { described_class.new.filter_parameters }
+  describe "#log_redact_keys=" do
+    let(:config) { described_class.new }
 
-    describe "#push" do
-      it "returns empty array" do
-        expect(subject.objects).to eq([])
-      end
+    it "passes normalized keys to existing logger" do
+      logger = Rage::Logger.new(nil)
+      config.logger = logger
 
-      it "allows to add strings and symbols" do
-        subject << :password << "token"
-        expect(subject.objects).to eq([:password, "token"])
-      end
+      config.log_redact_keys = [:password, ["token"], :password, ""]
 
-      it "allows to add arrays" do
-        subject << [:password, "token"]
-        expect(subject.objects).to eq([:password, "token"])
-      end
-
-      it "removes duplicates" do
-        subject << :password << [:password, "token"]
-        expect(subject.objects).to eq([:password, "token"])
-      end
-
-      it "raises an error for invalid objects" do
-        expect {
-          subject << proc {}
-        }.to raise_error(ArgumentError)
-      end
+      expect(logger.log_redact_keys).to eq(["password", "token"])
     end
 
-    describe "#filter_parameters=" do
-      let(:config) { described_class.new }
+    it "applies current keys when logger is assigned later" do
+      logger = Rage::Logger.new(nil)
+      config.log_redact_keys = [:password, "token"]
 
-      it "replaces current filters" do
-        config.filter_parameters << :password
-        config.filter_parameters = [:token]
+      config.logger = logger
 
-        expect(config.filter_parameters.objects).to eq([:token])
-      end
-
-      it "accepts nil" do
-        config.filter_parameters = nil
-        expect(config.filter_parameters.objects).to eq([])
-      end
+      expect(logger.log_redact_keys).to eq(["password", "token"])
     end
 
-    describe "#__finalize" do
-      let(:config) { described_class.new }
-      let(:logger) { Rage::Logger.new(nil) }
+    it "passes keys during finalize" do
+      config.log_redact_keys = [:password, "token"]
 
-      before do
-        config.logger = logger
-      end
+      config.__finalize
 
-      it "passes filters to logger" do
-        config.filter_parameters = [:password, "token"]
+      expect(config.logger.log_redact_keys).to eq(["password", "token"])
+    end
 
-        config.__finalize
+    it "clears current keys with nil" do
+      logger = Rage::Logger.new(nil)
+      config.logger = logger
+      config.log_redact_keys = [:password]
 
-        expect(logger.filter_parameters).to eq(["password", "token"])
-      end
+      config.log_redact_keys = nil
+
+      expect(logger.log_redact_keys).to be_nil
+    end
+
+    it "raises an error for invalid objects" do
+      expect {
+        config.log_redact_keys = [proc {}]
+      }.to raise_error(ArgumentError, "log redact keys have to be strings, symbols, or arrays of strings and symbols")
     end
   end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -341,6 +341,70 @@ RSpec.describe Rage::Configuration do
     end
   end
 
+  describe "#filter_parameters" do
+    subject { described_class.new.filter_parameters }
+
+    describe "#push" do
+      it "returns empty array" do
+        expect(subject.objects).to eq([])
+      end
+
+      it "allows to add strings and symbols" do
+        subject << :password << "token"
+        expect(subject.objects).to eq([:password, "token"])
+      end
+
+      it "allows to add arrays" do
+        subject << [:password, "token"]
+        expect(subject.objects).to eq([:password, "token"])
+      end
+
+      it "removes duplicates" do
+        subject << :password << [:password, "token"]
+        expect(subject.objects).to eq([:password, "token"])
+      end
+
+      it "raises an error for invalid objects" do
+        expect {
+          subject << proc {}
+        }.to raise_error(ArgumentError)
+      end
+    end
+
+    describe "#filter_parameters=" do
+      let(:config) { described_class.new }
+
+      it "replaces current filters" do
+        config.filter_parameters << :password
+        config.filter_parameters = [:token]
+
+        expect(config.filter_parameters.objects).to eq([:token])
+      end
+
+      it "accepts nil" do
+        config.filter_parameters = nil
+        expect(config.filter_parameters.objects).to eq([])
+      end
+    end
+
+    describe "#__finalize" do
+      let(:config) { described_class.new }
+      let(:logger) { Rage::Logger.new(nil) }
+
+      before do
+        config.logger = logger
+      end
+
+      it "passes filters to logger" do
+        config.filter_parameters = [:password, "token"]
+
+        config.__finalize
+
+        expect(logger.filter_parameters).to eq(["password", "token"])
+      end
+    end
+  end
+
   describe "#logger" do
     subject { described_class.new }
 

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -228,15 +228,15 @@ RSpec.describe Rage::Logger do
     end
   end
 
-  context "with filtered parameters" do
+  context "with log redact keys" do
     before do
-      subject.filter_parameters = [:password, :token]
+      subject.log_redact_keys = [:password, :token]
     end
 
     it "filters partial key matches case-insensitively" do
       subject.info "passed", password_confirmation: "secret", "AUTH_TOKEN" => "abc", user_id: 12345
 
-      expect(io.tap(&:rewind).read).to eq("[my_test_tag] timestamp=very_accurate_timestamp pid=777 level=info password_confirmation=[FILTERED] AUTH_TOKEN=[FILTERED] user_id=12345 message=passed\n")
+      expect(io.tap(&:rewind).read).to eq("[my_test_tag] timestamp=very_accurate_timestamp pid=777 level=info password_confirmation=[REDACTED] AUTH_TOKEN=[REDACTED] user_id=12345 message=passed\n")
     end
 
     it "filters request log context" do
@@ -253,7 +253,7 @@ RSpec.describe Rage::Logger do
         subject.info nil
       end
 
-      expect(io.tap(&:rewind).read).to eq("[my_test_tag] timestamp=very_accurate_timestamp pid=777 level=info method=GET path=/test_path controller=RspecController action=index password=[FILTERED] status=200 duration=1.45\n")
+      expect(io.tap(&:rewind).read).to eq("[my_test_tag] timestamp=very_accurate_timestamp pid=777 level=info method=GET path=/test_path controller=RspecController action=index password=[REDACTED] status=200 duration=1.45\n")
     end
   end
 
@@ -675,9 +675,9 @@ RSpec.describe Rage::Logger do
         end
       end
 
-      context "with filter parameters" do
+      context "with log redact keys" do
         before do
-          subject.filter_parameters = [:password, :token]
+          subject.log_redact_keys = [:password, :token]
         end
 
         it "filters nested context recursively without mutating original values" do
@@ -692,9 +692,9 @@ RSpec.describe Rage::Logger do
             severity: :info,
             tags: ["my_test_tag"],
             context: {
-              api_token: "[FILTERED]",
-              user: { email: "user@example.com", password_confirmation: "[FILTERED]" },
-              sessions: [{ "AUTH_TOKEN" => "[FILTERED]" }, { name: "browser" }]
+              api_token: "[REDACTED]",
+              user: { email: "user@example.com", password_confirmation: "[REDACTED]" },
+              sessions: [{ "AUTH_TOKEN" => "[REDACTED]" }, { name: "browser" }]
             },
             message: "test",
             request_info: nil
@@ -719,7 +719,7 @@ RSpec.describe Rage::Logger do
           expect(external_logger).to receive(:call).with(
             severity: :info,
             tags: ["my_test_tag"],
-            context: { api_token: "[FILTERED]" },
+            context: { api_token: "[REDACTED]" },
             message: nil,
             request_info: {
               env: { "REQUEST_METHOD" => "GET", "PATH_INFO" => "/test_path" },

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -228,6 +228,35 @@ RSpec.describe Rage::Logger do
     end
   end
 
+  context "with filtered parameters" do
+    before do
+      subject.filter_parameters = [:password, :token]
+    end
+
+    it "filters partial key matches case-insensitively" do
+      subject.info "passed", password_confirmation: "secret", "AUTH_TOKEN" => "abc", user_id: 12345
+
+      expect(io.tap(&:rewind).read).to eq("[my_test_tag] timestamp=very_accurate_timestamp pid=777 level=info password_confirmation=[FILTERED] AUTH_TOKEN=[FILTERED] user_id=12345 message=passed\n")
+    end
+
+    it "filters request log context" do
+      Fiber[:__rage_logger_final] = {
+        env: { "REQUEST_METHOD" => "GET", "PATH_INFO" => "/test_path" },
+        params: { controller: "rspec", action: "index" },
+        response: [200, {}, []],
+        duration: 1.45
+      }
+
+      stub_const("RspecController", double(name: "RspecController"))
+
+      subject.with_context(password: "secret") do
+        subject.info nil
+      end
+
+      expect(io.tap(&:rewind).read).to eq("[my_test_tag] timestamp=very_accurate_timestamp pid=777 level=info method=GET path=/test_path controller=RspecController action=index password=[FILTERED] status=200 duration=1.45\n")
+    end
+  end
+
   context "outside the request/response cycle" do
     before do
       Fiber[:__rage_logger_tags] = nil
@@ -643,6 +672,64 @@ RSpec.describe Rage::Logger do
               end
             end
           end
+        end
+      end
+
+      context "with filter parameters" do
+        before do
+          subject.filter_parameters = [:password, :token]
+        end
+
+        it "filters nested context recursively without mutating original values" do
+          inline_context = {
+            user: { email: "user@example.com", password_confirmation: "secret" },
+            sessions: [{ "AUTH_TOKEN" => "abc123" }, { name: "browser" }]
+          }
+
+          subject.dynamic_context = proc { { api_token: "global-secret" } }
+
+          expect(external_logger).to receive(:call).with(
+            severity: :info,
+            tags: ["my_test_tag"],
+            context: {
+              api_token: "[FILTERED]",
+              user: { email: "user@example.com", password_confirmation: "[FILTERED]" },
+              sessions: [{ "AUTH_TOKEN" => "[FILTERED]" }, { name: "browser" }]
+            },
+            message: "test",
+            request_info: nil
+          )
+
+          subject.info "test", inline_context
+
+          expect(inline_context).to eq({
+            user: { email: "user@example.com", password_confirmation: "secret" },
+            sessions: [{ "AUTH_TOKEN" => "abc123" }, { name: "browser" }]
+          })
+        end
+
+        it "leaves request_info untouched" do
+          Fiber[:__rage_logger_final] = {
+            env: { "REQUEST_METHOD" => "GET", "PATH_INFO" => "/test_path" },
+            params: { password: "secret" },
+            response: [200, {}, []],
+            duration: 1.45
+          }
+
+          expect(external_logger).to receive(:call).with(
+            severity: :info,
+            tags: ["my_test_tag"],
+            context: { api_token: "[FILTERED]" },
+            message: nil,
+            request_info: {
+              env: { "REQUEST_METHOD" => "GET", "PATH_INFO" => "/test_path" },
+              params: { password: "secret" },
+              response: [200, {}, []],
+              duration: 1.45
+            }
+          )
+
+          subject.info nil, api_token: "secret"
         end
       end
 


### PR DESCRIPTION
## Description:

Issue #370 asked for a built-in way to redact sensitive values from Rage's structured log context.

This PR adds config.log_redact_keys=, which applies Rails-style case-insensitive partial matching to structured context keys and replaces matching values with [REDACTED] before the log entry is written.

The implementation stays inside Rage's own logger code and applies consistently to with_context, inline logger context, request log context added through append_info_to_payload, global config.log_context, and dynamic external logger context payloads.

As discussed in the issue, this PR only redacts structured context. It does not change request_info.

It also adds regression specs for logger redaction, configuration wiring, nested structured context, and the unchanged request_info behavior for dynamic external loggers.

Closes #370.

## Checklist:

- [x] I have added relevant regression test cases for this change.
- [x] I have run linting checks using bundle exec rubocop lib/rage/logger/logger.rb lib/rage/configuration.rb spec/logger_spec.rb spec/configuration_spec.rb.
- [x] I have run focused specs using bundle exec rspec spec/logger_spec.rb spec/configuration_spec.rb.
- [x] I have run syntax checks using bundle exec ruby -c lib/rage/logger/logger.rb && bundle exec ruby -c lib/rage/configuration.rb.

### Before the fix:

Sensitive keys in structured log context were written as-is.

Rage did not have a built-in redaction mechanism for with_context, inline logger context, or request log context merged through append_info_to_payload.

Example:

    [my_test_tag] timestamp=... level=info password_confirmation=secret AUTH_TOKEN=abc user_id=12345 message=passed

### After the fix:

config.log_redact_keys= redacts matching structured context keys before log emission.

Matching is case-insensitive and partial, so keys like password_confirmation and AUTH_TOKEN are redacted.

Nested hashes and arrays are redacted recursively.

Dynamic external loggers receive redacted context and unchanged request_info.

Example:

    [my_test_tag] timestamp=... level=info password_confirmation=[REDACTED] AUTH_TOKEN=[REDACTED] user_id=12345 message=passed
