### PR TITLE
[Cable] Reset `is_subscribing` flag

### DIFF
--- a/lib/rage/cable/channel.rb
+++ b/lib/rage/cable/channel.rb
@@ -302,17 +302,7 @@ class Rage::Cable::Channel
 
     # @private
     def __stream_name_for(streamables)
-      stream_name = Array(streamables).map do |streamable|
-        if streamable.respond_to?(:id)
-          "#{streamable.class.name}:#{streamable.id}"
-        elsif streamable.is_a?(String) || streamable.is_a?(Symbol) || streamable.is_a?(Numeric)
-          streamable
-        else
-          raise ArgumentError, "Unable to generate stream name. Expected an object that responds to `id`, got: #{streamable.class}"
-        end
-      end
-
-      "#{name}:#{stream_name.join(":")}"
+      "#{name}:#{Rage::Internal.stream_name_for(streamables)}"
     end
 
     protected

--- a/lib/rage/cable/channel.rb
+++ b/lib/rage/cable/channel.rb
@@ -169,6 +169,12 @@ class Rage::Cable::Channel
               ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
             RUBY
           end}
+
+          #{if is_subscribing
+            <<~RUBY
+              @__is_subscribing = false
+            RUBY
+          end}
         end
       RUBY
 


### PR DESCRIPTION
This pull request introduces a couple of changes to `Rage::Cable::Channel`, focusing on improving subscription state handling and stream name generation. The main updates include resetting a subscription flag after subscribing and delegating stream name construction to a shared internal method. No test updates necessary as there are no changes in behaviour.