### PR TITLE
Phase 4: HTTP streaming support via render stream:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- Add HTTP streaming support: `render stream:` sends any `#each` body with chunked transfer encoding and transparent backpressure.
 - [OpenAPI] Add `openapi:validate` Rake task for OpenAPI tags validation (#163).
 
 ### Fixed

--- a/lib/rage/all.rb
+++ b/lib/rage/all.rb
@@ -37,3 +37,4 @@ require_relative "middleware/body_finalizer"
 
 require_relative "telemetry/telemetry"
 require_relative "sse/sse"
+require_relative "streaming"

--- a/lib/rage/controller/api.rb
+++ b/lib/rage/controller/api.rb
@@ -468,6 +468,7 @@ class RageController::API
   # @param json [String, #to_json] send a json response to the client; objects will be serialized automatically
   # @param plain [#to_s] send a text response to the client
   # @param sse [#each, Proc, #to_json] send an SSE response to the client
+  # @param stream [#each] send a streaming response to the client
   # @param status [Integer, Symbol] set a response status
   # @example Render a JSON object
   #   render json: { hello: "world" }
@@ -482,10 +483,14 @@ class RageController::API
   #     connection.write("data: Hello, World!\n\n")
   #     connection.close
   #   end
+  # @example Render a streaming response
+  #   render stream: "hello world".each_char
   # @note `render` doesn't terminate execution of the action, so if you want to exit an action after rendering, you need to do something like `render(...) and return`.
-  def render(json: nil, plain: nil, sse: nil, status: nil)
+  def render(json: nil, plain: nil, sse: nil, stream: nil, status: nil)
     raise "Render was called multiple times in this action." if @__rendered
     @__rendered = true
+
+    raise ArgumentError, "Cannot render both an SSE stream and an HTTP stream." if sse && stream
 
     if json || plain
       @__body << if json
@@ -513,6 +518,20 @@ class RageController::API
       @__env["rack.upgrade"] = Rage::SSE::Application.new(sse)
       @__status = 200
       @__headers["content-type"] = "text/event-stream; charset=utf-8"
+    end
+
+    if stream
+      raise ArgumentError, "Cannot render both a standard body and an HTTP stream." unless @__body.empty?
+
+      if status
+        return if @__status == 204
+        raise ArgumentError, "Streaming responses only support 200 and 204 statuses." if @__status != 200
+      end
+
+      @__body = Rage::Streaming.new(stream)
+      @__status = 200
+      ct = @__headers["content-type"]
+      @__headers["content-type"] = "text/plain; charset=utf-8" if ct.nil? || ct.equal?(DEFAULT_CONTENT_TYPE)
     end
   end
 

--- a/lib/rage/response.rb
+++ b/lib/rage/response.rb
@@ -19,9 +19,11 @@ class Rage::Response
   end
 
   # Returns the content of the response as a string. This contains the contents of any calls to `render`.
+  # Streaming responses have no buffered body, so this returns an empty string for them.
   # @return [String]
   def body
-    @controller.__body[0] || ""
+    body = @controller.__body
+    body.is_a?(Array) ? body[0] || "" : ""
   end
 
   # Returns the headers for the response.

--- a/lib/rage/streaming.rb
+++ b/lib/rage/streaming.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+##
+# Converts an enumerable object into a streaming response body. Powers the `render stream:`
+# API (see {RageController::API#render}) and is not meant to be used directly. Chunks are
+# sent as they are produced using chunked transfer encoding; when the client cannot keep up,
+# the producer fiber is parked and resumed once the connection drains.
+#
+class Rage::Streaming
+  # Iodine rejects a single write of 64+ internal ~16KB packets; larger chunks are sliced.
+  MAX_WRITE_BYTES = 256 * 1024
+
+  # @param source [#each] an object that yields response chunks; chunks are converted
+  #   to strings with `to_s`, `nil` chunks are skipped
+  def initialize(source)
+    raise ArgumentError, "Streaming body must respond to #each." unless source.respond_to?(:each)
+
+    @source = source
+    @log_tags, @log_context = Fiber[:__rage_logger_tags], Fiber[:__rage_logger_context]
+  end
+
+  # @private
+  # Called by the server with a stream writer once the response is handed off. Runs the
+  # producer in a separate fiber so blocking calls in the source don't block the event loop.
+  def call(stream)
+    Fiber.schedule do
+      Iodine.task_inc!
+      Fiber[:__rage_logger_tags], Fiber[:__rage_logger_context] = @log_tags, @log_context
+      stream_body(stream)
+    rescue => e
+      Rage.logger.error("Streaming response failed with exception: #{e.class} (#{e.message}):\n#{e.backtrace.join("\n")}")
+      Rage::Errors.report(e)
+    ensure
+      stream.close
+      Iodine.task_dec!
+    end
+  end
+
+  # @private
+  # No-op for Rack compatibility: the stream is closed by the producer fiber.
+  def close
+  end
+
+  private
+
+  # Writes each chunk to the stream. On `:would_block` the producer parks until a wake
+  # message ("drain" or "close") and retries; a terminal write status ends the iteration.
+  def stream_body(stream)
+    producer, parked = Fiber.current, false
+    channel = stream.wake_channel
+
+    if channel
+      Iodine.subscribe(channel) do
+        if parked
+          parked = false
+          producer.resume if producer.alive?
+        end
+      end
+    end
+
+    @source.each do |chunk|
+      next if chunk.nil?
+      data = chunk.to_s
+      offset = 0
+
+      loop do
+        slice = data.bytesize > MAX_WRITE_BYTES ? data.byteslice(offset, MAX_WRITE_BYTES) : data
+
+        loop do
+          case stream.write(slice)
+          when :ok
+            break
+          when :would_block
+            # no wake channel means the producer can never be resumed: bail out
+            return if channel.nil?
+            parked = true
+            Fiber.defer(-1)
+          when :error
+            Rage.logger.error("Streaming response terminated: stream.write returned :error")
+            return
+          else # :closed, :disconnected
+            return
+          end
+        end
+
+        offset += MAX_WRITE_BYTES
+        break if offset >= data.bytesize
+      end
+    end
+  ensure
+    Iodine.defer { Iodine.unsubscribe(channel) } if channel
+  end
+end

--- a/lib/rage/streaming.rb
+++ b/lib/rage/streaming.rb
@@ -46,48 +46,53 @@ class Rage::Streaming
   # Writes each chunk to the stream. On `:would_block` the producer parks until a wake
   # message ("drain" or "close") and retries; a terminal write status ends the iteration.
   def stream_body(stream)
-    producer, parked = Fiber.current, false
+    @producer, @parked = Fiber.current, false
     channel = stream.wake_channel
 
     if channel
       Iodine.subscribe(channel) do
-        if parked
-          parked = false
-          producer.resume if producer.alive?
+        if @parked
+          @parked = false
+          @producer.resume if @producer.alive?
         end
       end
     end
 
     @source.each do |chunk|
       next if chunk.nil?
-      data = chunk.to_s
-      offset = 0
-
-      loop do
-        slice = data.bytesize > MAX_WRITE_BYTES ? data.byteslice(offset, MAX_WRITE_BYTES) : data
-
-        loop do
-          case stream.write(slice)
-          when :ok
-            break
-          when :would_block
-            # no wake channel means the producer can never be resumed: bail out
-            return if channel.nil?
-            parked = true
-            Fiber.defer(-1)
-          when :error
-            Rage.logger.error("Streaming response terminated: stream.write returned :error")
-            return
-          else # :closed, :disconnected
-            return
-          end
-        end
-
-        offset += MAX_WRITE_BYTES
-        break if offset >= data.bytesize
-      end
+      break unless write_chunk(stream, chunk.to_s, channel)
     end
   ensure
     Iodine.defer { Iodine.unsubscribe(channel) } if channel
+  end
+
+  # Writes one chunk, slicing it below the write size limit. Returns false when a
+  # terminal write status ends the stream.
+  def write_chunk(stream, data, channel)
+    offset = 0
+
+    loop do
+      slice = data.bytesize > MAX_WRITE_BYTES ? data.byteslice(offset, MAX_WRITE_BYTES) : data
+
+      loop do
+        case stream.write(slice)
+        when :ok
+          break
+        when :would_block
+          # no wake channel means the producer can never be resumed: bail out
+          return false if channel.nil?
+          @parked = true
+          Fiber.defer(-1)
+        when :error
+          Rage.logger.error("Streaming response terminated: stream.write returned :error")
+          return false
+        else # :closed, :disconnected
+          return false
+        end
+      end
+
+      offset += MAX_WRITE_BYTES
+      return true if offset >= data.bytesize
+    end
   end
 end

--- a/spec/controller/api/stream_spec.rb
+++ b/spec/controller/api/stream_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+module ControllerApiStreamSpec
+  class TestControllerStream < RageController::API
+    def index
+      render stream: "hello world".each_char
+    end
+  end
+
+  class TestControllerStreamAnd204 < RageController::API
+    def index
+      render stream: "hello world".each_char, status: 204
+    end
+  end
+
+  class TestControllerStreamAnd401 < RageController::API
+    def index
+      render stream: "hello world".each_char, status: 401
+    end
+  end
+
+  class TestControllerTwoRenders < RageController::API
+    def index
+      render plain: "hello world"
+      render stream: "hello world".each_char
+    end
+  end
+
+  class TestControllerStreamAndPlain < RageController::API
+    def index
+      render stream: "hello world".each_char, plain: "hello world"
+    end
+  end
+
+  class TestControllerStreamAndSSE < RageController::API
+    def index
+      render stream: "hello world".each_char, sse: "hello world"
+    end
+  end
+
+  class TestControllerStreamAndCustomContentType < RageController::API
+    def index
+      headers["content-type"] = "application/x-ndjson"
+      render stream: "hello world".each_char
+    end
+  end
+
+  class TestControllerStreamAndInvalidBody < RageController::API
+    def index
+      render stream: proc { |s| s }
+    end
+  end
+end
+
+RSpec.describe RageController::API do
+  let(:env) { {} }
+
+  subject { run_action(klass, :index, env:) }
+
+  context "with a streaming body" do
+    let(:klass) { ControllerApiStreamSpec::TestControllerStream }
+
+    it "returns a streaming response" do
+      status, headers, body = subject
+
+      expect(status).to eq(200)
+      expect(headers).to eq({ "content-type" => "text/plain; charset=utf-8" })
+      expect(body).to be_a(Rage::Streaming)
+    end
+  end
+
+  context "with 204 response status" do
+    let(:klass) { ControllerApiStreamSpec::TestControllerStreamAnd204 }
+
+    it "returns a regular head response" do
+      status, _, body = subject
+
+      expect(status).to eq(204)
+      expect(body).to be_empty
+      expect(body).not_to be_a(Rage::Streaming)
+    end
+  end
+
+  context "with 401 response status" do
+    let(:klass) { ControllerApiStreamSpec::TestControllerStreamAnd401 }
+
+    it "raises an error" do
+      expect { subject }.to raise_error(/Streaming responses only support 200 and 204 statuses/)
+    end
+  end
+
+  context "with two renders" do
+    let(:klass) { ControllerApiStreamSpec::TestControllerTwoRenders }
+
+    it "raises an error" do
+      expect { subject }.to raise_error(/Render was called multiple times/)
+    end
+  end
+
+  context "with a standard body" do
+    let(:klass) { ControllerApiStreamSpec::TestControllerStreamAndPlain }
+
+    it "raises an error" do
+      expect { subject }.to raise_error(/Cannot render both a standard body and an HTTP stream/)
+    end
+  end
+
+  context "with an SSE stream" do
+    let(:klass) { ControllerApiStreamSpec::TestControllerStreamAndSSE }
+
+    it "raises an error" do
+      expect { subject }.to raise_error(/Cannot render both an SSE stream and an HTTP stream/)
+    end
+
+    it "doesn't upgrade the request" do
+      subject rescue nil
+      expect(env["rack.upgrade"]).to be_nil
+    end
+  end
+
+  context "with custom content type" do
+    let(:klass) { ControllerApiStreamSpec::TestControllerStreamAndCustomContentType }
+
+    it "preserves the custom content type" do
+      _, headers, _ = subject
+      expect(headers["content-type"]).to eq("application/x-ndjson")
+    end
+  end
+
+  context "with a body that doesn't respond to #each" do
+    let(:klass) { ControllerApiStreamSpec::TestControllerStreamAndInvalidBody }
+
+    it "raises an error" do
+      expect { subject }.to raise_error(ArgumentError, /must respond to #each/)
+    end
+  end
+end

--- a/spec/rage/response_spec.rb
+++ b/spec/rage/response_spec.rb
@@ -130,6 +130,16 @@ RSpec.describe Rage::Response do
         expect(subject.body).to eq("test_body")
       end
     end
+
+    context "with a streaming body" do
+      before do
+        controller.render stream: %w(chunk)
+      end
+
+      it "returns empty string" do
+        expect(subject.body).to eq("")
+      end
+    end
   end
 
   context "#status" do

--- a/spec/streaming_spec.rb
+++ b/spec/streaming_spec.rb
@@ -1,0 +1,255 @@
+# frozen_string_literal: true
+
+RSpec.describe Rage::Streaming do
+  before :all do
+    Fiber.set_scheduler(Rage::FiberScheduler.new)
+  end
+
+  after :all do
+    Fiber.set_scheduler(nil)
+  end
+
+  class FakeRackStream
+    attr_reader :chunks, :close_count
+
+    def initialize(script: [])
+      @script = script
+      @chunks = []
+      @close_count = 0
+      @channel = "test:stream:wake:#{object_id}"
+    end
+
+    def write(data)
+      result = @script.empty? ? :ok : @script.shift
+      @chunks << data if result == :ok
+      result
+    end
+
+    def close
+      @close_count += 1
+      nil
+    end
+
+    def closed?
+      @close_count > 0
+    end
+
+    def wake_channel
+      @channel
+    end
+  end
+
+  def wait_until(timeout = 2)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    until yield
+      raise "timed out waiting for condition" if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+      sleep(0.02)
+    end
+  end
+
+  it "rejects a source that doesn't respond to #each" do
+    expect { described_class.new(proc {}) }.to raise_error(ArgumentError, /must respond to #each/)
+  end
+
+  it "writes every chunk and closes the stream" do
+    stream = FakeRackStream.new
+    streaming = described_class.new(%w[a b c].each)
+
+    within_reactor do
+      streaming.call(stream)
+      wait_until { stream.close_count > 0 }
+
+      -> do
+        expect(stream.chunks).to eq(%w[a b c])
+        expect(stream.close_count).to eq(1)
+      end
+    end
+  end
+
+  it "coerces chunks to strings and skips nils" do
+    stream = FakeRackStream.new
+    streaming = described_class.new([1, nil, :chunk].each)
+
+    within_reactor do
+      streaming.call(stream)
+      wait_until { stream.close_count > 0 }
+
+      -> { expect(stream.chunks).to eq(%w[1 chunk]) }
+    end
+  end
+
+  it "stops producing once the client disconnects" do
+    stream = FakeRackStream.new(script: [:ok, :disconnected])
+    streaming = described_class.new(%w[a b c].each)
+
+    within_reactor do
+      streaming.call(stream)
+      wait_until { stream.close_count > 0 }
+
+      -> do
+        expect(stream.chunks).to eq(%w[a])
+        expect(stream.close_count).to eq(1)
+      end
+    end
+  end
+
+  it "stops producing and logs on a write error" do
+    logger = double("logger")
+    allow(Rage).to receive(:logger).and_return(logger)
+    allow(logger).to receive(:error)
+
+    stream = FakeRackStream.new(script: [:error])
+    streaming = described_class.new(%w[a b c].each)
+
+    within_reactor do
+      streaming.call(stream)
+      wait_until { stream.close_count > 0 }
+
+      -> do
+        expect(stream.chunks).to be_empty
+        expect(stream.close_count).to eq(1)
+        expect(logger).to have_received(:error).with(/stream\.write returned :error/)
+      end
+    end
+  end
+
+  it "parks the producer on :would_block and resumes it on a drain message" do
+    stream = FakeRackStream.new(script: [:ok, :would_block, :ok, :would_block])
+    streaming = described_class.new(%w[a b c].each)
+
+    within_reactor do
+      streaming.call(stream)
+      expect(stream.close_count).to eq(0) # parked, not finished
+
+      Iodine.publish(stream.wake_channel, "drain", Iodine::PubSub::PROCESS)
+      wait_until { stream.chunks == %w[a b] }
+
+      Iodine.publish(stream.wake_channel, "drain", Iodine::PubSub::PROCESS)
+      wait_until { stream.close_count > 0 }
+
+      -> do
+        expect(stream.chunks).to eq(%w[a b c])
+        expect(stream.close_count).to eq(1)
+      end
+    end
+  end
+
+  it "wakes a parked producer when the stream is closed externally" do
+    stream = FakeRackStream.new(script: [:would_block, :closed])
+    streaming = described_class.new(%w[a b c].each)
+
+    within_reactor do
+      streaming.call(stream)
+      expect(stream.close_count).to eq(0) # parked, not finished
+
+      Iodine.publish(stream.wake_channel, "close", Iodine::PubSub::PROCESS)
+      wait_until { stream.close_count > 0 }
+
+      -> do
+        expect(stream.chunks).to be_empty
+        expect(stream.close_count).to eq(1)
+      end
+    end
+  end
+
+  it "slices chunks larger than the max write size" do
+    stream = FakeRackStream.new
+    data = "x" * (2 * 256 * 1024 + 100)
+    streaming = described_class.new([data].each)
+
+    within_reactor do
+      streaming.call(stream)
+      wait_until { stream.close_count > 0 }
+
+      -> do
+        expect(stream.chunks.map(&:bytesize)).to eq([256 * 1024, 256 * 1024, 100])
+        expect(stream.chunks.join).to eq(data)
+      end
+    end
+  end
+
+  it "doesn't slice chunks at or below the max write size" do
+    stream = FakeRackStream.new
+    data = "x" * (256 * 1024)
+    streaming = described_class.new([data].each)
+
+    within_reactor do
+      streaming.call(stream)
+      wait_until { stream.close_count > 0 }
+
+      -> { expect(stream.chunks.map(&:bytesize)).to eq([256 * 1024]) }
+    end
+  end
+
+  it "stops mid-chunk when the stream closes between slices" do
+    stream = FakeRackStream.new(script: [:ok, :closed])
+    data = "x" * (2 * 256 * 1024)
+    streaming = described_class.new([data].each)
+
+    within_reactor do
+      streaming.call(stream)
+      wait_until { stream.close_count > 0 }
+
+      -> do
+        expect(stream.chunks.map(&:bytesize)).to eq([256 * 1024])
+        expect(stream.close_count).to eq(1)
+      end
+    end
+  end
+
+  it "parks between slices on :would_block and resumes on a drain message" do
+    stream = FakeRackStream.new(script: [:ok, :would_block])
+    data = "x" * (2 * 256 * 1024)
+    streaming = described_class.new([data].each)
+
+    within_reactor do
+      streaming.call(stream)
+      expect(stream.close_count).to eq(0) # parked mid-chunk, not finished
+
+      Iodine.publish(stream.wake_channel, "drain", Iodine::PubSub::PROCESS)
+      wait_until { stream.close_count > 0 }
+
+      -> do
+        expect(stream.chunks.map(&:bytesize)).to eq([256 * 1024, 256 * 1024])
+        expect(stream.chunks.join).to eq(data)
+      end
+    end
+  end
+
+  it "closes the stream when the source raises" do
+    logger = double("logger")
+    allow(Rage).to receive(:logger).and_return(logger)
+    allow(logger).to receive(:error)
+    allow(Rage::Errors).to receive(:report)
+
+    stream = FakeRackStream.new
+    source = Enumerator.new do |y|
+      y << "a"
+      raise "boom"
+    end
+    streaming = described_class.new(source)
+
+    within_reactor do
+      streaming.call(stream)
+      wait_until { stream.close_count > 0 }
+
+      -> do
+        expect(stream.chunks).to eq(%w[a])
+        expect(stream.close_count).to eq(1)
+        expect(Rage::Errors).to have_received(:report).with(instance_of(RuntimeError))
+      end
+    end
+  end
+
+  it "unsubscribes from the wake channel once the stream completes" do
+    stream = FakeRackStream.new
+    streaming = described_class.new(%w[a].each)
+
+    within_reactor do
+      streaming.call(stream)
+      wait_until { stream.close_count > 0 && !Iodine.subscribed?(stream.wake_channel) }
+
+      -> { expect(Iodine.subscribed?(stream.wake_channel)).to be(false) }
+    end
+  end
+end

--- a/spec/support/reactor_helper.rb
+++ b/spec/support/reactor_helper.rb
@@ -6,6 +6,9 @@ module ReactorHelper
   # the block is expected to return a proc to enable the code inside the reactor to communicate the test result to rspec.
   #
   def within_reactor(&block)
+    allow(Fiber).to receive(:schedule).and_call_original
+    allow(Fiber).to receive(:await).and_call_original
+
     fiber = nil
 
     Iodine.defer { fiber = Fiber.schedule { block.call } }


### PR DESCRIPTION
Adds HTTP chunked streaming to Rage. 
Server-side support landed in rage-iodine this is the framework API on top of it.

### Usage

    def logs
      render stream: Enumerator.new { |y| source.each { |chunk| y << chunk } }
    end

Any #each source works. Chunks are sent as they are produced.

## How it works

- `Rage::Streaming` wraps the source and is detected by iodine as a `call(stream)` body. The producer runs in its own fiber, so blocking IO inside it never blocks the event loop.
- Backpressure: on `:would_block` the producer parks and is resumed via the stream's pub/sub wake channel ("drain"/"close"), so a slow client paces the producer instead of buffering unbounded output.
- Chunks over 256KB are sliced below iodine's per-write packet limit, so producers can yield blocks of any size.
- Render semantics mirror SSE: status 200 only (204 opt-out), cannot be combined with `sse:` or a standard body, content-type defaults to text/plain when untouched.
- `Response#body` returns "" for streaming responses; they have no buffered body, and reading it (e.g. in `append_info_to_payload`) no longer raises.

## Testing

23 new examples: producer mechanics against a scripted fake stream (slicing, parking/resume, disconnect, error logging, cleanup) and render semantics. Verified end to end against rage-iodine: incremental delivery, backpressure with a rate-limited client, blocking IO in the producer, concurrent requests during a stream, client disconnect.