### PR TITLE
Ensure no duplicate daemons or error reporters can be registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Correctly enqueue deferred tasks with only positional arguments on Ruby < 3.3.4 (#385).
 - Improve restart logs in daemon (#391).
+- Ensure no duplicate daemons or error reporters can be registered (#392).
 
 ## [1.27.0] - 2026-08-06
 

--- a/lib/rage/configuration.rb
+++ b/lib/rage/configuration.rb
@@ -471,7 +471,7 @@ class Rage::Configuration
     #   end
     def <<(reporter)
       validate_input!(reporter)
-      return self if @objects.include?(reporter)
+      raise ArgumentError, "#{reporter} is already registered" if @objects.include?(reporter)
 
       @objects << reporter
       Rage::Errors.__send__(:__register_reporter, reporter)
@@ -1202,7 +1202,11 @@ class Rage::Configuration
     #   end
     def <<(daemon)
       validate!(daemon)
+      raise ArgumentError, "#{daemon} is already registered" if @klasses.include?(daemon)
+
       @klasses << daemon
+
+      self
     end
 
     alias_method :push, :<<

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1450,5 +1450,17 @@ RSpec.describe Rage::Configuration do
         expect(subject.klasses).to be_empty
       end
     end
+
+    context "with a duplicate daemon" do
+      it "raises an error" do
+        subject << daemon
+
+        expect {
+          subject << daemon
+        }.to raise_error(ArgumentError, /is already registered/)
+
+        expect(subject.klasses).to eq([daemon])
+      end
+    end
   end
 end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -29,6 +29,15 @@ RSpec.describe Rage::Errors do
       }.to raise_error(ArgumentError, "error reporter must respond to #call")
     end
 
+    it "raises an error when adding a duplicate reporter" do
+      reporter = Class.new { def call(_); end }.new
+      error_reporters << reporter
+
+      expect {
+        error_reporters << reporter
+      }.to raise_error(ArgumentError, /is already registered/)
+    end
+
     it "allows removing a registered error reporter" do
       call_count = 0
       reporter = Class.new do


### PR DESCRIPTION
This pull request improves the registration logic for reporters and daemons in the configuration by raising errors when duplicates are added, and adds corresponding tests to ensure this behavior.